### PR TITLE
refactor: convert method-call sugar to explicit free function calls

### DIFF
--- a/src/allocator.mach
+++ b/src/allocator.mach
@@ -35,7 +35,7 @@ pub rec Allocator {
 # size: number of bytes (0 returns nil).
 # align: requested alignment in bytes.
 # ret: Ok(ptr) on success or Err(AllocError) on out-of-memory.
-pub fun (this: *Allocator) alloc_bytes(size: usize, align: usize) Result[ptr, AllocError] {
+pub fun allocator_alloc_bytes(this: *Allocator, size: usize, align: usize) Result[ptr, AllocError] {
     if (size == 0) {
         ret ok[ptr, AllocError](nil);
     }
@@ -55,7 +55,7 @@ pub fun (this: *Allocator) alloc_bytes(size: usize, align: usize) Result[ptr, Al
 # new_size: desired size in bytes (0 frees the allocation).
 # align: alignment in bytes.
 # ret: Ok(ptr) with the new pointer (or nil for freed) or Err(AllocError) on OOM.
-pub fun (this: *Allocator) resize_bytes(p: ptr, old_size: usize, new_size: usize, align: usize) Result[ptr, AllocError] {
+pub fun allocator_resize_bytes(this: *Allocator, p: ptr, old_size: usize, new_size: usize, align: usize) Result[ptr, AllocError] {
     if (new_size == 0) {
         val ok_free: bool = this.free_fn(this.ctx, p, old_size, align);
         ret ok[ptr, AllocError](nil);
@@ -75,7 +75,7 @@ pub fun (this: *Allocator) resize_bytes(p: ptr, old_size: usize, new_size: usize
 # size: size in bytes that was allocated.
 # align: alignment in bytes.
 # ret: true on success.
-pub fun (this: *Allocator) free_bytes(p: ptr, size: usize, align: usize) bool {
+pub fun allocator_free_bytes(this: *Allocator, p: ptr, size: usize, align: usize) bool {
     ret this.free_fn(this.ctx, p, size, align);
 }
 
@@ -83,7 +83,7 @@ pub fun (this: *Allocator) free_bytes(p: ptr, size: usize, align: usize) bool {
 # ---
 # count: number of elements to allocate
 # ret: Ok(*T) pointer (nil for count == 0) or Err(AllocError) on OOM or overflow.
-pub fun (this: *Allocator) alloc[T](count: usize) Result[*T, AllocError] {
+pub fun allocator_alloc(this: *Allocator)[T](count: usize) Result[*T, AllocError] {
     if (count == 0) {
         ret ok[*T, AllocError](nil::*T);
     }
@@ -95,25 +95,25 @@ pub fun (this: *Allocator) alloc[T](count: usize) Result[*T, AllocError] {
         ret err[*T, AllocError]("allocation size overflow");
     }
 
-    val r: Result[ptr, AllocError] = this.alloc_bytes(total, $align_of(T));
-    if (r.is_err()) {
-        ret err[*T, AllocError](r.unwrap_err());
+    val r: Result[ptr, AllocError] = allocator_alloc_bytes(this, total, $align_of(T));
+    if (result_is_err(r)) {
+        ret err[*T, AllocError](result_unwrap_err(r));
     }
 
-    ret ok[*T, AllocError](r.unwrap_ok()::*T);
+    ret ok[*T, AllocError](result_unwrap_ok(r)::*T);
 }
 
 # Allocate and zero-initialize count elements of T.
 # ---
 # count: number of elements to allocate
 # ret: Ok(*T) pointer (nil for count == 0) or Err(AllocError) on OOM or overflow.
-pub fun (this: *Allocator) zalloc[T](count: usize) Result[*T, AllocError] {
-    val r: Result[*T, AllocError] = this.alloc[T](count);
-    if (r.is_err()) {
+pub fun allocator_zalloc(this: *Allocator)[T](count: usize) Result[*T, AllocError] {
+    val r: Result[*T, AllocError] = allocator_alloc[T](this, count);
+    if (result_is_err(r)) {
         ret r;
     }
 
-    val p: *T = r.unwrap_ok();
+    val p: *T = result_unwrap_ok(r);
     if (p != nil && count != 0) {
         val total: usize = $size_of(T) * count;
         val bytes: *u8 = p::ptr::*u8;
@@ -132,12 +132,12 @@ pub fun (this: *Allocator) zalloc[T](count: usize) Result[*T, AllocError] {
 # p: pointer returned by alloc/zalloc (may be nil)
 # count: number of elements to free
 # ret: true on success; no-op for nil pointer or count == 0.
-pub fun (this: *Allocator) free[T](p: *T, count: usize) bool {
+pub fun allocator_free(this: *Allocator)[T](p: *T, count: usize) bool {
     if (p == nil || count == 0) {
         ret true;
     }
 
-    ret this.free_bytes(p::ptr, $size_of(T) * count, $align_of(T));
+    ret allocator_free_bytes(this, p::ptr, $size_of(T) * count, $align_of(T));
 }
 
 # Resize an allocation of T elements.
@@ -146,9 +146,9 @@ pub fun (this: *Allocator) free[T](p: *T, count: usize) bool {
 # old_count: previous number of elements
 # new_count: desired number of elements (0 frees)
 # ret: Ok(*T) with new pointer or Err(AllocError) on error.
-pub fun (this: *Allocator) resize[T](p: *T, old_count: usize, new_count: usize) Result[*T, AllocError] {
+pub fun allocator_resize(this: *Allocator)[T](p: *T, old_count: usize, new_count: usize) Result[*T, AllocError] {
     if (new_count == 0) {
-        val ok_free: bool = this.free[T](p, old_count);
+        val ok_free: bool = allocator_free[T](this, p, old_count);
         ret ok[*T, AllocError](nil::*T);
     }
 
@@ -160,12 +160,12 @@ pub fun (this: *Allocator) resize[T](p: *T, old_count: usize, new_count: usize) 
         ret err[*T, AllocError]("allocation size overflow");
     }
 
-    val r: Result[ptr, AllocError] = this.resize_bytes(p::ptr, old_size, new_size, $align_of(T));
-    if (r.is_err()) {
-        ret err[*T, AllocError](r.unwrap_err());
+    val r: Result[ptr, AllocError] = allocator_resize_bytes(this, p::ptr, old_size, new_size, $align_of(T));
+    if (result_is_err(r)) {
+        ret err[*T, AllocError](result_unwrap_err(r));
     }
 
-    ret ok[*T, AllocError](r.unwrap_ok()::*T);
+    ret ok[*T, AllocError](result_unwrap_ok(r)::*T);
 }
 
 # default allocator (page-granular) backed by platform memory.
@@ -229,29 +229,29 @@ test "allocator: default returns valid allocator" {
 
 test "allocator: alloc_bytes allocates memory" {
     var a: Allocator = page_allocator();
-    val r: Result[ptr, AllocError] = a.alloc_bytes(64, 8);
-    if (r.is_err()) { ret 0; }
-    val p: ptr = r.unwrap_ok();
+    val r: Result[ptr, AllocError] = allocator_alloc_bytes(a, 64, 8);
+    if (result_is_err(r)) { ret 0; }
+    val p: ptr = result_unwrap_ok(r);
     if (p == nil) { ret 0; }
-    val ok: bool = a.free_bytes(p, 64, 8);
+    val ok: bool = allocator_free_bytes(a, p, 64, 8);
     if (!ok) { ret 0; }
     ret 1;
 }
 
 test "allocator: alloc_bytes with size zero returns nil" {
     var a: Allocator = page_allocator();
-    val r: Result[ptr, AllocError] = a.alloc_bytes(0, 8);
-    if (r.is_err()) { ret 0; }
-    val p: ptr = r.unwrap_ok();
+    val r: Result[ptr, AllocError] = allocator_alloc_bytes(a, 0, 8);
+    if (result_is_err(r)) { ret 0; }
+    val p: ptr = result_unwrap_ok(r);
     if (p != nil) { ret 0; }
     ret 1;
 }
 
 test "allocator: alloc typed allocation" {
     var a: Allocator = page_allocator();
-    val r: Result[*i64, AllocError] = a.alloc[i64](4);
-    if (r.is_err()) { ret 0; }
-    val p: *i64 = r.unwrap_ok();
+    val r: Result[*i64, AllocError] = allocator_alloc[i64](a, 4);
+    if (result_is_err(r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(r);
     if (p == nil) { ret 0; }
 
     # write and read back
@@ -262,25 +262,25 @@ test "allocator: alloc typed allocation" {
     if (p[0] != 100) { ret 0; }
     if (p[3] != 400) { ret 0; }
 
-    val ok: bool = a.free[i64](p, 4);
+    val ok: bool = allocator_free[i64](a, p, 4);
     if (!ok) { ret 0; }
     ret 1;
 }
 
 test "allocator: alloc with count zero returns nil" {
     var a: Allocator = page_allocator();
-    val r: Result[*i64, AllocError] = a.alloc[i64](0);
-    if (r.is_err()) { ret 0; }
-    val p: *i64 = r.unwrap_ok();
+    val r: Result[*i64, AllocError] = allocator_alloc[i64](a, 0);
+    if (result_is_err(r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(r);
     if (p != nil) { ret 0; }
     ret 1;
 }
 
 test "allocator: zalloc zero-initializes memory" {
     var a: Allocator = page_allocator();
-    val r: Result[*i64, AllocError] = a.zalloc[i64](4);
-    if (r.is_err()) { ret 0; }
-    val p: *i64 = r.unwrap_ok();
+    val r: Result[*i64, AllocError] = allocator_zalloc[i64](a, 4);
+    if (result_is_err(r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(r);
     if (p == nil) { ret 0; }
 
     # all values should be zero
@@ -289,87 +289,87 @@ test "allocator: zalloc zero-initializes memory" {
     if (p[2] != 0) { ret 0; }
     if (p[3] != 0) { ret 0; }
 
-    val ok: bool = a.free[i64](p, 4);
+    val ok: bool = allocator_free[i64](a, p, 4);
     if (!ok) { ret 0; }
     ret 1;
 }
 
 test "allocator: zalloc with count zero returns nil" {
     var a: Allocator = page_allocator();
-    val r: Result[*i64, AllocError] = a.zalloc[i64](0);
-    if (r.is_err()) { ret 0; }
-    val p: *i64 = r.unwrap_ok();
+    val r: Result[*i64, AllocError] = allocator_zalloc[i64](a, 0);
+    if (result_is_err(r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(r);
     if (p != nil) { ret 0; }
     ret 1;
 }
 
 test "allocator: free with nil pointer succeeds" {
     var a: Allocator = page_allocator();
-    val ok: bool = a.free[i64](nil, 10);
+    val ok: bool = allocator_free[i64](a, nil, 10);
     if (!ok) { ret 0; }
     ret 1;
 }
 
 test "allocator: free with count zero succeeds" {
     var a: Allocator = page_allocator();
-    val r: Result[*i64, AllocError] = a.alloc[i64](4);
-    if (r.is_err()) { ret 0; }
-    val p: *i64 = r.unwrap_ok();
+    val r: Result[*i64, AllocError] = allocator_alloc[i64](a, 4);
+    if (result_is_err(r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(r);
     # free with count 0 should succeed (noop)
-    val ok: bool = a.free[i64](p, 0);
+    val ok: bool = allocator_free[i64](a, p, 0);
     if (!ok) { ret 0; }
     # now actually free it
-    val ok2: bool = a.free[i64](p, 4);
+    val ok2: bool = allocator_free[i64](a, p, 4);
     if (!ok2) { ret 0; }
     ret 1;
 }
 
 test "allocator: resize grows allocation" {
     var a: Allocator = page_allocator();
-    val r1: Result[*i64, AllocError] = a.alloc[i64](2);
-    if (r1.is_err()) { ret 0; }
-    val p1: *i64 = r1.unwrap_ok();
+    val r1: Result[*i64, AllocError] = allocator_alloc[i64](a, 2);
+    if (result_is_err(r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok(r1);
     p1[0] = 111;
     p1[1] = 222;
 
-    val r2: Result[*i64, AllocError] = a.resize[i64](p1, 2, 4);
-    if (r2.is_err()) { ret 0; }
-    val p2: *i64 = r2.unwrap_ok();
+    val r2: Result[*i64, AllocError] = allocator_resize[i64](a, p1, 2, 4);
+    if (result_is_err(r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok(r2);
     if (p2 == nil) { ret 0; }
 
     # original data should be preserved
     if (p2[0] != 111) { ret 0; }
     if (p2[1] != 222) { ret 0; }
 
-    val ok: bool = a.free[i64](p2, 4);
+    val ok: bool = allocator_free[i64](a, p2, 4);
     if (!ok) { ret 0; }
     ret 1;
 }
 
 test "allocator: resize to zero frees and returns nil" {
     var a: Allocator = page_allocator();
-    val r1: Result[*i64, AllocError] = a.alloc[i64](4);
-    if (r1.is_err()) { ret 0; }
-    val p: *i64 = r1.unwrap_ok();
+    val r1: Result[*i64, AllocError] = allocator_alloc[i64](a, 4);
+    if (result_is_err(r1)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(r1);
 
-    val r2: Result[*i64, AllocError] = a.resize[i64](p, 4, 0);
-    if (r2.is_err()) { ret 0; }
-    val p2: *i64 = r2.unwrap_ok();
+    val r2: Result[*i64, AllocError] = allocator_resize[i64](a, p, 4, 0);
+    if (result_is_err(r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok(r2);
     if (p2 != nil) { ret 0; }
     ret 1;
 }
 
 test "allocator: resize from nil allocates new" {
     var a: Allocator = page_allocator();
-    val r: Result[*i64, AllocError] = a.resize[i64](nil, 0, 4);
-    if (r.is_err()) { ret 0; }
-    val p: *i64 = r.unwrap_ok();
+    val r: Result[*i64, AllocError] = allocator_resize[i64](a, nil, 0, 4);
+    if (result_is_err(r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(r);
     if (p == nil) { ret 0; }
 
     p[0] = 42;
     if (p[0] != 42) { ret 0; }
 
-    val ok: bool = a.free[i64](p, 4);
+    val ok: bool = allocator_free[i64](a, p, 4);
     if (!ok) { ret 0; }
     ret 1;
 }

--- a/src/allocator/arena.mach
+++ b/src/allocator/arena.mach
@@ -76,7 +76,7 @@ pub fun init(backing: a.Allocator, cap: usize) Result[Arena, a.AllocError] {
 # Free any backing storage associated with the arena.
 # ---
 # ret: true if the backing allocator reports success; no-op for nil or empty arenas.
-pub fun (this: *Arena) deinit() bool {
+pub fun arena_deinit(this: *Arena) bool {
     if (this == nil) { ret true; }
     if (this.buf == nil || this.cap == 0) { ret true; }
 
@@ -90,7 +90,7 @@ pub fun (this: *Arena) deinit() bool {
 }
 
 # Reset the arena to an empty state without freeing backing storage; existing allocations become invalid.
-pub fun (this: *Arena) reset() {
+pub fun arena_reset(this: *Arena) {
     if (this == nil) { ret; }
     this.off = 0;
     this.last_off  = 0;
@@ -171,7 +171,7 @@ fun arena_free(ctx: ptr, p: ptr, size: usize, align: usize) bool {
 # Return an a.Allocator view that delegates to this arena.
 # ---
 # ret: Allocator view that delegates to this arena.
-pub fun (this: *Arena) allocator() a.Allocator {
+pub fun arena_allocator(this: *Arena) a.Allocator {
     var al: a.Allocator;
     al.ctx = this::ptr;
     al.alloc_fn  = arena_alloc;
@@ -185,9 +185,9 @@ pub fun (this: *Arena) allocator() a.Allocator {
 test "arena: init with zero capacity succeeds" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 0);
-    if (r.is_err()) { ret 0; }
-    var ar: Arena = r.unwrap_ok();
-    val ok: bool = ar.deinit();
+    if (result_is_err(r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok(r);
+    val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -195,9 +195,9 @@ test "arena: init with zero capacity succeeds" {
 test "arena: init with capacity allocates backing storage" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 1024);
-    if (r.is_err()) { ret 0; }
-    var ar: Arena = r.unwrap_ok();
-    val ok: bool = ar.deinit();
+    if (result_is_err(r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok(r);
+    val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -205,13 +205,13 @@ test "arena: init with capacity allocates backing storage" {
 test "arena: allocator returns functional allocator" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (r.is_err()) { ret 0; }
-    var ar: Arena = r.unwrap_ok();
+    if (result_is_err(r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok(r);
 
-    var alloc: a.Allocator = ar.allocator();
-    val alloc_r: Result[*i64, a.AllocError] = alloc.alloc[i64](4);
-    if (alloc_r.is_err()) { ret 0; }
-    val p: *i64 = alloc_r.unwrap_ok();
+    var alloc: a.Allocator = arena_allocator(?ar);
+    val alloc_r: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 4);
+    if (result_is_err(alloc_r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(alloc_r);
     if (p == nil) { ret 0; }
 
     p[0] = 100;
@@ -219,7 +219,7 @@ test "arena: allocator returns functional allocator" {
     if (p[0] != 100) { ret 0; }
     if (p[1] != 200) { ret 0; }
 
-    val ok: bool = ar.deinit();
+    val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -227,17 +227,17 @@ test "arena: allocator returns functional allocator" {
 test "arena: multiple allocations bump offset" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (r.is_err()) { ret 0; }
-    var ar: Arena = r.unwrap_ok();
-    var alloc: a.Allocator = ar.allocator();
+    if (result_is_err(r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok(r);
+    var alloc: a.Allocator = arena_allocator(?ar);
 
-    val r1: Result[*i64, a.AllocError] = alloc.alloc[i64](2);
-    if (r1.is_err()) { ret 0; }
-    val p1: *i64 = r1.unwrap_ok();
+    val r1: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
+    if (result_is_err(r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok(r1);
 
-    val r2: Result[*i64, a.AllocError] = alloc.alloc[i64](2);
-    if (r2.is_err()) { ret 0; }
-    val p2: *i64 = r2.unwrap_ok();
+    val r2: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
+    if (result_is_err(r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok(r2);
 
     # p2 should be after p1 in memory
     if (p2::usize <= p1::usize) { ret 0; }
@@ -247,7 +247,7 @@ test "arena: multiple allocations bump offset" {
     if (p1[0] != 111) { ret 0; }
     if (p2[0] != 222) { ret 0; }
 
-    val ok: bool = ar.deinit();
+    val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -255,28 +255,28 @@ test "arena: multiple allocations bump offset" {
 test "arena: reset clears allocations" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (r.is_err()) { ret 0; }
-    var ar: Arena = r.unwrap_ok();
-    var alloc: a.Allocator = ar.allocator();
+    if (result_is_err(r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok(r);
+    var alloc: a.Allocator = arena_allocator(?ar);
 
     # allocate some memory
-    val r1: Result[*i64, a.AllocError] = alloc.alloc[i64](100);
-    if (r1.is_err()) { ret 0; }
-    val p1: *i64 = r1.unwrap_ok();
+    val r1: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 100);
+    if (result_is_err(r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok(r1);
 
     # reset
-    ar.reset();
+    arena_reset(?ar);
 
     # allocate again - should get same (or similar) address
-    val r2: Result[*i64, a.AllocError] = alloc.alloc[i64](100);
-    if (r2.is_err()) { ret 0; }
-    val p2: *i64 = r2.unwrap_ok();
+    val r2: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 100);
+    if (result_is_err(r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok(r2);
 
     # after reset, new allocation should start from beginning
     # so p2 should be at or near the same address as p1
     if (p2 != p1) { ret 0; }
 
-    val ok: bool = ar.deinit();
+    val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -284,27 +284,27 @@ test "arena: reset clears allocations" {
 test "arena: free is noop for non-last allocation" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (r.is_err()) { ret 0; }
-    var ar: Arena = r.unwrap_ok();
-    var alloc: a.Allocator = ar.allocator();
+    if (result_is_err(r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok(r);
+    var alloc: a.Allocator = arena_allocator(?ar);
 
-    val r1: Result[*i64, a.AllocError] = alloc.alloc[i64](2);
-    if (r1.is_err()) { ret 0; }
-    val p1: *i64 = r1.unwrap_ok();
+    val r1: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
+    if (result_is_err(r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok(r1);
 
-    val r2: Result[*i64, a.AllocError] = alloc.alloc[i64](2);
-    if (r2.is_err()) { ret 0; }
-    val p2: *i64 = r2.unwrap_ok();
+    val r2: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
+    if (result_is_err(r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok(r2);
 
     # free p1 (not the last allocation) - should be noop
-    val ok_free: bool = alloc.free[i64](p1, 2);
+    val ok_free: bool = a.allocator_free[i64](alloc, p1, 2);
     if (!ok_free) { ret 0; }
 
     # p2 should still be accessible
     p2[0] = 999;
     if (p2[0] != 999) { ret 0; }
 
-    val ok: bool = ar.deinit();
+    val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -312,30 +312,30 @@ test "arena: free is noop for non-last allocation" {
 test "arena: free last allocation rolls back" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (r.is_err()) { ret 0; }
-    var ar: Arena = r.unwrap_ok();
-    var alloc: a.Allocator = ar.allocator();
+    if (result_is_err(r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok(r);
+    var alloc: a.Allocator = arena_allocator(?ar);
 
-    val r1: Result[*i64, a.AllocError] = alloc.alloc[i64](2);
-    if (r1.is_err()) { ret 0; }
-    val p1: *i64 = r1.unwrap_ok();
+    val r1: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
+    if (result_is_err(r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok(r1);
 
-    val r2: Result[*i64, a.AllocError] = alloc.alloc[i64](2);
-    if (r2.is_err()) { ret 0; }
-    val p2: *i64 = r2.unwrap_ok();
+    val r2: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
+    if (result_is_err(r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok(r2);
 
     # free p2 (last allocation) - should roll back
-    val ok_free: bool = alloc.free[i64](p2, 2);
+    val ok_free: bool = a.allocator_free[i64](alloc, p2, 2);
     if (!ok_free) { ret 0; }
 
     # next allocation should reuse p2's space
-    val r3: Result[*i64, a.AllocError] = alloc.alloc[i64](2);
-    if (r3.is_err()) { ret 0; }
-    val p3: *i64 = r3.unwrap_ok();
+    val r3: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
+    if (result_is_err(r3)) { ret 0; }
+    val p3: *i64 = result_unwrap_ok(r3);
 
     if (p3 != p2) { ret 0; }
 
-    val ok: bool = ar.deinit();
+    val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -343,20 +343,20 @@ test "arena: free last allocation rolls back" {
 test "arena: resize last allocation in-place" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (r.is_err()) { ret 0; }
-    var ar: Arena = r.unwrap_ok();
-    var alloc: a.Allocator = ar.allocator();
+    if (result_is_err(r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok(r);
+    var alloc: a.Allocator = arena_allocator(?ar);
 
-    val r1: Result[*i64, a.AllocError] = alloc.alloc[i64](2);
-    if (r1.is_err()) { ret 0; }
-    val p1: *i64 = r1.unwrap_ok();
+    val r1: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
+    if (result_is_err(r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok(r1);
     p1[0] = 111;
     p1[1] = 222;
 
     # resize in-place (should succeed for last allocation)
-    val r2: Result[*i64, a.AllocError] = alloc.resize[i64](p1, 2, 4);
-    if (r2.is_err()) { ret 0; }
-    val p2: *i64 = r2.unwrap_ok();
+    val r2: Result[*i64, a.AllocError] = a.allocator_resize[i64](?alloc, p1, 2, 4);
+    if (result_is_err(r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok(r2);
 
     # should be same pointer for in-place resize
     if (p2 != p1) { ret 0; }
@@ -371,7 +371,7 @@ test "arena: resize last allocation in-place" {
     if (p2[2] != 333) { ret 0; }
     if (p2[3] != 444) { ret 0; }
 
-    val ok: bool = ar.deinit();
+    val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -381,7 +381,7 @@ test "arena: deinit on nil arena succeeds" {
     ar.buf = nil;
     ar.cap = 0;
     ar.off = 0;
-    val ok: bool = ar.deinit();
+    val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -389,24 +389,24 @@ test "arena: deinit on nil arena succeeds" {
 test "arena: allocation respects alignment" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (r.is_err()) { ret 0; }
-    var ar: Arena = r.unwrap_ok();
-    var alloc: a.Allocator = ar.allocator();
+    if (result_is_err(r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok(r);
+    var alloc: a.Allocator = arena_allocator(?ar);
 
     # allocate 1 byte
-    val r1: Result[ptr, a.AllocError] = alloc.alloc_bytes(1, 1);
-    if (r1.is_err()) { ret 0; }
+    val r1: Result[ptr, a.AllocError] = a.allocator_alloc_bytes(alloc, 1, 1);
+    if (result_is_err(r1)) { ret 0; }
 
     # allocate 8 bytes with 8-byte alignment
-    val r2: Result[ptr, a.AllocError] = alloc.alloc_bytes(8, 8);
-    if (r2.is_err()) { ret 0; }
-    val p2: ptr = r2.unwrap_ok();
+    val r2: Result[ptr, a.AllocError] = a.allocator_alloc_bytes(alloc, 8, 8);
+    if (result_is_err(r2)) { ret 0; }
+    val p2: ptr = result_unwrap_ok(r2);
 
     # check alignment
     val addr: usize = p2::usize;
     if ((addr % 8) != 0) { ret 0; }
 
-    val ok: bool = ar.deinit();
+    val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }

--- a/src/collections/map.mach
+++ b/src/collections/map.mach
@@ -61,7 +61,7 @@ pub fun init[K, V](alloc: allocator.Allocator, hash_fn: fun(ptr) u64, eq_fn: fun
 # Free all backing storage and reset the map
 # ---
 # ret: true if memory was freed successfully
-pub fun (this: *Map[K, V]) dnit() bool {
+pub fun map_dnit(this: *Map[K, V]) bool {
     if (this == nil) { ret true; }
     if (this.cap == 0) {
         this.keys = nil;
@@ -72,9 +72,9 @@ pub fun (this: *Map[K, V]) dnit() bool {
     }
 
     var ok: bool = true;
-    ok = this.alloc.free[K](this.keys, this.cap) && ok;
-    ok = this.alloc.free[V](this.values, this.cap) && ok;
-    ok = this.alloc.free[u8](this.states, this.cap) && ok;
+    ok = allocator.allocator_free[K](this.alloc, this.keys, this.cap) && ok;
+    ok = allocator.allocator_free[V](this.alloc, this.values, this.cap) && ok;
+    ok = allocator.allocator_free[u8](this.alloc, this.states, this.cap) && ok;
 
     this.keys = nil;
     this.values = nil;
@@ -88,27 +88,27 @@ pub fun (this: *Map[K, V]) dnit() bool {
 # Check if the map is empty
 # ---
 # ret: true if the map has no entries
-pub fun (this: Map[K, V]) is_empty() bool {
+pub fun map_is_empty(this: Map[K, V]) bool {
     ret this.len == 0;
 }
 
 # Return the number of entries in the map
 # ---
 # ret: Number of key-value pairs
-pub fun (this: Map[K, V]) length() usize {
+pub fun map_length(this: Map[K, V]) usize {
     ret this.len;
 }
 
 # Return the current capacity
 # ---
 # ret: Capacity in slots
-pub fun (this: Map[K, V]) capacity() usize {
+pub fun map_capacity(this: Map[K, V]) usize {
     ret this.cap;
 }
 
 # Clear all entries but keep allocated capacity
 # ---
-pub fun (this: *Map[K, V]) clear() {
+pub fun map_clear(this: *Map[K, V]) {
     if (this == nil || this.cap == 0) { ret; }
     mem.raw_fill(this.states::ptr, SLOT_EMPTY, this.cap);
     this.len = 0;
@@ -118,7 +118,7 @@ pub fun (this: *Map[K, V]) clear() {
 # ---
 # key: Key to search for
 # ret: (index, found) tuple - if found is true, key exists at index
-fun (this: &Map[K, V]) find_slot(key: &K) rec { idx: usize; found: bool; } {
+fun map_find_slot(this: &Map[K, V], key: &K) rec { idx: usize; found: bool; } {
     var result: rec { idx: usize; found: bool; };
     result.found = false;
     result.idx = 0;
@@ -180,32 +180,32 @@ fun (this: &Map[K, V]) find_slot(key: &K) rec { idx: usize; found: bool; } {
 # ---
 # new_cap: New capacity (must be > current capacity)
 # ret: Ok(new capacity) or Err(error message)
-fun (this: *Map[K, V]) grow(new_cap: usize) Result[usize, str] {
+fun map_grow(this: *Map[K, V], new_cap: usize) Result[usize, str] {
     if (new_cap <= this.cap) {
         ret ok[usize, str](this.cap);
     }
 
     # allocate new arrays
-    val keys_r: Result[*K, allocator.AllocError] = this.alloc.alloc[K](new_cap);
-    if (keys_r.is_err()) {
-        ret err[usize, str](keys_r.unwrap_err());
+    val keys_r: Result[*K, allocator.AllocError] = allocator.allocator_alloc[K](this.alloc, new_cap);
+    if (result_is_err(keys_r)) {
+        ret err[usize, str](result_unwrap_err(keys_r));
     }
-    val new_keys: *K = keys_r.unwrap_ok();
+    val new_keys: *K = result_unwrap_ok(keys_r);
 
-    val values_r: Result[*V, allocator.AllocError] = this.alloc.alloc[V](new_cap);
-    if (values_r.is_err()) {
-        this.alloc.free[K](new_keys, new_cap);
-        ret err[usize, str](values_r.unwrap_err());
+    val values_r: Result[*V, allocator.AllocError] = allocator.allocator_alloc[V](this.alloc, new_cap);
+    if (result_is_err(values_r)) {
+        allocator.allocator_free[K](this.alloc, new_keys, new_cap);
+        ret err[usize, str](result_unwrap_err(values_r));
     }
-    val new_values: *V = values_r.unwrap_ok();
+    val new_values: *V = result_unwrap_ok(values_r);
 
-    val states_r: Result[*u8, allocator.AllocError] = this.alloc.zalloc[u8](new_cap);
-    if (states_r.is_err()) {
-        this.alloc.free[K](new_keys, new_cap);
-        this.alloc.free[V](new_values, new_cap);
-        ret err[usize, str](states_r.unwrap_err());
+    val states_r: Result[*u8, allocator.AllocError] = allocator.allocator_zalloc[u8](this.alloc, new_cap);
+    if (result_is_err(states_r)) {
+        allocator.allocator_free[K](this.alloc, new_keys, new_cap);
+        allocator.allocator_free[V](this.alloc, new_values, new_cap);
+        ret err[usize, str](result_unwrap_err(states_r));
     }
-    val new_states: *u8 = states_r.unwrap_ok();
+    val new_states: *u8 = result_unwrap_ok(states_r);
 
     # save old arrays
     val old_keys: *K = this.keys;
@@ -243,9 +243,9 @@ fun (this: *Map[K, V]) grow(new_cap: usize) Result[usize, str] {
         }
 
         # free old arrays
-        this.alloc.free[K](old_keys, old_cap);
-        this.alloc.free[V](old_values, old_cap);
-        this.alloc.free[u8](old_states, old_cap);
+        allocator.allocator_free[K](this.alloc, old_keys, old_cap);
+        allocator.allocator_free[V](this.alloc, old_values, old_cap);
+        allocator.allocator_free[u8](this.alloc, old_states, old_cap);
     }
 
     ret ok[usize, str](new_cap);
@@ -254,15 +254,15 @@ fun (this: *Map[K, V]) grow(new_cap: usize) Result[usize, str] {
 # Ensure the map has capacity for at least one more entry
 # ---
 # ret: Ok(capacity) or Err(error message)
-fun (this: *Map[K, V]) ensure_capacity() Result[usize, str] {
+fun map_ensure_capacity(this: *Map[K, V]) Result[usize, str] {
     if (this.cap == 0) {
-        ret this.grow(DEFAULT_CAPACITY);
+        ret map_grow(this, DEFAULT_CAPACITY);
     }
 
     # check load factor
     val threshold: usize = (this.cap * LOAD_FACTOR_PERCENT) / 100;
     if (this.len >= threshold) {
-        ret this.grow(this.cap * 2);
+        ret map_grow(this, this.cap * 2);
     }
 
     ret ok[usize, str](this.cap);
@@ -273,13 +273,13 @@ fun (this: *Map[K, V]) ensure_capacity() Result[usize, str] {
 # key: Key to insert
 # value: Value to associate with the key
 # ret: Ok(true) if inserted new, Ok(false) if updated existing, Err on allocation failure
-pub fun (this: *Map[K, V]) insert(key: K, value: V) Result[bool, str] {
-    val cap_r: Result[usize, str] = this.ensure_capacity();
-    if (cap_r.is_err()) {
-        ret err[bool, str](cap_r.unwrap_err());
+pub fun map_insert(this: *Map[K, V], key: K, value: V) Result[bool, str] {
+    val cap_r: Result[usize, str] = map_ensure_capacity(this);
+    if (result_is_err(cap_r)) {
+        ret err[bool, str](result_unwrap_err(cap_r));
     }
 
-    val slot: rec { idx: usize; found: bool; } = this.find_slot(?key);
+    val slot: rec { idx: usize; found: bool; } = map_find_slot(this, ?key);
 
     if (slot.found) {
         # update existing
@@ -300,12 +300,12 @@ pub fun (this: *Map[K, V]) insert(key: K, value: V) Result[bool, str] {
 # ---
 # key: Key to look up
 # ret: Ok(pointer to value) or Err("key not found")
-pub fun (this: &Map[K, V]) get(key: &K) Result[*V, str] {
+pub fun map_get(this: &Map[K, V], key: &K) Result[*V, str] {
     if (this.cap == 0) {
         ret err[*V, str]("key not found");
     }
 
-    val slot: rec { idx: usize; found: bool; } = this.find_slot(key);
+    val slot: rec { idx: usize; found: bool; } = map_find_slot(this, key);
 
     if (!slot.found) {
         ret err[*V, str]("key not found");
@@ -318,12 +318,12 @@ pub fun (this: &Map[K, V]) get(key: &K) Result[*V, str] {
 # ---
 # key: Key to check for
 # ret: true if the key exists in the map
-pub fun (this: &Map[K, V]) contains(key: &K) bool {
+pub fun map_contains(this: &Map[K, V], key: &K) bool {
     if (this.cap == 0) {
         ret false;
     }
 
-    val slot: rec { idx: usize; found: bool; } = this.find_slot(key);
+    val slot: rec { idx: usize; found: bool; } = map_find_slot(this, key);
     ret slot.found;
 }
 
@@ -331,12 +331,12 @@ pub fun (this: &Map[K, V]) contains(key: &K) bool {
 # ---
 # key: Key to remove
 # ret: Ok(true) if removed, Ok(false) if key not found
-pub fun (this: *Map[K, V]) remove(key: &K) Result[bool, str] {
+pub fun map_remove(this: *Map[K, V], key: &K) Result[bool, str] {
     if (this.cap == 0) {
         ret ok[bool, str](false);
     }
 
-    val slot: rec { idx: usize; found: bool; } = this.find_slot(key);
+    val slot: rec { idx: usize; found: bool; } = map_find_slot(this, key);
 
     if (!slot.found) {
         ret ok[bool, str](false);
@@ -460,9 +460,9 @@ pub fun eq_u64(pa: ptr, pb: ptr) bool {
 test "map: init creates empty map" {
     var a: allocator.Allocator = allocator.page_allocator();
     val m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
-    if (!m.is_empty()) { ret 0; }
-    if (m.length() != 0) { ret 0; }
-    if (m.capacity() != 0) { ret 0; }
+    if (!map_is_empty(m)) { ret 0; }
+    if (map_length(m) != 0) { ret 0; }
+    if (map_capacity(m) != 0) { ret 0; }
     ret 1;
 }
 
@@ -470,19 +470,19 @@ test "map: insert and get" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    val r: Result[bool, str] = m.insert(42, 100);
-    if (r.is_err()) { ret 0; }
-    if (!r.unwrap_ok()) { ret 0; } # should be new insert
+    val r: Result[bool, str] = map_insert(?m, 42, 100);
+    if (result_is_err(r)) { ret 0; }
+    if (!result_unwrap_ok(r)) { ret 0; } # should be new insert
 
-    if (m.length() != 1) { ret 0; }
-    if (m.is_empty()) { ret 0; }
+    if (map_length(m) != 1) { ret 0; }
+    if (map_is_empty(m)) { ret 0; }
 
     val key: i64 = 42;
-    val gr: Result[*i64, str] = m.get(?key);
-    if (gr.is_err()) { ret 0; }
-    if (@gr.unwrap_ok() != 100) { ret 0; }
+    val gr: Result[*i64, str] = map_get(?m, ?key);
+    if (result_is_err(gr)) { ret 0; }
+    if (@result_unwrap_ok(gr) != 100) { ret 0; }
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -491,19 +491,19 @@ test "map: insert updates existing" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    m.insert(10, 100);
-    val r: Result[bool, str] = m.insert(10, 200);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok()) { ret 0; } # should be update, not new
+    map_insert(?m, 10, 100);
+    val r: Result[bool, str] = map_insert(?m, 10, 200);
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r)) { ret 0; } # should be update, not new
 
-    if (m.length() != 1) { ret 0; }
+    if (map_length(m) != 1) { ret 0; }
 
     val key: i64 = 10;
-    val gr: Result[*i64, str] = m.get(?key);
-    if (gr.is_err()) { ret 0; }
-    if (@gr.unwrap_ok() != 200) { ret 0; }
+    val gr: Result[*i64, str] = map_get(?m, ?key);
+    if (result_is_err(gr)) { ret 0; }
+    if (@result_unwrap_ok(gr) != 200) { ret 0; }
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -512,18 +512,18 @@ test "map: contains" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    m.insert(5, 50);
-    m.insert(10, 100);
+    map_insert(?m, 5, 50);
+    map_insert(?m, 10, 100);
 
     val k1: i64 = 5;
     val k2: i64 = 10;
     val k3: i64 = 15;
 
-    if (!m.contains(?k1)) { ret 0; }
-    if (!m.contains(?k2)) { ret 0; }
-    if (m.contains(?k3)) { ret 0; }
+    if (!str_contains(m, ?k1)) { ret 0; }
+    if (!str_contains(m, ?k2)) { ret 0; }
+    if (str_contains(m, ?k3)) { ret 0; }
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -532,27 +532,27 @@ test "map: remove" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    m.insert(1, 10);
-    m.insert(2, 20);
-    m.insert(3, 30);
+    map_insert(?m, 1, 10);
+    map_insert(?m, 2, 20);
+    map_insert(?m, 3, 30);
 
-    if (m.length() != 3) { ret 0; }
+    if (map_length(m) != 3) { ret 0; }
 
     val k2: i64 = 2;
-    val rr: Result[bool, str] = m.remove(?k2);
-    if (rr.is_err()) { ret 0; }
-    if (!rr.unwrap_ok()) { ret 0; }
+    val rr: Result[bool, str] = map_remove(?m, ?k2);
+    if (result_is_err(rr)) { ret 0; }
+    if (!result_unwrap_ok(rr)) { ret 0; }
 
-    if (m.length() != 2) { ret 0; }
-    if (m.contains(?k2)) { ret 0; }
+    if (map_length(m) != 2) { ret 0; }
+    if (str_contains(m, ?k2)) { ret 0; }
 
     # other keys should still be there
     val k1: i64 = 1;
     val k3: i64 = 3;
-    if (!m.contains(?k1)) { ret 0; }
-    if (!m.contains(?k3)) { ret 0; }
+    if (!str_contains(m, ?k1)) { ret 0; }
+    if (!str_contains(m, ?k3)) { ret 0; }
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -561,14 +561,14 @@ test "map: remove non-existent" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    m.insert(1, 10);
+    map_insert(?m, 1, 10);
 
     val k: i64 = 999;
-    val rr: Result[bool, str] = m.remove(?k);
-    if (rr.is_err()) { ret 0; }
-    if (rr.unwrap_ok()) { ret 0; } # should return false
+    val rr: Result[bool, str] = map_remove(?m, ?k);
+    if (result_is_err(rr)) { ret 0; }
+    if (result_unwrap_ok(rr)) { ret 0; } # should return false
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -577,13 +577,13 @@ test "map: get non-existent returns error" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    m.insert(1, 10);
+    map_insert(?m, 1, 10);
 
     val k: i64 = 999;
-    val gr: Result[*i64, str] = m.get(?k);
-    if (gr.is_ok()) { ret 0; }
+    val gr: Result[*i64, str] = map_get(?m, ?k);
+    if (result_is_ok(gr)) { ret 0; }
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -592,18 +592,18 @@ test "map: clear" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    m.insert(1, 10);
-    m.insert(2, 20);
-    m.insert(3, 30);
+    map_insert(?m, 1, 10);
+    map_insert(?m, 2, 20);
+    map_insert(?m, 3, 30);
 
-    val cap_before: usize = m.capacity();
-    m.clear();
+    val cap_before: usize = map_capacity(m);
+    map_clear(?m);
 
-    if (m.length() != 0) { ret 0; }
-    if (!m.is_empty()) { ret 0; }
-    if (m.capacity() != cap_before) { ret 0; }
+    if (map_length(m) != 0) { ret 0; }
+    if (!map_is_empty(m)) { ret 0; }
+    if (map_capacity(m) != cap_before) { ret 0; }
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -615,24 +615,24 @@ test "map: many insertions trigger growth" {
     # insert many entries
     var i: i64 = 0;
     for (i < 100) {
-        val r: Result[bool, str] = m.insert(i, i * 10);
-        if (r.is_err()) { ret 0; }
+        val r: Result[bool, str] = map_insert(?m, i, i * 10);
+        if (result_is_err(r)) { ret 0; }
         i = i + 1;
     }
 
-    if (m.length() != 100) { ret 0; }
-    if (m.capacity() < 100) { ret 0; }
+    if (map_length(m) != 100) { ret 0; }
+    if (map_capacity(m) < 100) { ret 0; }
 
     # verify all entries
     var j: i64 = 0;
     for (j < 100) {
-        val gr: Result[*i64, str] = m.get(?j);
-        if (gr.is_err()) { ret 0; }
-        if (@gr.unwrap_ok() != j * 10) { ret 0; }
+        val gr: Result[*i64, str] = map_get(?m, ?j);
+        if (result_is_err(gr)) { ret 0; }
+        if (@result_unwrap_ok(gr) != j * 10) { ret 0; }
         j = j + 1;
     }
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -641,24 +641,24 @@ test "map: insert after remove reuses tombstone" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    m.insert(1, 10);
-    m.insert(2, 20);
+    map_insert(?m, 1, 10);
+    map_insert(?m, 2, 20);
 
     val k: i64 = 1;
-    m.remove(?k);
+    map_remove(?m, ?k);
 
     # insert new key
-    m.insert(3, 30);
+    map_insert(?m, 3, 30);
 
-    if (m.length() != 2) { ret 0; }
+    if (map_length(m) != 2) { ret 0; }
 
     val k2: i64 = 2;
     val k3: i64 = 3;
-    if (!m.contains(?k2)) { ret 0; }
-    if (!m.contains(?k3)) { ret 0; }
-    if (m.contains(?k)) { ret 0; }
+    if (!str_contains(m, ?k2)) { ret 0; }
+    if (!str_contains(m, ?k3)) { ret 0; }
+    if (str_contains(m, ?k)) { ret 0; }
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -666,7 +666,7 @@ test "map: insert after remove reuses tombstone" {
 test "map: dnit on empty map" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -675,27 +675,27 @@ test "map: string keys" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[str, i64] = init[str, i64](a, hash_str, eq_str);
 
-    m.insert("hello", 1);
-    m.insert("world", 2);
-    m.insert("foo", 3);
+    map_insert(?m, "hello", 1);
+    map_insert(?m, "world", 2);
+    map_insert(?m, "foo", 3);
 
-    if (m.length() != 3) { ret 0; }
+    if (map_length(m) != 3) { ret 0; }
 
     val k1: str = "hello";
     val k2: str = "world";
     val k3: str = "bar";
 
-    val r1: Result[*i64, str] = m.get(?k1);
-    if (r1.is_err()) { ret 0; }
-    if (@r1.unwrap_ok() != 1) { ret 0; }
+    val r1: Result[*i64, str] = map_get(?m, ?k1);
+    if (result_is_err(r1)) { ret 0; }
+    if (@result_unwrap_ok(r1) != 1) { ret 0; }
 
-    val r2: Result[*i64, str] = m.get(?k2);
-    if (r2.is_err()) { ret 0; }
-    if (@r2.unwrap_ok() != 2) { ret 0; }
+    val r2: Result[*i64, str] = map_get(?m, ?k2);
+    if (result_is_err(r2)) { ret 0; }
+    if (@result_unwrap_ok(r2) != 2) { ret 0; }
 
-    if (m.contains(?k3)) { ret 0; }
+    if (str_contains(m, ?k3)) { ret 0; }
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -704,20 +704,20 @@ test "map: get allows mutation" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    m.insert(42, 100);
+    map_insert(?m, 42, 100);
 
     val k: i64 = 42;
-    val r: Result[*i64, str] = m.get(?k);
-    if (r.is_err()) { ret 0; }
+    val r: Result[*i64, str] = map_get(?m, ?k);
+    if (result_is_err(r)) { ret 0; }
 
-    val p: *i64 = r.unwrap_ok();
+    val p: *i64 = result_unwrap_ok(r);
     @p = 999;
 
-    val r2: Result[*i64, str] = m.get(?k);
-    if (r2.is_err()) { ret 0; }
-    if (@r2.unwrap_ok() != 999) { ret 0; }
+    val r2: Result[*i64, str] = map_get(?m, ?k);
+    if (result_is_err(r2)) { ret 0; }
+    if (@result_unwrap_ok(r2) != 999) { ret 0; }
 
-    val ok: bool = m.dnit();
+    val ok: bool = map_dnit(?m);
     if (!ok) { ret 0; }
     ret 1;
 }

--- a/src/collections/slice.mach
+++ b/src/collections/slice.mach
@@ -23,14 +23,14 @@ pub fun slice_make[T](data: *T, size: usize) Slice[T] {
 # Checks if the Slice[T] is empty.
 # ---
 # ret: true if the slice is empty, false otherwise.
-pub fun (this: Slice[T]) is_empty() bool {
+pub fun slice_is_empty(this: Slice[T]) bool {
     ret this.size == 0;
 }
 
 # Converts the Slice[T] to a View[T].
 # ---
 # ret: A View[T] representing the same data as the slice.
-pub fun (this: Slice[T]) as_view() View[T] {
+pub fun slice_as_view(this: Slice[T]) View[T] {
     var v: View[T];
     v.data = this.data;
     v.size = this.size;
@@ -50,14 +50,14 @@ test "slice: slice_make creates slice from pointer and size" {
 test "slice: is_empty returns true for zero size" {
     var arr: [4]i64 = [4]i64{1, 2, 3, 4};
     val s: Slice[i64] = slice_make[i64](?arr[0], 0);
-    if (!s.is_empty()) { ret 0; }
+    if (!slice_is_empty(s)) { ret 0; }
     ret 1;
 }
 
 test "slice: is_empty returns false for non-zero size" {
     var arr: [4]i64 = [4]i64{1, 2, 3, 4};
     val s: Slice[i64] = slice_make[i64](?arr[0], 4);
-    if (s.is_empty()) { ret 0; }
+    if (slice_is_empty(s)) { ret 0; }
     ret 1;
 }
 
@@ -81,7 +81,7 @@ test "slice: data is mutable via slice" {
 test "slice: as_view converts to view" {
     var arr: [3]i64 = [3]i64{5, 6, 7};
     val s: Slice[i64] = slice_make[i64](?arr[0], 3);
-    val v: View[i64] = s.as_view();
+    val v: View[i64] = slice_as_view(s);
     if (v.size != 3) { ret 0; }
     if (v.data == nil) { ret 0; }
     ret 1;
@@ -90,7 +90,7 @@ test "slice: as_view converts to view" {
 test "slice: as_view preserves data reference" {
     var arr: [2]i64 = [2]i64{42, 43};
     val s: Slice[i64] = slice_make[i64](?arr[0], 2);
-    val v: View[i64] = s.as_view();
+    val v: View[i64] = slice_as_view(s);
     if (v.data[0] != 42) { ret 0; }
     if (v.data[1] != 43) { ret 0; }
     ret 1;

--- a/src/collections/vector.mach
+++ b/src/collections/vector.mach
@@ -31,7 +31,7 @@ pub fun init[T](alloc: allocator.Allocator) Vector[T] {
 # Free the backing buffer and reset the vector fields
 # ---
 # ret: true if memory was freed successfully, false otherwise
-pub fun (this: *Vector[T]) deinit() bool {
+pub fun vector_deinit(this: *Vector[T]) bool {
     if (this == nil) { ret true; }
     if (this.cap == 0) {
         this.data = nil;
@@ -39,7 +39,7 @@ pub fun (this: *Vector[T]) deinit() bool {
         ret true;
     }
 
-    val ok_free: bool = this.alloc.free[T](this.data, this.cap);
+    val ok_free: bool = allocator.allocator_free[T](this.alloc, this.data, this.cap);
     if (ok_free) {
         this.data = nil;
         this.len = 0;
@@ -52,28 +52,28 @@ pub fun (this: *Vector[T]) deinit() bool {
 # Check if the vector is empty
 # ---
 # ret: true if the vector has no elements, false otherwise
-pub fun (this: Vector[T]) is_empty() bool {
+pub fun vector_is_empty(this: Vector[T]) bool {
     ret this.len == 0;
 }
 
 # Return the current number of elements in the vector
 # ---
 # ret: Number of elements (usize)
-pub fun (this: Vector[T]) length() usize {
+pub fun vector_length(this: Vector[T]) usize {
     ret this.len;
 }
 
 # Return the current capacity in elements
 # ---
 # ret: Capacity in elements (usize)
-pub fun (this: Vector[T]) capacity() usize {
+pub fun vector_capacity(this: Vector[T]) usize {
     ret this.cap;
 }
 
 # Clear the vector contents but keep allocated capacity
 # ---
 # ret: None
-pub fun (this: *Vector[T]) clear() {
+pub fun vector_clear(this: *Vector[T]) {
     if (this == nil) { ret; }
     this.len = 0;
 }
@@ -82,7 +82,7 @@ pub fun (this: *Vector[T]) clear() {
 # ---
 # additional: Number of extra elements to reserve space for
 # ret: Ok(new capacity) or Err(error message)
-pub fun (this: *Vector[T]) reserve(additional: usize) Result[usize, str] {
+pub fun vector_reserve(this: *Vector[T], additional: usize) Result[usize, str] {
     if (this == nil) { ret err[usize, str]("vector is nil"); }
 
     val required: usize = this.len + additional;
@@ -110,12 +110,12 @@ pub fun (this: *Vector[T]) reserve(additional: usize) Result[usize, str] {
         }
     }
 
-    val r: Result[*T, allocator.AllocError] = this.alloc.resize[T](this.data, this.cap, new_cap);
-    if (r.is_err()) {
-        ret err[usize, str](r.unwrap_err());
+    val r: Result[*T, allocator.AllocError] = allocator.allocator_resize[T](this.alloc, this.data, this.cap, new_cap);
+    if (result_is_err(r)) {
+        ret err[usize, str](result_unwrap_err(r));
     }
 
-    this.data = r.unwrap_ok();
+    this.data = result_unwrap_ok(r);
     this.cap = new_cap;
 
     ret ok[usize, str](this.cap);
@@ -125,10 +125,10 @@ pub fun (this: *Vector[T]) reserve(additional: usize) Result[usize, str] {
 # ---
 # value: Value to append
 # ret: Ok(new length) or Err(error message)
-pub fun (this: *Vector[T]) push(value: T) Result[usize, str] {
-    val r: Result[usize, str] = this.reserve(1);
-    if (r.is_err()) {
-        ret err[usize, str](r.unwrap_err());
+pub fun vector_push(this: *Vector[T], value: T) Result[usize, str] {
+    val r: Result[usize, str] = vector_reserve(this, 1);
+    if (result_is_err(r)) {
+        ret err[usize, str](result_unwrap_err(r));
     }
 
     this.data[this.len] = value;
@@ -139,7 +139,7 @@ pub fun (this: *Vector[T]) push(value: T) Result[usize, str] {
 # Pop the last element from the vector
 # ---
 # ret: Ok(value) or Err(error message if vector is empty)
-pub fun (this: *Vector[T]) pop() Result[T, str] {
+pub fun vector_pop(this: *Vector[T]) Result[T, str] {
     if (this.len == 0) {
         ret err[T, str]("pop from empty vector");
     }
@@ -152,7 +152,7 @@ pub fun (this: *Vector[T]) pop() Result[T, str] {
 # ---
 # index: Element index
 # ret: Ok(pointer) or Err("index out of bounds")
-pub fun (this: &Vector[T]) get(index: usize) Result[*T, str] {
+pub fun vector_get(this: &Vector[T], index: usize) Result[*T, str] {
     if (index >= this.len) {
         ret err[*T, str]("index out of bounds");
     }
@@ -163,7 +163,7 @@ pub fun (this: &Vector[T]) get(index: usize) Result[*T, str] {
 # ---
 # index: Element index
 # ret: Ok(reference) or Err("index out of bounds")
-pub fun (this: Vector[T]) get_ref(index: usize) Result[&T, str] {
+pub fun vector_get_ref(this: Vector[T], index: usize) Result[&T, str] {
     if (index >= this.len) {
         ret err[&T, str]("index out of bounds");
     }
@@ -175,9 +175,9 @@ pub fun (this: Vector[T]) get_ref(index: usize) Result[&T, str] {
 test "vector: init creates empty vector" {
     var a: allocator.Allocator = allocator.page_allocator();
     val v: Vector[i64] = init[i64](a);
-    if (!v.is_empty()) { ret 0; }
-    if (v.length() != 0) { ret 0; }
-    if (v.capacity() != 0) { ret 0; }
+    if (!vector_is_empty(v)) { ret 0; }
+    if (vector_length(v) != 0) { ret 0; }
+    if (vector_capacity(v) != 0) { ret 0; }
     ret 1;
 }
 
@@ -185,12 +185,12 @@ test "vector: push adds element" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    val r: Result[usize, str] = v.push(42);
-    if (r.is_err()) { ret 0; }
-    if (v.length() != 1) { ret 0; }
-    if (v.is_empty()) { ret 0; }
+    val r: Result[usize, str] = vector_push(?v, 42);
+    if (result_is_err(r)) { ret 0; }
+    if (vector_length(v) != 1) { ret 0; }
+    if (vector_is_empty(v)) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -200,16 +200,16 @@ test "vector: push multiple elements" {
     var v: Vector[i64] = init[i64](a);
 
     var r: Result[usize, str];
-    r = v.push(10);
-    if (r.is_err()) { ret 0; }
-    r = v.push(20);
-    if (r.is_err()) { ret 0; }
-    r = v.push(30);
-    if (r.is_err()) { ret 0; }
+    r = vector_push(?v, 10);
+    if (result_is_err(r)) { ret 0; }
+    r = vector_push(?v, 20);
+    if (result_is_err(r)) { ret 0; }
+    r = vector_push(?v, 30);
+    if (result_is_err(r)) { ret 0; }
 
-    if (v.length() != 3) { ret 0; }
+    if (vector_length(v) != 3) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -218,16 +218,16 @@ test "vector: pop returns last element" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    v.push(100);
-    v.push(200);
-    v.push(300);
+    vector_push(?v, 100);
+    vector_push(?v, 200);
+    vector_push(?v, 300);
 
-    val r: Result[i64, str] = v.pop();
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 300) { ret 0; }
-    if (v.length() != 2) { ret 0; }
+    val r: Result[i64, str] = vector_pop(?v);
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 300) { ret 0; }
+    if (vector_length(v) != 2) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -236,10 +236,10 @@ test "vector: pop from empty returns error" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    val r: Result[i64, str] = v.pop();
-    if (r.is_ok()) { ret 0; }
+    val r: Result[i64, str] = vector_pop(?v);
+    if (result_is_ok(r)) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -248,16 +248,16 @@ test "vector: get returns pointer to element" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    v.push(111);
-    v.push(222);
-    v.push(333);
+    vector_push(?v, 111);
+    vector_push(?v, 222);
+    vector_push(?v, 333);
 
-    val r: Result[*i64, str] = v.get(1);
-    if (r.is_err()) { ret 0; }
-    val p: *i64 = r.unwrap_ok();
+    val r: Result[*i64, str] = vector_get(?v, 1);
+    if (result_is_err(r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(r);
     if (@p != 222) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -266,12 +266,12 @@ test "vector: get out of bounds returns error" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    v.push(42);
+    vector_push(?v, 42);
 
-    val r: Result[*i64, str] = v.get(5);
-    if (r.is_ok()) { ret 0; }
+    val r: Result[*i64, str] = vector_get(?v, 5);
+    if (result_is_ok(r)) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -280,18 +280,18 @@ test "vector: get allows mutation" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    v.push(100);
+    vector_push(?v, 100);
 
-    val r: Result[*i64, str] = v.get(0);
-    if (r.is_err()) { ret 0; }
-    val p: *i64 = r.unwrap_ok();
+    val r: Result[*i64, str] = vector_get(?v, 0);
+    if (result_is_err(r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(r);
     @p = 999;
 
-    val r2: Result[*i64, str] = v.get(0);
-    if (r2.is_err()) { ret 0; }
-    if (@r2.unwrap_ok() != 999) { ret 0; }
+    val r2: Result[*i64, str] = vector_get(?v, 0);
+    if (result_is_err(r2)) { ret 0; }
+    if (@result_unwrap_ok(r2) != 999) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -300,15 +300,15 @@ test "vector: get_ref returns immutable reference" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    v.push(555);
-    v.push(666);
+    vector_push(?v, 555);
+    vector_push(?v, 666);
 
-    val r: Result[&i64, str] = v.get_ref(1);
-    if (r.is_err()) { ret 0; }
-    val ref: &i64 = r.unwrap_ok();
+    val r: Result[&i64, str] = vector_get_ref(v, 1);
+    if (result_is_err(r)) { ret 0; }
+    val ref: &i64 = result_unwrap_ok(r);
     if (@ref != 666) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -317,12 +317,12 @@ test "vector: get_ref out of bounds returns error" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    v.push(42);
+    vector_push(?v, 42);
 
-    val r: Result[&i64, str] = v.get_ref(10);
-    if (r.is_ok()) { ret 0; }
+    val r: Result[&i64, str] = vector_get_ref(v, 10);
+    if (result_is_ok(r)) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -331,12 +331,12 @@ test "vector: reserve increases capacity" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    val r: Result[usize, str] = v.reserve(100);
-    if (r.is_err()) { ret 0; }
-    if (v.capacity() < 100) { ret 0; }
-    if (v.length() != 0) { ret 0; }
+    val r: Result[usize, str] = vector_reserve(?v, 100);
+    if (result_is_err(r)) { ret 0; }
+    if (vector_capacity(v) < 100) { ret 0; }
+    if (vector_length(v) != 0) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -345,15 +345,15 @@ test "vector: reserve when already sufficient is noop" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    v.reserve(50);
-    val cap1: usize = v.capacity();
+    vector_reserve(?v, 50);
+    val cap1: usize = vector_capacity(v);
 
-    v.reserve(10);
-    val cap2: usize = v.capacity();
+    vector_reserve(?v, 10);
+    val cap2: usize = vector_capacity(v);
 
     if (cap2 != cap1) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -362,18 +362,18 @@ test "vector: clear resets length but keeps capacity" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    v.push(1);
-    v.push(2);
-    v.push(3);
-    val cap_before: usize = v.capacity();
+    vector_push(?v, 1);
+    vector_push(?v, 2);
+    vector_push(?v, 3);
+    val cap_before: usize = vector_capacity(v);
 
-    v.clear();
+    vector_clear(?v);
 
-    if (v.length() != 0) { ret 0; }
-    if (!v.is_empty()) { ret 0; }
-    if (v.capacity() != cap_before) { ret 0; }
+    if (vector_length(v) != 0) { ret 0; }
+    if (!vector_is_empty(v)) { ret 0; }
+    if (vector_capacity(v) != cap_before) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -381,7 +381,7 @@ test "vector: clear resets length but keeps capacity" {
 test "vector: deinit on empty vector succeeds" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -393,24 +393,24 @@ test "vector: push triggers capacity growth" {
     # push many elements to trigger growth
     var i: i64 = 0;
     for (i < 100) {
-        val r: Result[usize, str] = v.push(i);
-        if (r.is_err()) { ret 0; }
+        val r: Result[usize, str] = vector_push(?v, i);
+        if (result_is_err(r)) { ret 0; }
         i = i + 1;
     }
 
-    if (v.length() != 100) { ret 0; }
-    if (v.capacity() < 100) { ret 0; }
+    if (vector_length(v) != 100) { ret 0; }
+    if (vector_capacity(v) < 100) { ret 0; }
 
     # verify all values
     var j: usize = 0;
     for (j < 100) {
-        val r: Result[&i64, str] = v.get_ref(j);
-        if (r.is_err()) { ret 0; }
-        if (@r.unwrap_ok() != j::i64) { ret 0; }
+        val r: Result[&i64, str] = vector_get_ref(v, j);
+        if (result_is_err(r)) { ret 0; }
+        if (@result_unwrap_ok(r) != j::i64) { ret 0; }
         j = j + 1;
     }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -419,33 +419,33 @@ test "vector: push and pop sequence" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    v.push(1);
-    v.push(2);
-    v.push(3);
+    vector_push(?v, 1);
+    vector_push(?v, 2);
+    vector_push(?v, 3);
 
     var r: Result[i64, str];
 
-    r = v.pop();
-    if (r.unwrap_ok() != 3) { ret 0; }
+    r = vector_pop(?v);
+    if (result_unwrap_ok(r) != 3) { ret 0; }
 
-    v.push(4);
-    v.push(5);
+    vector_push(?v, 4);
+    vector_push(?v, 5);
 
-    r = v.pop();
-    if (r.unwrap_ok() != 5) { ret 0; }
+    r = vector_pop(?v);
+    if (result_unwrap_ok(r) != 5) { ret 0; }
 
-    r = v.pop();
-    if (r.unwrap_ok() != 4) { ret 0; }
+    r = vector_pop(?v);
+    if (result_unwrap_ok(r) != 4) { ret 0; }
 
-    r = v.pop();
-    if (r.unwrap_ok() != 2) { ret 0; }
+    r = vector_pop(?v);
+    if (result_unwrap_ok(r) != 2) { ret 0; }
 
-    r = v.pop();
-    if (r.unwrap_ok() != 1) { ret 0; }
+    r = vector_pop(?v);
+    if (result_unwrap_ok(r) != 1) { ret 0; }
 
-    if (!v.is_empty()) { ret 0; }
+    if (!vector_is_empty(v)) { ret 0; }
 
-    val ok: bool = v.deinit();
+    val ok: bool = vector_deinit(?v);
     if (!ok) { ret 0; }
     ret 1;
 }

--- a/src/collections/view.mach
+++ b/src/collections/view.mach
@@ -22,7 +22,7 @@ pub fun view_make[T](data: &T, size: usize) View[T] {
 # Checks if the View[T] is empty.
 # ---
 # ret: true if the view is empty, false otherwise.
-pub fun (this: View[T]) is_empty() bool {
+pub fun view_is_empty(this: View[T]) bool {
     ret this.size == 0;
 }
 
@@ -39,14 +39,14 @@ test "view: view_make creates view from pointer and size" {
 test "view: is_empty returns true for zero size" {
     var arr: [4]i64 = [4]i64{1, 2, 3, 4};
     val v: View[i64] = view_make[i64](?arr[0], 0);
-    if (!v.is_empty()) { ret 0; }
+    if (!view_is_empty(v)) { ret 0; }
     ret 1;
 }
 
 test "view: is_empty returns false for non-zero size" {
     var arr: [4]i64 = [4]i64{1, 2, 3, 4};
     val v: View[i64] = view_make[i64](?arr[0], 4);
-    if (v.is_empty()) { ret 0; }
+    if (view_is_empty(v)) { ret 0; }
     ret 1;
 }
 
@@ -70,6 +70,6 @@ test "view: view of u8 bytes" {
 
 test "view: nil data with zero size is empty" {
     val v: View[i64] = view_make[i64](nil, 0);
-    if (!v.is_empty()) { ret 0; }
+    if (!view_is_empty(v)) { ret 0; }
     ret 1;
 }

--- a/src/data/toml.mach
+++ b/src/data/toml.mach
@@ -74,12 +74,12 @@ fun alloc_copy(a: *Allocator, src: str, start: usize, len: usize) Result[str, st
         ret err[str, str]("allocator is nil");
     }
 
-    val r: Result[*u8, AllocError] = a.alloc[u8](len + 1);
-    if (r.is_err()) {
-        ret err[str, str](r.unwrap_err());
+    val r: Result[*u8, AllocError] = allocator_alloc[u8](a, len + 1);
+    if (result_is_err(r)) {
+        ret err[str, str](result_unwrap_err(r));
     }
 
-    val buf: *u8 = r.unwrap_ok();
+    val buf: *u8 = result_unwrap_ok(r);
     mem.raw_copy(buf::ptr, (src::usize + start)::ptr, len);
     buf[len] = 0;
     ret ok[str, str](buf::&u8);
@@ -87,20 +87,20 @@ fun alloc_copy(a: *Allocator, src: str, start: usize, len: usize) Result[str, st
 
 fun concat_key(a: *Allocator, prefix: str, key: str) Result[str, str] {
     if (prefix == nil || prefix[0] == 0) {
-        ret alloc_copy(a, key, 0, key.len());
+        ret alloc_copy(a, key, 0, str_len(key));
     }
 
-    val p_len: usize = prefix.len();
-    val k_len: usize = key.len();
+    val p_len: usize = str_len(prefix);
+    val k_len: usize = str_len(key);
 
     # prefix + '.' + key
     val out_len: usize = p_len + 1 + k_len;
-    val r: Result[*u8, AllocError] = a.alloc[u8](out_len + 1);
-    if (r.is_err()) {
-        ret err[str, str](r.unwrap_err());
+    val r: Result[*u8, AllocError] = allocator_alloc[u8](a, out_len + 1);
+    if (result_is_err(r)) {
+        ret err[str, str](result_unwrap_err(r));
     }
 
-    val buf: *u8 = r.unwrap_ok();
+    val buf: *u8 = result_unwrap_ok(r);
     mem.raw_copy(buf::ptr, prefix::ptr, p_len);
     buf[p_len] = 46;
     mem.raw_copy((buf::usize + p_len + 1)::ptr, key::ptr, k_len);
@@ -117,11 +117,11 @@ fun push_entry(a: *Allocator, entries: *Entry, cap: *usize, len: *usize, e: Entr
 
     if (@cap == 0) {
         @cap = 16;
-        val r: Result[*Entry, AllocError] = a.alloc[Entry](@cap);
-        if (r.is_err()) {
-            ret err[*Entry, str](r.unwrap_err());
+        val r: Result[*Entry, AllocError] = allocator_alloc[Entry](a, @cap);
+        if (result_is_err(r)) {
+            ret err[*Entry, str](result_unwrap_err(r));
         }
-        out = r.unwrap_ok();
+        out = result_unwrap_ok(r);
     } or (out == nil) {
         ret err[*Entry, str]("internal error");
     }
@@ -129,11 +129,11 @@ fun push_entry(a: *Allocator, entries: *Entry, cap: *usize, len: *usize, e: Entr
     if (@len >= @cap) {
         val old: usize = @cap;
         val new_cap: usize = old * 2;
-        val r2: Result[*Entry, AllocError] = a.resize[Entry](out, old, new_cap);
-        if (r2.is_err()) {
-            ret err[*Entry, str](r2.unwrap_err());
+        val r2: Result[*Entry, AllocError] = allocator_resize[Entry](a, out, old, new_cap);
+        if (result_is_err(r2)) {
+            ret err[*Entry, str](result_unwrap_err(r2));
         }
-        out = r2.unwrap_ok();
+        out = result_unwrap_ok(r2);
         @cap = new_cap;
     }
 
@@ -177,12 +177,12 @@ fun parse_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     }
 
     # allocate
-    val r: Result[*u8, AllocError] = a.alloc[u8](out_len + 1);
-    if (r.is_err()) {
-        ret err[str, str](r.unwrap_err());
+    val r: Result[*u8, AllocError] = allocator_alloc[u8](a, out_len + 1);
+    if (result_is_err(r)) {
+        ret err[str, str](result_unwrap_err(r));
     }
 
-    val buf: *u8 = r.unwrap_ok();
+    val buf: *u8 = result_unwrap_ok(r);
 
     # pass 2: copy/translate
     var si: usize = start;
@@ -286,20 +286,20 @@ fun parse_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
     val b: u8 = src[@i];
     if (b == 34) {
         val r: Result[str, str] = parse_string(a, src, i);
-        if (r.is_err()) { ret err[Value, str](r.unwrap_err()); }
-        ret ok[Value, str](Value{string: r.unwrap_ok()});
+        if (result_is_err(r)) { ret err[Value, str](result_unwrap_err(r)); }
+        ret ok[Value, str](Value{string: result_unwrap_ok(r)});
     }
 
     if (b == 45 || (b >= 48 && b <= 57)) {
         val r: Result[i64, str] = parse_int(src, i);
-        if (r.is_err()) { ret err[Value, str](r.unwrap_err()); }
-        ret ok[Value, str](Value{integer: r.unwrap_ok()});
+        if (result_is_err(r)) { ret err[Value, str](result_unwrap_err(r)); }
+        ret ok[Value, str](Value{integer: result_unwrap_ok(r)});
     }
 
     if (b == 116 || b == 102) {
         val r: Result[bool, str] = parse_bool(src, i);
-        if (r.is_err()) { ret err[Value, str](r.unwrap_err()); }
-        ret ok[Value, str](Value{boolean: r.unwrap_ok()});
+        if (result_is_err(r)) { ret err[Value, str](result_unwrap_err(r)); }
+        ret ok[Value, str](Value{boolean: result_unwrap_ok(r)});
     }
 
     if (b == 91) {
@@ -319,25 +319,25 @@ fun parse_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
             }
 
             val vr: Result[Value, str] = parse_value(a, src, i);
-            if (vr.is_err()) {
-                ret err[Value, str](vr.unwrap_err());
+            if (result_is_err(vr)) {
+                ret err[Value, str](result_unwrap_err(vr));
             }
 
             if (cap == 0) {
                 cap = 8;
-                val r0: Result[*Value, AllocError] = a.alloc[Value](cap);
-                if (r0.is_err()) { ret err[Value, str](r0.unwrap_err()); }
-                items = r0.unwrap_ok();
+                val r0: Result[*Value, AllocError] = allocator_alloc[Value](a, cap);
+                if (result_is_err(r0)) { ret err[Value, str](result_unwrap_err(r0)); }
+                items = result_unwrap_ok(r0);
             } or (len >= cap) {
                 val old: usize = cap;
                 val new_cap: usize = cap * 2;
-                val r1: Result[*Value, AllocError] = a.resize[Value](items, old, new_cap);
-                if (r1.is_err()) { ret err[Value, str](r1.unwrap_err()); }
-                items = r1.unwrap_ok();
+                val r1: Result[*Value, AllocError] = allocator_resize[Value](a, items, old, new_cap);
+                if (result_is_err(r1)) { ret err[Value, str](result_unwrap_err(r1)); }
+                items = result_unwrap_ok(r1);
                 cap = new_cap;
             }
 
-            items[len] = vr.unwrap_ok();
+            items[len] = result_unwrap_ok(vr);
             len = len + 1;
 
             skip_ws_and_comments(src, i);
@@ -406,11 +406,11 @@ pub fun parse(a: *Allocator, src: str) Result[Document, str] {
             }
 
             val r: Result[str, str] = alloc_copy(a, src, start, end - start);
-            if (r.is_err()) {
-                ret err[Document, str](r.unwrap_err());
+            if (result_is_err(r)) {
+                ret err[Document, str](result_unwrap_err(r));
             }
 
-            prefix = r.unwrap_ok();
+            prefix = result_unwrap_ok(r);
 
             # consume ']'
             i = i + 1;
@@ -428,8 +428,8 @@ pub fun parse(a: *Allocator, src: str) Result[Document, str] {
 
         # trim key trailing spaces (shouldn't happen for is_ident loop)
         val key_r: Result[str, str] = alloc_copy(a, src, key_start, i - key_start);
-        if (key_r.is_err()) {
-            ret err[Document, str](key_r.unwrap_err());
+        if (result_is_err(key_r)) {
+            ret err[Document, str](result_unwrap_err(key_r));
         }
 
         skip_ws_and_comments(src, ?i);
@@ -439,21 +439,21 @@ pub fun parse(a: *Allocator, src: str) Result[Document, str] {
         i = i + 1;
 
         val vr: Result[Value, str] = parse_value(a, src, ?i);
-        if (vr.is_err()) {
-            ret err[Document, str](vr.unwrap_err());
+        if (result_is_err(vr)) {
+            ret err[Document, str](result_unwrap_err(vr));
         }
 
-        val full_key_r: Result[str, str] = concat_key(a, prefix, key_r.unwrap_ok());
-        if (full_key_r.is_err()) {
-            ret err[Document, str](full_key_r.unwrap_err());
+        val full_key_r: Result[str, str] = concat_key(a, prefix, result_unwrap_ok(key_r));
+        if (result_is_err(full_key_r)) {
+            ret err[Document, str](result_unwrap_err(full_key_r));
         }
 
-        val pr: Result[*Entry, str] = push_entry(a, entries, ?cap, ?len, Entry{key: full_key_r.unwrap_ok(), value: vr.unwrap_ok()});
-        if (pr.is_err()) {
-            ret err[Document, str](pr.unwrap_err());
+        val pr: Result[*Entry, str] = push_entry(a, entries, ?cap, ?len, Entry{key: result_unwrap_ok(full_key_r), value: result_unwrap_ok(vr)});
+        if (result_is_err(pr)) {
+            ret err[Document, str](result_unwrap_err(pr));
         }
 
-        entries = pr.unwrap_ok();
+        entries = result_unwrap_ok(pr);
 
         # consume rest of line
         for (src[i] != 0 && src[i] != 10) {

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -96,7 +96,7 @@ pub fun create(path: str, mode: i32) Result[File, str] {
 # close: close the underlying file descriptor.
 # ---
 # ret: Ok(true) on success or Err(str) with errno message on failure.
-pub fun (this: *File) close() Result[bool, str] {
+pub fun file_close(this: *File) Result[bool, str] {
     if (this == nil) {
         ret ok[bool, str](true);
     }
@@ -123,7 +123,7 @@ pub fun (this: *File) close() Result[bool, str] {
 # buf: buffer to read into
 # len: maximum number of bytes to read
 # ret: Ok(bytes_read) on success or Err(str) with errno message on failure.
-pub fun (this: *File) read(buf: *u8, len: usize) Result[usize, str] {
+pub fun file_read(this: *File, buf: *u8, len: usize) Result[usize, str] {
     if (this == nil) {
         ret err[usize, str]("io error");
     }
@@ -150,7 +150,7 @@ pub fun (this: *File) read(buf: *u8, len: usize) Result[usize, str] {
 # buf: buffer to write from
 # len: number of bytes to write
 # ret: Ok(bytes_written) on success or Err(str) with errno message on failure.
-pub fun (this: *File) write(buf: &u8, len: usize) Result[usize, str] {
+pub fun file_write(this: *File, buf: &u8, len: usize) Result[usize, str] {
     if (this == nil) {
         ret err[usize, str]("io error");
     }
@@ -175,7 +175,7 @@ pub fun (this: *File) write(buf: &u8, len: usize) Result[usize, str] {
 # stat: get file metadata.
 # ---
 # ret: Ok(Stat) on success or Err(str) with errno message on failure.
-pub fun (this: &File) stat() Result[Stat, str] {
+pub fun file_stat(this: &File) Result[Stat, str] {
     if (this == nil) {
         ret err[Stat, str]("io error");
     }
@@ -193,7 +193,7 @@ pub fun (this: &File) stat() Result[Stat, str] {
 # offset: offset to seek to
 # whence: seek mode (e.g., SEEK_SET, SEEK_CUR, SEEK_END)
 # ret: Ok(new_offset) on success or Err(str) with errno message on failure.
-pub fun (this: &File) seek(offset: i64, whence: i32) Result[i64, str] {
+pub fun file_seek(this: &File, offset: i64, whence: i32) Result[i64, str] {
     if (this == nil) {
         ret err[i64, str]("io error");
     }
@@ -252,11 +252,11 @@ pub fun stat_path(path: str) Result[Stat, str] {
 # ret: true if directory, false otherwise
 pub fun is_dir(path: str) bool {
     val st_res: Result[Stat, str] = stat_path(path);
-    if (st_res.is_err()) {
+    if (result_is_err(st_res)) {
         ret false;
     }
 
-    val st: Stat = st_res.unwrap_ok();
+    val st: Stat = result_unwrap_ok(st_res);
     ret (st.st_mode & c.S_IFMT) == c.S_IFDIR;
 }
 
@@ -266,11 +266,11 @@ pub fun is_dir(path: str) bool {
 # ret: true if regular file, false otherwise
 pub fun is_file(path: str) bool {
     val st_res: Result[Stat, str] = stat_path(path);
-    if (st_res.is_err()) {
+    if (result_is_err(st_res)) {
         ret false;
     }
 
-    val st: Stat = st_res.unwrap_ok();
+    val st: Stat = result_unwrap_ok(st_res);
     ret (st.st_mode & c.S_IFMT) == c.S_IFREG;
 }
 
@@ -328,28 +328,28 @@ pub fun create_dir_all(path_str: str, mode: i32) Result[bool, str] {
     }
 
     val create_res: Result[bool, str] = create_dir(path_str, mode);
-    if (create_res.is_ok()) {
+    if (result_is_ok(create_res)) {
         ret create_res;
     }
 
     var a: allocator.Allocator = allocator.default();
     val parent_res: Result[path.Path, allocator.AllocError] = path.parent(?a, path_str);
-    if (parent_res.is_err()) {
-        ret err[bool, str](parent_res.unwrap_err());
+    if (result_is_err(parent_res)) {
+        ret err[bool, str](result_unwrap_err(parent_res));
     }
 
-    val parent_path: path.Path = parent_res.unwrap_ok();
+    val parent_path: path.Path = result_unwrap_ok(parent_res);
     val parent_create_res: Result[bool, str] = create_dir_all(parent_path, mode);
 
-    val parent_len: usize = parent_path.len();
-    a.free[u8](parent_path::ptr::*u8, parent_len + 1);
+    val parent_len: usize = str_len(parent_path);
+    allocator_free[u8](a, parent_path::ptr::*u8, parent_len + 1);
 
-    if (parent_create_res.is_err()) {
+    if (result_is_err(parent_create_res)) {
         ret parent_create_res;
     }
 
     val final_res: Result[bool, str] = create_dir(path_str, mode);
-    if (final_res.is_ok()) {
+    if (result_is_ok(final_res)) {
         ret final_res;
     }
 
@@ -391,7 +391,7 @@ pub fun temp_create(prefix: str) Result[TempFile, str] {
         tf.path_len = 0;
 
         # copy "/tmp/"
-        val dir_len: usize = TEMP_DIR.len();
+        val dir_len: usize = str_len(TEMP_DIR);
         mem.raw_copy(?tf.path_buf[0], TEMP_DIR, dir_len);
         tf.path_len = dir_len;
 
@@ -401,7 +401,7 @@ pub fun temp_create(prefix: str) Result[TempFile, str] {
 
         # copy prefix
         if (prefix != nil) {
-            val prefix_len: usize = prefix.len();
+            val prefix_len: usize = str_len(prefix);
             mem.raw_copy(?tf.path_buf[tf.path_len], prefix, prefix_len);
             tf.path_len = tf.path_len + prefix_len;
         }
@@ -475,39 +475,39 @@ fun write_u64_to_buf(buf: *u8, offset: usize, cap: usize, n: u64) usize {
 # path: returns the path of the temp file as a string.
 # ---
 # ret: null-terminated path string
-pub fun (this: &TempFile) path() str {
+pub fun temp_file_path(this: &TempFile) str {
     ret ?this.path_buf[0];
 }
 
 # as_file: return a pointer to the underlying file.
 # ---
 # ret: pointer to File
-pub fun (this: *TempFile) as_file() *File {
+pub fun temp_file_as_file(this: *TempFile) *File {
     ret ?this.file;
 }
 
 # close: close the temp file (does not remove it).
 # ---
 # ret: Ok(true) on success or Err(str) on failure.
-pub fun (this: *TempFile) close() Result[bool, str] {
-    ret (?this.file).close();
+pub fun temp_file_close(this: *TempFile) Result[bool, str] {
+    ret (file_close(?this.file));
 }
 
 # remove: remove the temp file from disk (should close first).
 # ---
 # ret: Ok(true) on success or Err(str) on failure.
-pub fun (this: *TempFile) remove() Result[bool, str] {
+pub fun temp_file_remove(this: *TempFile) Result[bool, str] {
     ret unlink(?this.path_buf[0]);
 }
 
 # close_and_remove: close the file and remove it from disk.
 # ---
 # ret: Ok(true) on success or Err(str) on failure (returns first error).
-pub fun (this: *TempFile) close_and_remove() Result[bool, str] {
-    val close_res: Result[bool, str] = this.close();
-    val remove_res: Result[bool, str] = this.remove();
+pub fun temp_file_close_and_remove(this: *TempFile) Result[bool, str] {
+    val close_res: Result[bool, str] = file_close(this);
+    val remove_res: Result[bool, str] = temp_file_remove(this);
 
-    if (close_res.is_err()) {
+    if (result_is_err(close_res)) {
         ret close_res;
     }
     ret remove_res;
@@ -517,8 +517,8 @@ pub fun (this: *TempFile) close_and_remove() Result[bool, str] {
 
 test "filesystem: temp_create creates file" {
     val r: Result[TempFile, str] = temp_create("test");
-    if (r.is_err()) { ret 0; }
-    var tf: TempFile = r.unwrap_ok();
+    if (result_is_err(r)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok(r);
 
     # file should have valid fd
     if (tf.file.fd < 0) { ret 2; }
@@ -527,173 +527,173 @@ test "filesystem: temp_create creates file" {
     if (tf.path_len == 0) { ret 3; }
 
     # clean up
-    val cr: Result[bool, str] = tf.close_and_remove();
-    if (cr.is_err()) { ret 4; }
+    val cr: Result[bool, str] = temp_file_close_and_remove(?tf);
+    if (result_is_err(cr)) { ret 4; }
     ret 1;
 }
 
 test "filesystem: temp_create path is valid" {
     val r: Result[TempFile, str] = temp_create("myprefix");
-    if (r.is_err()) { ret 0; }
-    var tf: TempFile = r.unwrap_ok();
+    if (result_is_err(r)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok(r);
 
-    val p: str = tf.path();
+    val p: str = temp_file_path(?tf);
     if (p == nil) { ret 2; }
 
     # path should start with /tmp/
-    if (!p.starts_with("/tmp/")) { ret 3; }
+    if (!str_starts_with(p, "/tmp/")) { ret 3; }
 
     # path should contain prefix
-    if (!p.contains("myprefix")) { ret 4; }
+    if (!str_contains(p, "myprefix")) { ret 4; }
 
-    tf.close_and_remove();
+    temp_file_close_and_remove(?tf);
     ret 1;
 }
 
 test "filesystem: temp file write and read" {
     val r: Result[TempFile, str] = temp_create("rw");
-    if (r.is_err()) { ret 0; }
-    var tf: TempFile = r.unwrap_ok();
+    if (result_is_err(r)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok(r);
 
     # write some data
     val data: str = "hello temp file";
-    val wr: Result[usize, str] = tf.file.write(data, data.len());
-    if (wr.is_err()) { ret 2; }
-    if (wr.unwrap_ok() != data.len()) { ret 3; }
+    val wr: Result[usize, str] = file_write(?tf.file, data, str_len(data));
+    if (result_is_err(wr)) { ret 2; }
+    if (result_unwrap_ok(wr) != str_len(data)) { ret 3; }
 
     # seek back to start
-    val sr: Result[i64, str] = tf.file.seek(0, c.SEEK_SET);
-    if (sr.is_err()) { ret 4; }
+    val sr: Result[i64, str] = file_seek(?tf.file, 0, c.SEEK_SET);
+    if (result_is_err(sr)) { ret 4; }
 
     # read back
     var buf: [64]u8;
-    val rr: Result[usize, str] = tf.file.read(?buf[0], 64);
-    if (rr.is_err()) { ret 5; }
-    if (rr.unwrap_ok() != data.len()) { ret 6; }
+    val rr: Result[usize, str] = file_read(?tf.file, ?buf[0], 64);
+    if (result_is_err(rr)) { ret 5; }
+    if (result_unwrap_ok(rr) != str_len(data)) { ret 6; }
 
     # verify content
     val read_str: str = ?buf[0];
-    if (!read_str.starts_with("hello temp file")) { ret 7; }
+    if (!str_starts_with(read_str, "hello temp file")) { ret 7; }
 
-    tf.close_and_remove();
+    temp_file_close_and_remove(?tf);
     ret 1;
 }
 
 test "filesystem: temp file close then remove" {
     val r: Result[TempFile, str] = temp_create("closeremove");
-    if (r.is_err()) { ret 0; }
-    var tf: TempFile = r.unwrap_ok();
+    if (result_is_err(r)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok(r);
 
-    val cr: Result[bool, str] = tf.close();
-    if (cr.is_err()) { ret 2; }
+    val cr: Result[bool, str] = file_close(?tf);
+    if (result_is_err(cr)) { ret 2; }
 
-    val rr: Result[bool, str] = tf.remove();
-    if (rr.is_err()) { ret 3; }
+    val rr: Result[bool, str] = temp_file_remove(?tf);
+    if (result_is_err(rr)) { ret 3; }
 
     ret 1;
 }
 
 test "filesystem: open non-existent file returns error" {
     val r: Result[File, str] = open("/tmp/this_file_should_not_exist_12345");
-    if (r.is_ok()) { ret 0; }
+    if (result_is_ok(r)) { ret 0; }
     ret 1;
 }
 
 test "filesystem: create write close open read" {
     # create a temp file
     val cr: Result[TempFile, str] = temp_create("fullcycle");
-    if (cr.is_err()) { ret 0; }
-    var tf: TempFile = cr.unwrap_ok();
+    if (result_is_err(cr)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok(cr);
 
     # write data
     val data: str = "test data 12345";
-    val wr: Result[usize, str] = tf.file.write(data, data.len());
-    if (wr.is_err()) { ret 2; }
+    val wr: Result[usize, str] = file_write(?tf.file, data, str_len(data));
+    if (result_is_err(wr)) { ret 2; }
 
     # close
-    val clr: Result[bool, str] = tf.close();
-    if (clr.is_err()) { ret 3; }
+    val clr: Result[bool, str] = file_close(?tf);
+    if (result_is_err(clr)) { ret 3; }
 
     # open again for reading
-    val open_res: Result[File, str] = open(tf.path());
-    if (open_res.is_err()) { ret 4; }
-    var f: File = open_res.unwrap_ok();
+    val open_res: Result[File, str] = open(temp_file_path(?tf));
+    if (result_is_err(open_res)) { ret 4; }
+    var f: File = result_unwrap_ok(open_res);
 
     # read
     var buf: [64]u8;
-    val rr: Result[usize, str] = f.read(?buf[0], 64);
-    if (rr.is_err()) { ret 5; }
-    if (rr.unwrap_ok() != data.len()) { ret 6; }
+    val rr: Result[usize, str] = file_read(?f, ?buf[0], 64);
+    if (result_is_err(rr)) { ret 5; }
+    if (result_unwrap_ok(rr) != str_len(data)) { ret 6; }
 
     # close and cleanup
-    f.close();
-    tf.remove();
+    file_close(?f);
+    temp_file_remove(?tf);
     ret 1;
 }
 
 test "filesystem: stat returns valid metadata" {
     val cr: Result[TempFile, str] = temp_create("stat");
-    if (cr.is_err()) { ret 0; }
-    var tf: TempFile = cr.unwrap_ok();
+    if (result_is_err(cr)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok(cr);
 
     # write some data
     val data: str = "some content";
-    tf.file.write(data, data.len());
+    file_write(?tf.file, data, str_len(data));
 
     # get stat
-    val sr: Result[Stat, str] = tf.file.stat();
-    if (sr.is_err()) { ret 2; }
-    val st: Stat = sr.unwrap_ok();
+    val sr: Result[Stat, str] = file_stat(?tf.file);
+    if (result_is_err(sr)) { ret 2; }
+    val st: Stat = result_unwrap_ok(sr);
 
     # size should match what we wrote
-    if (st.st_size != data.len()::i64) { ret 3; }
+    if (st.st_size != str_len(data)::i64) { ret 3; }
 
-    tf.close_and_remove();
+    temp_file_close_and_remove(?tf);
     ret 1;
 }
 
 test "filesystem: seek repositions file offset" {
     val cr: Result[TempFile, str] = temp_create("seek");
-    if (cr.is_err()) { ret 0; }
-    var tf: TempFile = cr.unwrap_ok();
+    if (result_is_err(cr)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok(cr);
 
     # write data
     val data: str = "0123456789";
-    tf.file.write(data, data.len());
+    file_write(?tf.file, data, str_len(data));
 
     # seek to position 5
-    val sr: Result[i64, str] = tf.file.seek(5, c.SEEK_SET);
-    if (sr.is_err()) { ret 2; }
-    if (sr.unwrap_ok() != 5) { ret 3; }
+    val sr: Result[i64, str] = file_seek(?tf.file, 5, c.SEEK_SET);
+    if (result_is_err(sr)) { ret 2; }
+    if (result_unwrap_ok(sr) != 5) { ret 3; }
 
     # read from position 5
     var buf: [10]u8;
-    val rr: Result[usize, str] = tf.file.read(?buf[0], 10);
-    if (rr.is_err()) { ret 4; }
-    if (rr.unwrap_ok() != 5) { ret 5; } # should read "56789"
+    val rr: Result[usize, str] = file_read(?tf.file, ?buf[0], 10);
+    if (result_is_err(rr)) { ret 4; }
+    if (result_unwrap_ok(rr) != 5) { ret 5; } # should read "56789"
 
     if (buf[0] != 53) { ret 6; } # '5'
     if (buf[4] != 57) { ret 7; } # '9'
 
-    tf.close_and_remove();
+    temp_file_close_and_remove(?tf);
     ret 1;
 }
 
 test "filesystem: unlink removes file" {
     val cr: Result[TempFile, str] = temp_create("unlink");
-    if (cr.is_err()) { ret 0; }
-    var tf: TempFile = cr.unwrap_ok();
-    val p: str = tf.path();
+    if (result_is_err(cr)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok(cr);
+    val p: str = temp_file_path(?tf);
 
-    tf.close();
+    file_close(?tf);
 
     # unlink the file
     val ur: Result[bool, str] = unlink(p);
-    if (ur.is_err()) { ret 2; }
+    if (result_is_err(ur)) { ret 2; }
 
     # try to open - should fail
     val open_res: Result[File, str] = open(p);
-    if (open_res.is_ok()) { ret 3; }
+    if (result_is_ok(open_res)) { ret 3; }
 
     ret 1;
 }

--- a/src/fmt.mach
+++ b/src/fmt.mach
@@ -27,7 +27,7 @@ pub fun write_bytes(w: *stream.Writer, buf: &u8, len: usize) Result[usize, str] 
 # ret: Ok(number of bytes written) on success or Err(str) on error.
 pub fun write_str(w: *stream.Writer, s: str) Result[usize, str] {
     if (s == nil) { ret ok[usize, str](0); }
-    ret stream.write_all(w, s, s.len());
+    ret stream.write_all(w, s, str_len(s));
 }
 
 # write_byte: write a single byte `b` to `w`.
@@ -94,13 +94,13 @@ pub fun write_i64(w: *stream.Writer, n: i64) Result[usize, str] {
     }
 
     val r1: Result[usize, str] = write_byte(w, 45); # '-'
-    if (r1.is_err()) { ret r1; }
+    if (result_is_err(r1)) { ret r1; }
 
     val pos: i64 = 0 - n;
     val r2: Result[usize, str] = write_u64(w, pos::u64);
-    if (r2.is_err()) { ret r2; }
+    if (result_is_err(r2)) { ret r2; }
 
-    ret ok[usize, str](r1.unwrap_ok() + r2.unwrap_ok());
+    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
 }
 
 # write_hex_u64: write a 64-bit value in hexadecimal.
@@ -148,12 +148,12 @@ pub fun write_hex_u64(w: *stream.Writer, n: u64, upper: bool) Result[usize, str]
 # ret: Ok(number of bytes written) on success or Err(str) on error.
 pub fun write_ptr(w: *stream.Writer, p: ptr) Result[usize, str] {
     val r1: Result[usize, str] = write_str(w, "0x");
-    if (r1.is_err()) { ret r1; }
+    if (result_is_err(r1)) { ret r1; }
 
     val r2: Result[usize, str] = write_hex_u64(w, p::usize::u64, false);
-    if (r2.is_err()) { ret r2; }
+    if (result_is_err(r2)) { ret r2; }
 
-    ret ok[usize, str](r1.unwrap_ok() + r2.unwrap_ok());
+    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
 }
 
 # ERR_BAD_FORMAT: returned when a format string is invalid.
@@ -179,8 +179,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         val b: u8 = format[i];
         if (b != 37) { # '%'
             val r: Result[usize, str] = write_byte(w, b);
-            if (r.is_err()) { ret r; }
-            total = total + r.unwrap_ok();
+            if (result_is_err(r)) { ret r; }
+            total = total + result_unwrap_ok(r);
             i = i + 1;
             cnt;
         }
@@ -194,8 +194,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
 
         if (c == 37) { # '%%'
             val r: Result[usize, str] = write_byte(w, 37);
-            if (r.is_err()) { ret r; }
-            total = total + r.unwrap_ok();
+            if (result_is_err(r)) { ret r; }
+            total = total + result_unwrap_ok(r);
             i = i + 1;
             cnt;
         }
@@ -203,8 +203,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 115) { # %s
             val arg: str = va_arg[str](ap);
             val r: Result[usize, str] = write_str(w, arg);
-            if (r.is_err()) { ret r; }
-            total = total + r.unwrap_ok();
+            if (result_is_err(r)) { ret r; }
+            total = total + result_unwrap_ok(r);
             i = i + 1;
             cnt;
         }
@@ -212,8 +212,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 100) { # %d
             val arg: i64 = va_arg[i64](ap);
             val r: Result[usize, str] = write_i64(w, arg);
-            if (r.is_err()) { ret r; }
-            total = total + r.unwrap_ok();
+            if (result_is_err(r)) { ret r; }
+            total = total + result_unwrap_ok(r);
             i = i + 1;
             cnt;
         }
@@ -221,8 +221,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 117) { # %u
             val arg: u64 = va_arg[u64](ap);
             val r: Result[usize, str] = write_u64(w, arg);
-            if (r.is_err()) { ret r; }
-            total = total + r.unwrap_ok();
+            if (result_is_err(r)) { ret r; }
+            total = total + result_unwrap_ok(r);
             i = i + 1;
             cnt;
         }
@@ -230,8 +230,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 120) { # %x
             val arg: u64 = va_arg[u64](ap);
             val r: Result[usize, str] = write_hex_u64(w, arg, false);
-            if (r.is_err()) { ret r; }
-            total = total + r.unwrap_ok();
+            if (result_is_err(r)) { ret r; }
+            total = total + result_unwrap_ok(r);
             i = i + 1;
             cnt;
         }
@@ -239,8 +239,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 88) { # %X
             val arg: u64 = va_arg[u64](ap);
             val r: Result[usize, str] = write_hex_u64(w, arg, true);
-            if (r.is_err()) { ret r; }
-            total = total + r.unwrap_ok();
+            if (result_is_err(r)) { ret r; }
+            total = total + result_unwrap_ok(r);
             i = i + 1;
             cnt;
         }
@@ -248,8 +248,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 99) { # %c
             val arg: u8 = va_arg[u8](ap);
             val r: Result[usize, str] = write_byte(w, arg);
-            if (r.is_err()) { ret r; }
-            total = total + r.unwrap_ok();
+            if (result_is_err(r)) { ret r; }
+            total = total + result_unwrap_ok(r);
             i = i + 1;
             cnt;
         }
@@ -257,8 +257,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 112) { # %p
             val arg: ptr = va_arg[ptr](ap);
             val r: Result[usize, str] = write_ptr(w, arg);
-            if (r.is_err()) { ret r; }
-            total = total + r.unwrap_ok();
+            if (result_is_err(r)) { ret r; }
+            total = total + result_unwrap_ok(r);
             i = i + 1;
             cnt;
         }

--- a/src/print.mach
+++ b/src/print.mach
@@ -27,12 +27,12 @@ pub fun println(s: str) Result[usize, str] {
     var w: stream.Writer = stdio.stdout();
 
     val r1: Result[usize, str] = f.write_str(?w, s);
-    if (r1.is_err()) { ret r1; }
+    if (result_is_err(r1)) { ret r1; }
 
     val r2: Result[usize, str] = f.write_newline(?w);
-    if (r2.is_err()) { ret r2; }
+    if (result_is_err(r2)) { ret r2; }
 
-    ret ok[usize, str](r1.unwrap_ok() + r2.unwrap_ok());
+    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
 }
 
 # eprint: write `s` to stderr.
@@ -52,12 +52,12 @@ pub fun eprintln(s: str) Result[usize, str] {
     var w: stream.Writer = stdio.stderr();
 
     val r1: Result[usize, str] = f.write_str(?w, s);
-    if (r1.is_err()) { ret r1; }
+    if (result_is_err(r1)) { ret r1; }
 
     val r2: Result[usize, str] = f.write_newline(?w);
-    if (r2.is_err()) { ret r2; }
+    if (result_is_err(r2)) { ret r2; }
 
-    ret ok[usize, str](r1.unwrap_ok() + r2.unwrap_ok());
+    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
 }
 
 # u64: write unsigned 64-bit integer n to stdout.
@@ -119,12 +119,12 @@ pub fun printlnf(format: str, ...) Result[usize, str] {
     va_start(?ap);
     val r1: Result[usize, str] = f.vformat(?w, format, ?ap);
     va_end(?ap);
-    if (r1.is_err()) { ret r1; }
+    if (result_is_err(r1)) { ret r1; }
 
     val r2: Result[usize, str] = f.write_newline(?w);
-    if (r2.is_err()) { ret r2; }
+    if (result_is_err(r2)) { ret r2; }
 
-    ret ok[usize, str](r1.unwrap_ok() + r2.unwrap_ok());
+    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
 }
 
 # eprintlnf: formatted output to stderr followed by a newline.
@@ -138,10 +138,10 @@ pub fun eprintlnf(format: str, ...) Result[usize, str] {
     va_start(?ap);
     val r1: Result[usize, str] = f.vformat(?w, format, ?ap);
     va_end(?ap);
-    if (r1.is_err()) { ret r1; }
+    if (result_is_err(r1)) { ret r1; }
 
     val r2: Result[usize, str] = f.write_newline(?w);
-    if (r2.is_err()) { ret r2; }
+    if (result_is_err(r2)) { ret r2; }
 
-    ret ok[usize, str](r1.unwrap_ok() + r2.unwrap_ok());
+    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
 }

--- a/src/stream.mach
+++ b/src/stream.mach
@@ -55,7 +55,7 @@ pub fun reader(fd: i32) Reader { ret Reader{fd: fd}; }
 # buf: buffer to write from
 # len: number of bytes to attempt to write
 # ret: Ok(wrote) on success or Err(str) with errno message on failure.
-pub fun (this: *Writer) write(buf: &u8, len: usize) Result[usize, str] {
+pub fun writer_write(this: *Writer, buf: &u8, len: usize) Result[usize, str] {
     var retries: usize = 0;
     var raw: i64 = 0;
     val w: Writer = @this;
@@ -79,7 +79,7 @@ pub fun (this: *Writer) write(buf: &u8, len: usize) Result[usize, str] {
 # buf: buffer to read into
 # len: maximum number of bytes to read
 # ret: Ok(got) with bytes read, or Err(str) with errno message on failure.
-pub fun (this: *Reader) read(buf: *u8, len: usize) Result[usize, str] {
+pub fun reader_read(this: *Reader, buf: *u8, len: usize) Result[usize, str] {
     var retries: usize = 0;
     var raw: i64 = 0;
     val r: Reader = @this;
@@ -109,10 +109,10 @@ pub fun write_all(w: *Writer, buf: &u8, len: usize) Result[usize, str] {
     var total: usize = 0;
     for (total < len) {
         val p: &u8 = (buf::usize + total)::&u8;
-        val r: Result[usize, str] = w.write(p, len - total);
-        if (r.is_err()) { ret r; }
+        val r: Result[usize, str] = writer_write(?w, p, len - total);
+        if (result_is_err(r)) { ret r; }
 
-        val wrote: usize = r.unwrap_ok();
+        val wrote: usize = result_unwrap_ok(r);
         if (wrote == 0) { ret err[usize, str](ERR_SHORT_WRITE); }
 
         total = total + wrote;
@@ -132,10 +132,10 @@ pub fun read_exact(r: *Reader, buf: *u8, len: usize) Result[usize, str] {
     var total: usize = 0;
     for (total < len) {
         val p: *u8 = (buf::usize + total)::*u8;
-        val res: Result[usize, str] = r.read(p, len - total);
-        if (res.is_err()) { ret res; }
+        val res: Result[usize, str] = reader_read(?r, p, len - total);
+        if (result_is_err(res)) { ret res; }
 
-        val got: usize = res.unwrap_ok();
+        val got: usize = result_unwrap_ok(res);
         if (got == 0) { ret err[usize, str](ERR_EOF); }
 
         total = total + got;

--- a/src/text/buffer_writer.mach
+++ b/src/text/buffer_writer.mach
@@ -37,7 +37,7 @@ pub fun buffer_writer(buf: *u8, cap: usize) BufferWriter {
 # data: bytes to write
 # len: number of bytes to write
 # ret: Ok(bytes written) or Err(ERR_BUFFER_FULL) if insufficient space
-pub fun (w: *BufferWriter) write(data: &u8, len: usize) Result[usize, str] {
+pub fun bw_write(w: *BufferWriter, data: &u8, len: usize) Result[usize, str] {
     if (w == nil || w.buf == nil) {
         ret err[usize, str]("nil writer");
     }
@@ -60,7 +60,7 @@ pub fun (w: *BufferWriter) write(data: &u8, len: usize) Result[usize, str] {
 # ---
 # b: byte to write
 # ret: Ok(1) or Err(ERR_BUFFER_FULL) if buffer is full
-pub fun (w: *BufferWriter) write_byte(b: u8) Result[usize, str] {
+pub fun bw_write_byte(w: *BufferWriter, b: u8) Result[usize, str] {
     if (w == nil || w.buf == nil) {
         ret err[usize, str]("nil writer");
     }
@@ -80,17 +80,17 @@ pub fun (w: *BufferWriter) write_byte(b: u8) Result[usize, str] {
 # ---
 # s: string to write
 # ret: Ok(bytes written) or Err(ERR_BUFFER_FULL) if insufficient space
-pub fun (w: *BufferWriter) write_str(s: str) Result[usize, str] {
+pub fun bw_write_str(w: *BufferWriter, s: str) Result[usize, str] {
     if (s == nil) {
         ret ok[usize, str](0);
     }
-    ret w.write(s, s.len());
+    ret bw_write(w, s, str_len(s));
 }
 
 # as_str: return the buffer contents as a string pointer.
 # ---
 # ret: pointer to buffer (may not be null-terminated)
-pub fun (w: *BufferWriter) as_str() str {
+pub fun bw_as_str(w: *BufferWriter) str {
     if (w == nil || w.buf == nil) {
         ret nil;
     }
@@ -100,7 +100,7 @@ pub fun (w: *BufferWriter) as_str() str {
 # length: return the number of bytes written.
 # ---
 # ret: bytes written
-pub fun (w: *BufferWriter) length() usize {
+pub fun bw_length(w: *BufferWriter) usize {
     if (w == nil) {
         ret 1;
     }
@@ -110,7 +110,7 @@ pub fun (w: *BufferWriter) length() usize {
 # remaining: return the number of bytes available.
 # ---
 # ret: bytes remaining
-pub fun (w: *BufferWriter) remaining() usize {
+pub fun bw_remaining(w: *BufferWriter) usize {
     if (w == nil) {
         ret 1;
     }
@@ -118,7 +118,7 @@ pub fun (w: *BufferWriter) remaining() usize {
 }
 
 # reset: clear the buffer (sets len to 0).
-pub fun (w: *BufferWriter) reset() {
+pub fun bw_reset(w: *BufferWriter) {
     if (w != nil) {
         w.len = 0;
     }
@@ -127,7 +127,7 @@ pub fun (w: *BufferWriter) reset() {
 # null_terminate: add null terminator if space available.
 # ---
 # ret: true if null terminator was added, false if buffer is full
-pub fun (w: *BufferWriter) null_terminate() bool {
+pub fun bw_null_terminate(w: *BufferWriter) bool {
     if (w == nil || w.buf == nil) {
         ret false;
     }
@@ -142,8 +142,8 @@ pub fun (w: *BufferWriter) null_terminate() bool {
 # c_str: null-terminate and return as string.
 # ---
 # ret: null-terminated string or nil if buffer is full
-pub fun (w: *BufferWriter) c_str() str {
-    if (!w.null_terminate()) {
+pub fun bw_c_str(w: *BufferWriter) str {
+    if (!bw_null_terminate(w)) {
         ret nil;
     }
     ret w.buf;
@@ -155,10 +155,10 @@ test "buffer_writer: basic write" {
     var buf: [64]u8;
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
-    val r: Result[usize, str] = w.write("hello", 5);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 5) { ret 2; }
-    if (w.length() != 5) { ret 3; }
+    val r: Result[usize, str] = bw_write(w, "hello", 5);
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 5) { ret 2; }
+    if (bw_length(w) != 5) { ret 3; }
     ret 1;
 }
 
@@ -166,12 +166,12 @@ test "buffer_writer: write_byte" {
     var buf: [64]u8;
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
-    val r1: Result[usize, str] = w.write_byte(65); # 'A'
-    val r2: Result[usize, str] = w.write_byte(66); # 'B'
+    val r1: Result[usize, str] = bw_write_byte(w, 65); # 'A'
+    val r2: Result[usize, str] = bw_write_byte(w, 66); # 'B'
 
-    if (r1.is_err()) { ret 0; }
-    if (r2.is_err()) { ret 2; }
-    if (w.length() != 2) { ret 3; }
+    if (result_is_err(r1)) { ret 0; }
+    if (result_is_err(r2)) { ret 2; }
+    if (bw_length(w) != 2) { ret 3; }
     if (buf[0] != 65) { ret 4; }
     if (buf[1] != 66) { ret 5; }
     ret 1;
@@ -181,10 +181,10 @@ test "buffer_writer: write_str" {
     var buf: [64]u8;
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
-    val r: Result[usize, str] = w.write_str("hello world");
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 11) { ret 2; }
-    if (w.length() != 11) { ret 3; }
+    val r: Result[usize, str] = bw_write_str(w, "hello world");
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 11) { ret 2; }
+    if (bw_length(w) != 11) { ret 3; }
     ret 1;
 }
 
@@ -192,13 +192,13 @@ test "buffer_writer: buffer full error" {
     var buf: [4]u8;
     var w: BufferWriter = buffer_writer(?buf[0], 4);
 
-    val r1: Result[usize, str] = w.write("ab", 2);
-    if (r1.is_err()) { ret 0; }
+    val r1: Result[usize, str] = bw_write(w, "ab", 2);
+    if (result_is_err(r1)) { ret 0; }
 
-    val r2: Result[usize, str] = w.write("cdef", 4);
-    if (r2.is_ok()) { ret 2; } # should fail
+    val r2: Result[usize, str] = bw_write(w, "cdef", 4);
+    if (result_is_ok(r2)) { ret 2; } # should fail
 
-    if (w.length() != 2) { ret 3; } # should still be 2
+    if (bw_length(w) != 2) { ret 3; } # should still be 2
     ret 1;
 }
 
@@ -206,12 +206,12 @@ test "buffer_writer: remaining" {
     var buf: [64]u8;
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
-    if (w.remaining() != 64) { ret 0; }
+    if (bw_remaining(w) != 64) { ret 0; }
 
-    val r: Result[usize, str] = w.write("hello", 5);
-    if (r.is_err()) { ret 2; }
+    val r: Result[usize, str] = bw_write(w, "hello", 5);
+    if (result_is_err(r)) { ret 2; }
 
-    if (w.remaining() != 59) { ret 3; }
+    if (bw_remaining(w) != 59) { ret 3; }
     ret 1;
 }
 
@@ -219,13 +219,13 @@ test "buffer_writer: reset" {
     var buf: [64]u8;
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
-    val r: Result[usize, str] = w.write("hello", 5);
-    if (r.is_err()) { ret 0; }
-    if (w.length() != 5) { ret 2; }
+    val r: Result[usize, str] = bw_write(w, "hello", 5);
+    if (result_is_err(r)) { ret 0; }
+    if (bw_length(w) != 5) { ret 2; }
 
-    w.reset();
-    if (w.length() != 0) { ret 3; }
-    if (w.remaining() != 64) { ret 4; }
+    bw_reset(w);
+    if (bw_length(w) != 0) { ret 3; }
+    if (bw_remaining(w) != 64) { ret 4; }
     ret 1;
 }
 
@@ -233,12 +233,12 @@ test "buffer_writer: c_str null terminates" {
     var buf: [64]u8;
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
-    val r: Result[usize, str] = w.write("test", 4);
-    if (r.is_err()) { ret 0; }
+    val r: Result[usize, str] = bw_write(w, "test", 4);
+    if (result_is_err(r)) { ret 0; }
 
-    val s: str = w.c_str();
+    val s: str = bw_c_str(w);
     if (s == nil) { ret 2; }
-    val s_len: usize = s.len();
+    val s_len: usize = str_len(s);
     if (s_len != 4) { ret 3; }
     if (buf[4] != 0) { ret 4; }
     ret 1;
@@ -249,10 +249,10 @@ test "buffer_writer: write nil string" {
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
     val s: str = nil;
-    val r: Result[usize, str] = w.write_str(s);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 0) { ret 2; }
-    if (w.length() != 0) { ret 3; }
+    val r: Result[usize, str] = bw_write_str(w, s);
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 0) { ret 2; }
+    if (bw_length(w) != 0) { ret 3; }
     ret 1;
 }
 
@@ -260,18 +260,18 @@ test "buffer_writer: multiple writes" {
     var buf: [64]u8;
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
-    val r1: Result[usize, str] = w.write_str("hello");
-    val r2: Result[usize, str] = w.write_str(" ");
-    val r3: Result[usize, str] = w.write_str("world");
+    val r1: Result[usize, str] = bw_write_str(w, "hello");
+    val r2: Result[usize, str] = bw_write_str(w, " ");
+    val r3: Result[usize, str] = bw_write_str(w, "world");
 
-    if (r1.is_err()) { ret 0; }
-    if (r2.is_err()) { ret 2; }
-    if (r3.is_err()) { ret 3; }
-    if (w.length() != 11) { ret 4; }
+    if (result_is_err(r1)) { ret 0; }
+    if (result_is_err(r2)) { ret 2; }
+    if (result_is_err(r3)) { ret 3; }
+    if (bw_length(w) != 11) { ret 4; }
 
-    val s: str = w.c_str();
+    val s: str = bw_c_str(w);
     if (s == nil) { ret 5; }
-    if (!s.equals("hello world")) { ret 6; }
+    if (!str_equals(s, "hello world")) { ret 6; }
     ret 1;
 }
 
@@ -279,12 +279,12 @@ test "buffer_writer: exact capacity" {
     var buf: [5]u8;
     var w: BufferWriter = buffer_writer(?buf[0], 5);
 
-    val r: Result[usize, str] = w.write("hello", 5);
-    if (r.is_err()) { ret 0; }
-    if (w.length() != 5) { ret 2; }
-    if (w.remaining() != 0) { ret 3; }
+    val r: Result[usize, str] = bw_write(w, "hello", 5);
+    if (result_is_err(r)) { ret 0; }
+    if (bw_length(w) != 5) { ret 2; }
+    if (bw_remaining(w) != 0) { ret 3; }
 
     # no room for null terminator
-    if (w.null_terminate()) { ret 4; }
+    if (bw_null_terminate(w)) { ret 4; }
     ret 1;
 }

--- a/src/text/builder.mach
+++ b/src/text/builder.mach
@@ -32,7 +32,7 @@ pub fun init(alloc: allocator.Allocator) Builder {
 # Free the builder's buffer and reset fields
 # ---
 # ret: true if memory was freed successfully, false otherwise
-pub fun (this: *Builder) deinit() bool {
+pub fun builder_deinit(this: *Builder) bool {
     if (this == nil) { ret true; }
     if (this.cap == 0) {
         this.buf = nil;
@@ -40,7 +40,7 @@ pub fun (this: *Builder) deinit() bool {
         ret true;
     }
 
-    val ok_free: bool = (?this.alloc).free[u8](this.buf, this.cap);
+    val ok_free: bool = (allocator.allocator_free[u8](?this.alloc), this.buf, this.cap);
     if (ok_free) {
         this.buf = nil;
         this.len = 0;
@@ -53,14 +53,14 @@ pub fun (this: *Builder) deinit() bool {
 # Return the current length of the builder (excludes NUL)
 # ---
 # ret: Length in bytes (usize)
-pub fun (this: Builder) length() usize {
+pub fun builder_length(this: Builder) usize {
     ret this.len;
 }
 
 # Return the usable capacity of the builder (excludes NUL)
 # ---
 # ret: Capacity in bytes (usize)
-pub fun (this: Builder) capacity() usize {
+pub fun builder_capacity(this: Builder) usize {
     if (this.cap == 0) { ret 0; }
     ret this.cap - 1;
 }
@@ -68,7 +68,7 @@ pub fun (this: Builder) capacity() usize {
 # Clear the builder contents and ensure a NUL terminator if allocated
 # ---
 # ret: None
-pub fun (this: *Builder) clear() {
+pub fun builder_clear(this: *Builder) {
     if (this == nil) { ret; }
     this.len = 0;
     if (this.cap != 0) { this.buf[0] = 0; }
@@ -78,7 +78,7 @@ pub fun (this: *Builder) clear() {
 # ---
 # additional: Number of bytes to reserve
 # ret: Ok(new capacity excluding NUL) or Err(error message)
-pub fun (this: *Builder) reserve(additional: usize) Result[usize, str] {
+pub fun builder_reserve(this: *Builder, additional: usize) Result[usize, str] {
     if (this == nil) { ret err[usize, str]("builder is nil"); }
 
     val need0: usize = this.len + additional;
@@ -107,10 +107,10 @@ pub fun (this: *Builder) reserve(additional: usize) Result[usize, str] {
         }
     }
 
-    val r: Result[*u8, allocator.AllocError] = (?this.alloc).resize[u8](this.buf, this.cap, new_cap);
-    if (r.is_err()) { ret err[usize, str](r.unwrap_err()); }
+    val r: Result[*u8, allocator.AllocError] = (allocator.allocator_resize[u8](?this.alloc), this.buf, this.cap, new_cap);
+    if (result_is_err(r)) { ret err[usize, str](result_unwrap_err(r)); }
 
-    this.buf = r.unwrap_ok();
+    this.buf = result_unwrap_ok(r);
     this.cap = new_cap;
     this.buf[this.len] = 0;
 
@@ -121,9 +121,9 @@ pub fun (this: *Builder) reserve(additional: usize) Result[usize, str] {
 # ---
 # b: Byte to append
 # ret: Ok(new length) or Err(error message)
-pub fun (this: *Builder) append_byte(b: u8) Result[usize, str] {
-    val r: Result[usize, str] = this.reserve(1);
-    if (r.is_err()) { ret err[usize, str](r.unwrap_err()); }
+pub fun builder_append_byte(this: *Builder, b: u8) Result[usize, str] {
+    val r: Result[usize, str] = builder_reserve(this, 1);
+    if (result_is_err(r)) { ret err[usize, str](result_unwrap_err(r)); }
 
     this.buf[this.len] = b;
     this.len = this.len + 1;
@@ -136,11 +136,11 @@ pub fun (this: *Builder) append_byte(b: u8) Result[usize, str] {
 # p: Source pointer to bytes
 # n: Number of bytes to append
 # ret: Ok(new length) or Err(error message)
-pub fun (this: *Builder) append_bytes(p: &u8, n: usize) Result[usize, str] {
+pub fun builder_append_bytes(this: *Builder, p: &u8, n: usize) Result[usize, str] {
     if (n == 0) { ret ok[usize, str](this.len); }
 
-    val r: Result[usize, str] = this.reserve(n);
-    if (r.is_err()) { ret err[usize, str](r.unwrap_err()); }
+    val r: Result[usize, str] = builder_reserve(this, n);
+    if (result_is_err(r)) { ret err[usize, str](result_unwrap_err(r)); }
 
     mem.raw_copy((this.buf::usize + this.len)::ptr, p::ptr, n);
     this.len = this.len + n;
@@ -152,14 +152,14 @@ pub fun (this: *Builder) append_bytes(p: &u8, n: usize) Result[usize, str] {
 # ---
 # s: Source string to append
 # ret: Ok(new length) or Err(error message)
-pub fun (this: *Builder) append_str(s: str) Result[usize, str] {
-    ret this.append_bytes(s, s.len());
+pub fun builder_append_str(this: *Builder, s: str) Result[usize, str] {
+    ret builder_append_bytes(this, s, str_len(s));
 }
 
 # Return a NUL-terminated C string backed by the builder
 # ---
 # ret: Ok(c-string) or Err(error message). If unallocated and empty returns Ok("").
-pub fun (this: *Builder) c_str() Result[str, str] {
+pub fun builder_c_str(this: *Builder) Result[str, str] {
     if (this.cap == 0) {
         if (this.len == 0) { ret ok[str, str](""); }
         ret err[str, str]("internal error");
@@ -174,8 +174,8 @@ pub fun (this: *Builder) c_str() Result[str, str] {
 test "builder: init creates empty builder" {
     var a: allocator.Allocator = allocator.page_allocator();
     val b: Builder = init(a);
-    if (b.length() != 0) { ret 0; }
-    if (b.capacity() != 0) { ret 0; }
+    if (builder_length(b) != 0) { ret 0; }
+    if (builder_capacity(b) != 0) { ret 0; }
     ret 1;
 }
 
@@ -183,11 +183,11 @@ test "builder: append_byte adds single byte" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    val r: Result[usize, str] = b.append_byte(65);
-    if (r.is_err()) { ret 0; }
-    if (b.length() != 1) { ret 0; }
+    val r: Result[usize, str] = builder_append_byte(?b, 65);
+    if (result_is_err(r)) { ret 0; }
+    if (builder_length(b) != 1) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -196,12 +196,12 @@ test "builder: append_byte multiple bytes" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    b.append_byte(72);
-    b.append_byte(105);
+    builder_append_byte(?b, 72);
+    builder_append_byte(?b, 105);
 
-    if (b.length() != 2) { ret 0; }
+    if (builder_length(b) != 2) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -210,11 +210,11 @@ test "builder: append_str adds string" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    val r: Result[usize, str] = b.append_str("hello");
-    if (r.is_err()) { ret 0; }
-    if (b.length() != 5) { ret 0; }
+    val r: Result[usize, str] = builder_append_str(?b, "hello");
+    if (result_is_err(r)) { ret 0; }
+    if (builder_length(b) != 5) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -223,14 +223,14 @@ test "builder: append_str empty string is noop" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    b.append_str("test");
-    val len_before: usize = b.length();
+    builder_append_str(?b, "test");
+    val len_before: usize = builder_length(b);
 
-    b.append_str("");
+    builder_append_str(?b, "");
 
-    if (b.length() != len_before) { ret 0; }
+    if (builder_length(b) != len_before) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -240,11 +240,11 @@ test "builder: append_bytes adds raw bytes" {
     var b: Builder = init(a);
 
     var data: [3]u8 = [3]u8{65, 66, 67};
-    val r: Result[usize, str] = b.append_bytes(?data[0], 3);
-    if (r.is_err()) { ret 0; }
-    if (b.length() != 3) { ret 0; }
+    val r: Result[usize, str] = builder_append_bytes(?b, ?data[0], 3);
+    if (result_is_err(r)) { ret 0; }
+    if (builder_length(b) != 3) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -253,15 +253,15 @@ test "builder: append_bytes with zero count is noop" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    b.append_str("test");
-    val len_before: usize = b.length();
+    builder_append_str(?b, "test");
+    val len_before: usize = builder_length(b);
 
     var data: [3]u8 = [3]u8{1, 2, 3};
-    b.append_bytes(?data[0], 0);
+    builder_append_bytes(?b, ?data[0], 0);
 
-    if (b.length() != len_before) { ret 0; }
+    if (builder_length(b) != len_before) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -270,15 +270,15 @@ test "builder: c_str returns null-terminated string" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    b.append_str("hello");
+    builder_append_str(?b, "hello");
 
-    val r: Result[str, str] = b.c_str();
-    if (r.is_err()) { ret 0; }
-    val s: str = r.unwrap_ok();
-    if (!s.equals("hello")) { ret 0; }
-    if (s.len() != 5) { ret 0; }
+    val r: Result[str, str] = builder_c_str(?b);
+    if (result_is_err(r)) { ret 0; }
+    val s: str = result_unwrap_ok(r);
+    if (!str_equals(s, "hello")) { ret 0; }
+    if (str_len(s) != 5) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -287,12 +287,12 @@ test "builder: c_str on empty builder returns empty string" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    val r: Result[str, str] = b.c_str();
-    if (r.is_err()) { ret 0; }
-    val s: str = r.unwrap_ok();
-    if (s.len() != 0) { ret 0; }
+    val r: Result[str, str] = builder_c_str(?b);
+    if (result_is_err(r)) { ret 0; }
+    val s: str = result_unwrap_ok(r);
+    if (str_len(s) != 0) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -301,12 +301,12 @@ test "builder: reserve increases capacity" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    val r: Result[usize, str] = b.reserve(100);
-    if (r.is_err()) { ret 0; }
-    if (b.capacity() < 100) { ret 0; }
-    if (b.length() != 0) { ret 0; }
+    val r: Result[usize, str] = builder_reserve(?b, 100);
+    if (result_is_err(r)) { ret 0; }
+    if (builder_capacity(b) < 100) { ret 0; }
+    if (builder_length(b) != 0) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -315,15 +315,15 @@ test "builder: reserve when sufficient is noop" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    b.reserve(50);
-    val cap1: usize = b.capacity();
+    builder_reserve(?b, 50);
+    val cap1: usize = builder_capacity(b);
 
-    b.reserve(10);
-    val cap2: usize = b.capacity();
+    builder_reserve(?b, 10);
+    val cap2: usize = builder_capacity(b);
 
     if (cap2 != cap1) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -332,15 +332,15 @@ test "builder: clear resets length but keeps capacity" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    b.append_str("hello world");
-    val cap_before: usize = b.capacity();
+    builder_append_str(?b, "hello world");
+    val cap_before: usize = builder_capacity(b);
 
-    b.clear();
+    builder_clear(?b);
 
-    if (b.length() != 0) { ret 0; }
-    if (b.capacity() != cap_before) { ret 0; }
+    if (builder_length(b) != 0) { ret 0; }
+    if (builder_capacity(b) != cap_before) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -349,15 +349,15 @@ test "builder: clear then append reuses buffer" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    b.append_str("first");
-    b.clear();
-    b.append_str("second");
+    builder_append_str(?b, "first");
+    builder_clear(?b);
+    builder_append_str(?b, "second");
 
-    val r: Result[str, str] = b.c_str();
-    if (r.is_err()) { ret 0; }
-    if (!r.unwrap_ok().equals("second")) { ret 0; }
+    val r: Result[str, str] = builder_c_str(?b);
+    if (result_is_err(r)) { ret 0; }
+    if (!result_unwrap_ok(str_equals(r), "second")) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -365,7 +365,7 @@ test "builder: clear then append reuses buffer" {
 test "builder: deinit on empty builder succeeds" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -374,17 +374,17 @@ test "builder: multiple appends build string" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
 
-    b.append_str("hello");
-    b.append_byte(32);
-    b.append_str("world");
+    builder_append_str(?b, "hello");
+    builder_append_byte(?b, 32);
+    builder_append_str(?b, "world");
 
-    val r: Result[str, str] = b.c_str();
-    if (r.is_err()) { ret 0; }
-    val s: str = r.unwrap_ok();
-    if (!s.equals("hello world")) { ret 0; }
-    if (s.len() != 11) { ret 0; }
+    val r: Result[str, str] = builder_c_str(?b);
+    if (result_is_err(r)) { ret 0; }
+    val s: str = result_unwrap_ok(r);
+    if (!str_equals(s, "hello world")) { ret 0; }
+    if (str_len(s) != 11) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -396,14 +396,14 @@ test "builder: capacity grows on append" {
     # append enough to trigger multiple capacity growths
     var i: i64 = 0;
     for (i < 50) {
-        b.append_str("test");
+        builder_append_str(?b, "test");
         i = i + 1;
     }
 
-    if (b.length() != 200) { ret 0; }
-    if (b.capacity() < 200) { ret 0; }
+    if (builder_length(b) != 200) { ret 0; }
+    if (builder_capacity(b) < 200) { ret 0; }
 
-    val ok: bool = b.deinit();
+    val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }

--- a/src/text/parse.mach
+++ b/src/text/parse.mach
@@ -15,7 +15,7 @@ use int: std.types.int;
 # base: numeric base (2-36), or 0 for auto-detect (0x, 0b, 0o prefixes)
 # ret: Result containing the parsed value or an error message
 pub fun parse_u64(s: str, base: u8) Result[u64, str] {
-    val len: usize = s.len();
+    val len: usize = str_len(s);
     if (len == 0) {
         ret err[u64, str]("empty string");
     }
@@ -123,7 +123,7 @@ pub fun parse_u64(s: str, base: u8) Result[u64, str] {
 # base: numeric base (2-36), or 0 for auto-detect (0x, 0b, 0o prefixes)
 # ret: Result containing the parsed value or an error message
 pub fun parse_i64(s: str, base: u8) Result[i64, str] {
-    val len: usize = s.len();
+    val len: usize = str_len(s);
     if (len == 0) {
         ret err[i64, str]("empty string");
     }
@@ -157,11 +157,11 @@ pub fun parse_i64(s: str, base: u8) Result[i64, str] {
     val remaining: str = (?s[i])::str;
     val u_result: Result[u64, str] = parse_u64(remaining, base);
 
-    if (u_result.is_err()) {
-        ret err[i64, str](u_result.unwrap_err());
+    if (result_is_err(u_result)) {
+        ret err[i64, str](result_unwrap_err(u_result));
     }
 
-    val u_val: u64 = u_result.unwrap_ok();
+    val u_val: u64 = result_unwrap_ok(u_result);
 
     # i64 range: -9223372036854775808 to 9223372036854775807
     if (negative) {
@@ -188,193 +188,193 @@ pub fun parse_i64(s: str, base: u8) Result[i64, str] {
 
 test "parse: u64 decimal simple" {
     val r: Result[u64, str] = parse_u64("12345", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 12345) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 12345) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 decimal zero" {
     val r: Result[u64, str] = parse_u64("0", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 0) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 0) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 hex lowercase" {
     val r: Result[u64, str] = parse_u64("ff", 16);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 255) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 255) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 hex uppercase" {
     val r: Result[u64, str] = parse_u64("FF", 16);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 255) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 255) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 binary" {
     val r: Result[u64, str] = parse_u64("1010", 2);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 10) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 10) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 octal" {
     val r: Result[u64, str] = parse_u64("77", 8);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 63) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 63) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 auto-detect hex" {
     val r: Result[u64, str] = parse_u64("0xff", 0);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 255) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 255) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 auto-detect binary" {
     val r: Result[u64, str] = parse_u64("0b1010", 0);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 10) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 10) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 auto-detect octal" {
     val r: Result[u64, str] = parse_u64("0o77", 0);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 63) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 63) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 auto-detect decimal" {
     val r: Result[u64, str] = parse_u64("999", 0);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 999) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 999) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 with underscores" {
     val r: Result[u64, str] = parse_u64("1_000_000", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 1000000) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 1000000) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 max value" {
     val r: Result[u64, str] = parse_u64("18446744073709551615", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 18446744073709551615) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 18446744073709551615) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 overflow" {
     val r: Result[u64, str] = parse_u64("18446744073709551616", 10);
-    if (r.is_ok()) { ret 0; }
+    if (result_is_ok(r)) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 empty string" {
     val r: Result[u64, str] = parse_u64("", 10);
-    if (r.is_ok()) { ret 0; }
+    if (result_is_ok(r)) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 invalid digit" {
     val r: Result[u64, str] = parse_u64("12g45", 10);
     # should parse up to 'g' and return 12
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 12) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 12) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 leading whitespace" {
     val r: Result[u64, str] = parse_u64("  42", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 42) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 42) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 positive" {
     val r: Result[i64, str] = parse_i64("12345", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 12345) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 12345) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 negative" {
     val r: Result[i64, str] = parse_i64("-12345", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != -12345) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != -12345) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 explicit positive" {
     val r: Result[i64, str] = parse_i64("+42", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 42) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 42) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 zero" {
     val r: Result[i64, str] = parse_i64("0", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 0) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 0) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 negative zero" {
     val r: Result[i64, str] = parse_i64("-0", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 0) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 0) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 max value" {
     val r: Result[i64, str] = parse_i64("9223372036854775807", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 9223372036854775807) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 9223372036854775807) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 min value" {
     val r: Result[i64, str] = parse_i64("-9223372036854775808", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != -9223372036854775808) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != -9223372036854775808) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 overflow positive" {
     val r: Result[i64, str] = parse_i64("9223372036854775808", 10);
-    if (r.is_ok()) { ret 0; }
+    if (result_is_ok(r)) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 overflow negative" {
     val r: Result[i64, str] = parse_i64("-9223372036854775809", 10);
-    if (r.is_ok()) { ret 0; }
+    if (result_is_ok(r)) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 hex with sign" {
     val r: Result[i64, str] = parse_i64("-0xff", 0);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != -255) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != -255) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 with underscores" {
     val r: Result[i64, str] = parse_i64("-1_000_000", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != -1000000) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != -1000000) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 leading whitespace" {
     val r: Result[i64, str] = parse_i64("  -42", 10);
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != -42) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != -42) { ret 0; }
     ret 1;
 }

--- a/src/time.mach
+++ b/src/time.mach
@@ -93,36 +93,36 @@ pub fun since(t: Time) Duration {
 # until: returns the duration until t.
 # ---
 # t: target time
-# ret: Duration until t (equivalent to t.sub(now()))
+# ret: Duration until t (equivalent to time_sub(t, now()))
 pub fun until(t: Time) Duration {
-    ret t.sub(now());
+    ret time_sub(t, now());
 }
 
 # unix_sec: returns seconds since Unix epoch.
 # ---
 # ret: seconds component
-pub fun (t: Time) unix_sec() i64 {
+pub fun time_unix_sec(t: Time) i64 {
     ret t.sec;
 }
 
 # unix_nano: returns nanoseconds since Unix epoch.
 # ---
 # ret: total nanoseconds since epoch
-pub fun (t: Time) unix_nano() i64 {
+pub fun time_unix_nano(t: Time) i64 {
     ret t.sec * 1000000000 + t.nsec;
 }
 
 # unix_milli: returns milliseconds since Unix epoch.
 # ---
 # ret: total milliseconds since epoch
-pub fun (t: Time) unix_milli() i64 {
+pub fun time_unix_milli(t: Time) i64 {
     ret t.sec * 1000 + t.nsec / 1000000;
 }
 
 # unix_micro: returns microseconds since Unix epoch.
 # ---
 # ret: total microseconds since epoch
-pub fun (t: Time) unix_micro() i64 {
+pub fun time_unix_micro(t: Time) i64 {
     ret t.sec * 1000000 + t.nsec / 1000;
 }
 
@@ -130,7 +130,7 @@ pub fun (t: Time) unix_micro() i64 {
 # ---
 # d: duration to add
 # ret: new Time offset by d
-pub fun (t: Time) add(d: Duration) Time {
+pub fun time_add(t: Time, d: Duration) Time {
     var sec: i64 = t.sec + d / 1000000000;
     var nsec: i64 = t.nsec + d % 1000000000;
 
@@ -150,7 +150,7 @@ pub fun (t: Time) add(d: Duration) Time {
 # ---
 # u: time to subtract
 # ret: Duration between t and u
-pub fun (t: Time) sub(u: Time) Duration {
+pub fun time_sub(t: Time, u: Time) Duration {
     val sec_diff: i64 = t.sec - u.sec;
     val nsec_diff: i64 = t.nsec - u.nsec;
     ret sec_diff * 1000000000 + nsec_diff;
@@ -160,7 +160,7 @@ pub fun (t: Time) sub(u: Time) Duration {
 # ---
 # u: time to compare against
 # ret: true if t < u
-pub fun (t: Time) before(u: Time) bool {
+pub fun time_before(t: Time, u: Time) bool {
     if (t.sec < u.sec) { ret true; }
     if (t.sec > u.sec) { ret false; }
     ret t.nsec < u.nsec;
@@ -170,7 +170,7 @@ pub fun (t: Time) before(u: Time) bool {
 # ---
 # u: time to compare against
 # ret: true if t > u
-pub fun (t: Time) after(u: Time) bool {
+pub fun time_after(t: Time, u: Time) bool {
     if (t.sec > u.sec) { ret true; }
     if (t.sec < u.sec) { ret false; }
     ret t.nsec > u.nsec;
@@ -180,63 +180,63 @@ pub fun (t: Time) after(u: Time) bool {
 # ---
 # u: time to compare against
 # ret: true if t == u
-pub fun (t: Time) equal(u: Time) bool {
+pub fun time_equal(t: Time, u: Time) bool {
     ret t.sec == u.sec && t.nsec == u.nsec;
 }
 
 # is_zero: reports whether t represents the zero time instant.
 # ---
 # ret: true if t is zero time (Unix epoch)
-pub fun (t: Time) is_zero() bool {
+pub fun time_is_zero(t: Time) bool {
     ret t.sec == 0 && t.nsec == 0;
 }
 
 # nanoseconds: returns the duration as nanoseconds.
 # ---
 # ret: duration in nanoseconds
-pub fun (d: Duration) nanoseconds() i64 {
+pub fun duration_nanoseconds(d: Duration) i64 {
     ret d;
 }
 
 # microseconds: returns the duration as microseconds.
 # ---
 # ret: duration in microseconds
-pub fun (d: Duration) microseconds() i64 {
+pub fun duration_microseconds(d: Duration) i64 {
     ret d / 1000;
 }
 
 # milliseconds: returns the duration as milliseconds.
 # ---
 # ret: duration in milliseconds
-pub fun (d: Duration) milliseconds() i64 {
+pub fun duration_milliseconds(d: Duration) i64 {
     ret d / 1000000;
 }
 
 # seconds: returns the duration as whole seconds.
 # ---
 # ret: duration in seconds
-pub fun (d: Duration) seconds() i64 {
+pub fun duration_seconds(d: Duration) i64 {
     ret d / 1000000000;
 }
 
 # minutes: returns the duration as whole minutes.
 # ---
 # ret: duration in minutes
-pub fun (d: Duration) minutes() i64 {
+pub fun duration_minutes(d: Duration) i64 {
     ret d / 60000000000;
 }
 
 # hours: returns the duration as whole hours.
 # ---
 # ret: duration in hours
-pub fun (d: Duration) hours() i64 {
+pub fun duration_hours(d: Duration) i64 {
     ret d / 3600000000000;
 }
 
 # abs: returns the absolute value of d.
 # ---
 # ret: |d|
-pub fun (d: Duration) abs() Duration {
+pub fun duration_abs(d: Duration) Duration {
     if (d < 0) {
         ret 0 - d;
     }
@@ -275,7 +275,7 @@ test "time: unix normalizes negative nsec" {
 
 test "time: add positive duration" {
     val t: Time = unix(100, 0);
-    val t2: Time = t.add(5 * SECOND);
+    val t2: Time = time_add(t, 5 * SECOND);
     if (t2.sec != 105) { ret 0; }
     if (t2.nsec != 0) { ret 2; }
     ret 1;
@@ -283,7 +283,7 @@ test "time: add positive duration" {
 
 test "time: add duration with nsec overflow" {
     val t: Time = unix(100, 800000000);
-    val t2: Time = t.add(500 * MILLISECOND);
+    val t2: Time = time_add(t, 500 * MILLISECOND);
     if (t2.sec != 101) { ret 0; }
     if (t2.nsec != 300000000) { ret 2; }
     ret 1;
@@ -291,7 +291,7 @@ test "time: add duration with nsec overflow" {
 
 test "time: add negative duration" {
     val t: Time = unix(100, 0);
-    val t2: Time = t.add(0 - 5 * SECOND);
+    val t2: Time = time_add(t, 0 - 5 * SECOND);
     if (t2.sec != 95) { ret 0; }
     ret 1;
 }
@@ -341,33 +341,33 @@ test "time: is_zero" {
 
 test "time: unix_nano" {
     val t: Time = unix(1, 500000000);
-    val ns: i64 = t.unix_nano();
+    val ns: i64 = time_unix_nano(t);
     if (ns != 1500000000) { ret 0; }
     ret 1;
 }
 
 test "time: unix_milli" {
     val t: Time = unix(1, 500000000);
-    val ms: i64 = t.unix_milli();
+    val ms: i64 = time_unix_milli(t);
     if (ms != 1500) { ret 0; }
     ret 1;
 }
 
 test "time: unix_micro" {
     val t: Time = unix(1, 500000000);
-    val us: i64 = t.unix_micro();
+    val us: i64 = time_unix_micro(t);
     if (us != 1500000) { ret 0; }
     ret 1;
 }
 
 test "time: duration conversions" {
     val d: Duration = 3661001001001; # 1h 1m 1s 1ms 1us 1ns
-    if (d.hours() != 1) { ret 0; }
-    if (d.minutes() != 61) { ret 2; }
-    if (d.seconds() != 3661) { ret 3; }
-    if (d.milliseconds() != 3661001) { ret 4; }
-    if (d.microseconds() != 3661001001) { ret 5; }
-    if (d.nanoseconds() != 3661001001001) { ret 6; }
+    if (duration_hours(d) != 1) { ret 0; }
+    if (duration_minutes(d) != 61) { ret 2; }
+    if (duration_seconds(d) != 3661) { ret 3; }
+    if (duration_milliseconds(d) != 3661001) { ret 4; }
+    if (duration_microseconds(d) != 3661001001) { ret 5; }
+    if (duration_nanoseconds(d) != 3661001001001) { ret 6; }
     ret 1;
 }
 

--- a/src/types/option.mach
+++ b/src/types/option.mach
@@ -9,21 +9,21 @@ pub rec Option[T] {
 # Unwraps the Option[T], returning the contained value.
 # ---
 # ret: The contained value.
-pub fun (this: Option[T]) unwrap() T {
+pub fun option_unwrap(this: Option[T]) T {
     ret this.value;
 }
 
 # Checks if the Option[T] is none (no value present).
 # ---
 # ret: true if no value is present, false otherwise.
-pub fun (this: Option[T]) is_none() bool {
+pub fun option_is_none(this: Option[T]) bool {
     ret this.has_value == false;
 }
 
 # Checks if the Option[T] is some (value is present).
 # ---
 # ret: true if a value is present, false otherwise.
-pub fun (this: Option[T]) is_some() bool {
+pub fun option_is_some(this: Option[T]) bool {
     ret this.has_value == true;
 }
 
@@ -51,70 +51,70 @@ pub fun none[T]() Option[T] {
 
 test "option: some creates value with is_some true" {
     val opt: Option[i64] = some[i64](42);
-    if (!opt.is_some()) { ret 0; }
+    if (!option_is_some(opt)) { ret 0; }
     ret 1;
 }
 
 test "option: some creates value with is_none false" {
     val opt: Option[i64] = some[i64](42);
-    if (opt.is_none()) { ret 0; }
+    if (option_is_none(opt)) { ret 0; }
     ret 1;
 }
 
 test "option: none creates value with is_none true" {
     val opt: Option[i64] = none[i64]();
-    if (!opt.is_none()) { ret 0; }
+    if (!option_is_none(opt)) { ret 0; }
     ret 1;
 }
 
 test "option: none creates value with is_some false" {
     val opt: Option[i64] = none[i64]();
-    if (opt.is_some()) { ret 0; }
+    if (option_is_some(opt)) { ret 0; }
     ret 1;
 }
 
 test "option: unwrap returns contained value" {
     val opt: Option[i64] = some[i64](123);
-    val v: i64 = opt.unwrap();
+    val v: i64 = option_unwrap(opt);
     if (v != 123) { ret 0; }
     ret 1;
 }
 
 test "option: some with zero value" {
     val opt: Option[i64] = some[i64](0);
-    if (!opt.is_some()) { ret 0; }
-    if (opt.unwrap() != 0) { ret 0; }
+    if (!option_is_some(opt)) { ret 0; }
+    if (option_unwrap(opt) != 0) { ret 0; }
     ret 1;
 }
 
 test "option: some with negative value" {
     val opt: Option[i64] = some[i64](-999);
-    if (!opt.is_some()) { ret 0; }
-    if (opt.unwrap() != -999) { ret 0; }
+    if (!option_is_some(opt)) { ret 0; }
+    if (option_unwrap(opt) != -999) { ret 0; }
     ret 1;
 }
 
 test "option: some with pointer type" {
     var x: i64 = 42;
     val opt: Option[*i64] = some[*i64](?x);
-    if (!opt.is_some()) { ret 0; }
-    val p: *i64 = opt.unwrap();
+    if (!option_is_some(opt)) { ret 0; }
+    val p: *i64 = option_unwrap(opt);
     if (@p != 42) { ret 0; }
     ret 1;
 }
 
 test "option: none with pointer type" {
     val opt: Option[*i64] = none[*i64]();
-    if (!opt.is_none()) { ret 0; }
+    if (!option_is_none(opt)) { ret 0; }
     ret 1;
 }
 
 test "option: some with bool type" {
     val opt_true: Option[bool] = some[bool](true);
     val opt_false: Option[bool] = some[bool](false);
-    if (!opt_true.is_some()) { ret 0; }
-    if (!opt_false.is_some()) { ret 0; }
-    if (opt_true.unwrap() != true) { ret 0; }
-    if (opt_false.unwrap() != false) { ret 0; }
+    if (!option_is_some(opt_true)) { ret 0; }
+    if (!option_is_some(opt_false)) { ret 0; }
+    if (option_unwrap(opt_true) != true) { ret 0; }
+    if (option_unwrap(opt_false) != false) { ret 0; }
     ret 1;
 }

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -57,13 +57,13 @@ pub fun clone(a: *Allocator, p: Path) Result[Path, AllocError] {
         ret ok[Path, AllocError](nil);
     }
 
-    val n: usize = p.len();
-    val r: Result[*u8, AllocError] = a.alloc[u8](n + 1);
-    if (r.is_err()) {
-        ret err[Path, AllocError](r.unwrap_err());
+    val n: usize = str_len(p);
+    val r: Result[*u8, AllocError] = allocator_alloc[u8](a, n + 1);
+    if (result_is_err(r)) {
+        ret err[Path, AllocError](result_unwrap_err(r));
     }
 
-    val buf: *u8 = r.unwrap_ok();
+    val buf: *u8 = result_unwrap_ok(r);
     mem.raw_copy(buf::ptr, p::ptr, n);
     buf[n] = 0;
     ret ok[Path, AllocError](buf::&u8);
@@ -90,8 +90,8 @@ pub fun join(a: *Allocator, left: Path, right: Path) Result[Path, AllocError] {
 
     val sep: u8 = separator();
 
-    val left_len: usize = left.len();
-    val right_len: usize = right.len();
+    val left_len: usize = str_len(left);
+    val right_len: usize = str_len(right);
 
     val left_has_sep: bool = left[left_len - 1] == sep;
     val right_has_sep: bool = right[0] == sep;
@@ -107,12 +107,12 @@ pub fun join(a: *Allocator, left: Path, right: Path) Result[Path, AllocError] {
     }
 
     val out_len: usize = left_len + right_len + extra;
-    val r: Result[*u8, AllocError] = a.alloc[u8](out_len + 1);
-    if (r.is_err()) {
-        ret err[Path, AllocError](r.unwrap_err());
+    val r: Result[*u8, AllocError] = allocator_alloc[u8](a, out_len + 1);
+    if (result_is_err(r)) {
+        ret err[Path, AllocError](result_unwrap_err(r));
     }
 
-    val buf: *u8 = r.unwrap_ok();
+    val buf: *u8 = result_unwrap_ok(r);
     mem.raw_copy(buf::ptr, left::ptr, left_len);
 
     var off: usize = left_len;
@@ -143,7 +143,7 @@ pub fun parent(a: *Allocator, p: Path) Result[Path, AllocError] {
         ret clone(a, ".");
     }
 
-    val len: usize = p.len();
+    val len: usize = str_len(p);
     val sep: u8 = separator();
 
     # skip trailing separators
@@ -154,11 +154,11 @@ pub fun parent(a: *Allocator, p: Path) Result[Path, AllocError] {
 
     if (end == 0) {
         # path was all separators (root)
-        val r: Result[*u8, AllocError] = a.alloc[u8](2);
-        if (r.is_err()) {
-            ret err[Path, AllocError](r.unwrap_err());
+        val r: Result[*u8, AllocError] = allocator_alloc[u8](a, 2);
+        if (result_is_err(r)) {
+            ret err[Path, AllocError](result_unwrap_err(r));
         }
-        val buf: *u8 = r.unwrap_ok();
+        val buf: *u8 = result_unwrap_ok(r);
         buf[0] = sep;
         buf[1] = 0;
         ret ok[Path, AllocError](buf::&u8);
@@ -180,11 +180,11 @@ pub fun parent(a: *Allocator, p: Path) Result[Path, AllocError] {
 
     if (i == 0 && p[0] == sep) {
         # separator at start only, parent is root
-        val r: Result[*u8, AllocError] = a.alloc[u8](2);
-        if (r.is_err()) {
-            ret err[Path, AllocError](r.unwrap_err());
+        val r: Result[*u8, AllocError] = allocator_alloc[u8](a, 2);
+        if (result_is_err(r)) {
+            ret err[Path, AllocError](result_unwrap_err(r));
         }
-        val buf: *u8 = r.unwrap_ok();
+        val buf: *u8 = result_unwrap_ok(r);
         buf[0] = sep;
         buf[1] = 0;
         ret ok[Path, AllocError](buf::&u8);
@@ -198,22 +198,22 @@ pub fun parent(a: *Allocator, p: Path) Result[Path, AllocError] {
 
     if (parent_end == 0) {
         # parent is root
-        val r: Result[*u8, AllocError] = a.alloc[u8](2);
-        if (r.is_err()) {
-            ret err[Path, AllocError](r.unwrap_err());
+        val r: Result[*u8, AllocError] = allocator_alloc[u8](a, 2);
+        if (result_is_err(r)) {
+            ret err[Path, AllocError](result_unwrap_err(r));
         }
-        val buf: *u8 = r.unwrap_ok();
+        val buf: *u8 = result_unwrap_ok(r);
         buf[0] = sep;
         buf[1] = 0;
         ret ok[Path, AllocError](buf::&u8);
     }
 
     # allocate and copy parent portion
-    val r: Result[*u8, AllocError] = a.alloc[u8](parent_end + 1);
-    if (r.is_err()) {
-        ret err[Path, AllocError](r.unwrap_err());
+    val r: Result[*u8, AllocError] = allocator_alloc[u8](a, parent_end + 1);
+    if (result_is_err(r)) {
+        ret err[Path, AllocError](result_unwrap_err(r));
     }
-    val buf: *u8 = r.unwrap_ok();
+    val buf: *u8 = result_unwrap_ok(r);
     mem.raw_copy(buf::ptr, p::ptr, parent_end);
     buf[parent_end] = 0;
 
@@ -230,7 +230,7 @@ pub fun is_root(p: Path) bool {
     }
 
     val sep: u8 = separator();
-    val len: usize = p.len();
+    val len: usize = str_len(p);
 
     # check if path is just the separator (or multiple separators)
     var i: usize = 0;

--- a/src/types/result.mach
+++ b/src/types/result.mach
@@ -13,28 +13,28 @@ pub rec Result[T, E] {
 # Checks if the Result[T, E] is ok (success).
 # ---
 # ret: true if the result is ok, false otherwise.
-pub fun (this: Result[T, E]) is_ok() bool {
+pub fun result_is_ok(this: Result[T, E]) bool {
     ret this.tag;
 }
 
 # Checks if the Result[T, E] is err (error).
 # ---
 # ret: true if the result is an error, false otherwise.
-pub fun (this: Result[T, E]) is_err() bool {
+pub fun result_is_err(this: Result[T, E]) bool {
     ret !this.tag;
 }
 
 # Unwraps the Result[T, E], returning the contained ok value.
 # ---
 # ret: The contained ok value if the result is ok; behavior is undefined otherwise.
-pub fun (this: Result[T, E]) unwrap_ok() T {
+pub fun result_unwrap_ok(this: Result[T, E]) T {
     ret this.value.ok;
 }
 
 # Unwraps the Result[T, E], returning the contained err value.
 # ---
 # ret: The contained err value if the result is an error; behavior is undefined otherwise.
-pub fun (this: Result[T, E]) unwrap_err() E {
+pub fun result_unwrap_err(this: Result[T, E]) E {
     ret this.value.err;
 }
 
@@ -64,87 +64,87 @@ pub fun err[T, E](value: E) Result[T, E] {
 
 test "result: ok creates value with is_ok true" {
     val r: Result[i64, i32] = ok[i64, i32](42);
-    if (!r.is_ok()) { ret 0; }
+    if (!result_is_ok(r)) { ret 0; }
     ret 1;
 }
 
 test "result: ok creates value with is_err false" {
     val r: Result[i64, i32] = ok[i64, i32](42);
-    if (r.is_err()) { ret 0; }
+    if (result_is_err(r)) { ret 0; }
     ret 1;
 }
 
 test "result: err creates value with is_err true" {
     val r: Result[i64, i32] = err[i64, i32](-1);
-    if (!r.is_err()) { ret 0; }
+    if (!result_is_err(r)) { ret 0; }
     ret 1;
 }
 
 test "result: err creates value with is_ok false" {
     val r: Result[i64, i32] = err[i64, i32](-1);
-    if (r.is_ok()) { ret 0; }
+    if (result_is_ok(r)) { ret 0; }
     ret 1;
 }
 
 test "result: unwrap_ok returns contained ok value" {
     val r: Result[i64, i32] = ok[i64, i32](123);
-    val v: i64 = r.unwrap_ok();
+    val v: i64 = result_unwrap_ok(r);
     if (v != 123) { ret 0; }
     ret 1;
 }
 
 test "result: unwrap_err returns contained err value" {
     val r: Result[i64, i32] = err[i64, i32](-99);
-    val e: i32 = r.unwrap_err();
+    val e: i32 = result_unwrap_err(r);
     if (e != -99) { ret 0; }
     ret 1;
 }
 
 test "result: ok with zero value" {
     val r: Result[i64, i32] = ok[i64, i32](0);
-    if (!r.is_ok()) { ret 0; }
-    if (r.unwrap_ok() != 0) { ret 0; }
+    if (!result_is_ok(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 0) { ret 0; }
     ret 1;
 }
 
 test "result: ok with negative value" {
     val r: Result[i64, i32] = ok[i64, i32](-999);
-    if (!r.is_ok()) { ret 0; }
-    if (r.unwrap_ok() != -999) { ret 0; }
+    if (!result_is_ok(r)) { ret 0; }
+    if (result_unwrap_ok(r) != -999) { ret 0; }
     ret 1;
 }
 
 test "result: ok with pointer type" {
     var x: i64 = 42;
     val r: Result[*i64, i32] = ok[*i64, i32](?x);
-    if (!r.is_ok()) { ret 0; }
-    val p: *i64 = r.unwrap_ok();
+    if (!result_is_ok(r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok(r);
     if (@p != 42) { ret 0; }
     ret 1;
 }
 
 test "result: err with pointer type" {
     val r: Result[*i64, i32] = err[*i64, i32](-1);
-    if (!r.is_err()) { ret 0; }
+    if (!result_is_err(r)) { ret 0; }
     ret 1;
 }
 
 test "result: ok with bool type" {
     val r_true: Result[bool, i32] = ok[bool, i32](true);
     val r_false: Result[bool, i32] = ok[bool, i32](false);
-    if (!r_true.is_ok()) { ret 0; }
-    if (!r_false.is_ok()) { ret 0; }
-    if (r_true.unwrap_ok() != true) { ret 0; }
-    if (r_false.unwrap_ok() != false) { ret 0; }
+    if (!result_is_ok(r_true)) { ret 0; }
+    if (!result_is_ok(r_false)) { ret 0; }
+    if (result_unwrap_ok(r_true) != true) { ret 0; }
+    if (result_unwrap_ok(r_false) != false) { ret 0; }
     ret 1;
 }
 
 test "result: different ok and err types" {
     val r_ok: Result[u64, i32] = ok[u64, i32](100);
     val r_err: Result[u64, i32] = err[u64, i32](-1);
-    if (!r_ok.is_ok()) { ret 0; }
-    if (!r_err.is_err()) { ret 0; }
-    if (r_ok.unwrap_ok() != 100) { ret 0; }
-    if (r_err.unwrap_err() != -1) { ret 0; }
+    if (!result_is_ok(r_ok)) { ret 0; }
+    if (!result_is_err(r_err)) { ret 0; }
+    if (result_unwrap_ok(r_ok) != 100) { ret 0; }
+    if (result_unwrap_err(r_err) != -1) { ret 0; }
     ret 1;
 }

--- a/src/types/semver.mach
+++ b/src/types/semver.mach
@@ -27,7 +27,7 @@ pub rec Semver {
 # input: major.minor.patch[-prerelease][+build]
 # ret:   parsed Semver or error message
 pub fun semver_parse(input: str) Result[Semver, str] {
-    if (input == nil || input.len() == 0) {
+    if (input == nil || str_len(input) == 0) {
         ret err[Semver, str]("empty version string");
     }
 
@@ -36,42 +36,42 @@ pub fun semver_parse(input: str) Result[Semver, str] {
     
     # parse major
     var major_result: Option[u64] = parse_number(input, ?pos);
-    if (major_result.is_none()) {
+    if (option_is_none(major_result)) {
         ret err[Semver, str]("invalid major version");
     }
-    v.major = major_result.unwrap();
+    v.major = option_unwrap(major_result);
     
-    if (pos >= input.len() || input[pos] != '.') {
+    if (pos >= str_len(input) || input[pos] != '.') {
         ret err[Semver, str]("expected '.' after major");
     }
     pos = pos + 1;
     
     # parse minor
     var minor_result: Option[u64] = parse_number(input, ?pos);
-    if (minor_result.is_none()) {
+    if (option_is_none(minor_result)) {
         ret err[Semver, str]("invalid minor version");
     }
-    v.minor = minor_result.unwrap();
+    v.minor = option_unwrap(minor_result);
     
-    if (pos >= input.len() || input[pos] != '.') {
+    if (pos >= str_len(input) || input[pos] != '.') {
         ret err[Semver, str]("expected '.' after minor");
     }
     pos = pos + 1;
     
     # parse patch
     var patch_result: Option[u64] = parse_number(input, ?pos);
-    if (patch_result.is_none()) {
+    if (option_is_none(patch_result)) {
         ret err[Semver, str]("invalid patch version");
     }
-    v.patch = patch_result.unwrap();
+    v.patch = option_unwrap(patch_result);
     
     # parse optional prerelease (starts with '-')
-    if (pos < input.len() && input[pos] == '-') {
+    if (pos < str_len(input) && input[pos] == '-') {
         pos = pos + 1;
         val start: usize = pos;
         
         # prerelease can contain alphanumerics, dots, and hyphens
-        for (pos < input.len()) {
+        for (pos < str_len(input)) {
             val c: u8 = input[pos];
             if (c == '+') {
                 brk;
@@ -89,12 +89,12 @@ pub fun semver_parse(input: str) Result[Semver, str] {
     }
     
     # parse optional build metadata (starts with '+')
-    if (pos < input.len() && input[pos] == '+') {
+    if (pos < str_len(input) && input[pos] == '+') {
         pos = pos + 1;
         val start: usize = pos;
         
         # build can contain alphanumerics, dots, and hyphens
-        for (pos < input.len()) {
+        for (pos < str_len(input)) {
             val c: u8 = input[pos];
             if (!is_valid_build_char(c)) {
                 ret err[Semver, str]("invalid build character");
@@ -111,9 +111,9 @@ pub fun semver_parse(input: str) Result[Semver, str] {
 # Validate that a `Semver` is well-formed.
 # ---
 # ret: true if valid, false otherwise.
-pub fun (this: &Semver) is_valid() bool {
+pub fun semver_is_valid(this: &Semver) bool {
     # check prerelease characters if present
-    if (!(this.prerelease == nil || this.prerelease.len() == 0)) {
+    if (!(this.prerelease == nil || str_len(this.prerelease) == 0)) {
         var i: usize = 0;
         for (this.prerelease[i] != 0) {
             val c: u8 = this.prerelease[i];
@@ -125,7 +125,7 @@ pub fun (this: &Semver) is_valid() bool {
     }
     
     # check build characters if present
-    if (!(this.build == nil || this.build.len() == 0)) {
+    if (!(this.build == nil || str_len(this.build) == 0)) {
         var i: usize = 0;
         for (this.build[i] != 0) {
             val c: u8 = this.build[i];
@@ -143,7 +143,7 @@ pub fun (this: &Semver) is_valid() bool {
 # ---
 # other: version to compare against
 # ret: <0 if this < other, 0 if equal, >0 if this > other
-pub fun (this: &Semver) compare(other: &Semver) i64 {
+pub fun semver_compare(this: &Semver, other: &Semver) i64 {
     # compare major
     if (this.major < other.major) { ret -1; }
     if (this.major > other.major) { ret 1; }
@@ -158,8 +158,8 @@ pub fun (this: &Semver) compare(other: &Semver) i64 {
     
     # compare prerelease
     # no prerelease (release) > prerelease
-    val this_has_pre:  bool = !(this.prerelease == nil || this.prerelease.len() == 0);
-    val other_has_pre: bool = !(other.prerelease == nil || other.prerelease.len() == 0);
+    val this_has_pre:  bool = !(this.prerelease == nil || str_len(this.prerelease) == 0);
+    val other_has_pre: bool = !(other.prerelease == nil || str_len(other.prerelease) == 0);
 
     if (!this_has_pre && other_has_pre) { ret 1; }
     if (this_has_pre && !other_has_pre) { ret -1; }
@@ -175,45 +175,45 @@ pub fun (this: &Semver) compare(other: &Semver) i64 {
 # ---
 # other: Version to compare against.
 # ret: true if less, false otherwise.
-pub fun (this: &Semver) is_less(other: &Semver) bool {
-    ret this.compare(other) < 0;
+pub fun semver_is_less(this: &Semver, other: &Semver) bool {
+    ret semver_compare(this, other) < 0;
 }
 
 # Return true if `this` Semver is greater than `other`.
 # ---
 # other: Version to compare against.
 # ret: true if greater, false otherwise.
-pub fun (this: &Semver) is_greater(other: &Semver) bool {
-    ret this.compare(other) > 0;
+pub fun semver_is_greater(this: &Semver, other: &Semver) bool {
+    ret semver_compare(this, other) > 0;
 }
 
 # Return true if `this` Semver equals `other` (ignoring build metadata).
 # ---
 # other: Version to compare against.
 # ret: true if equal, false otherwise.
-pub fun (this: &Semver) equals(other: &Semver) bool {
-    ret this.compare(other) == 0;
+pub fun semver_equals(this: &Semver, other: &Semver) bool {
+    ret semver_compare(this, other) == 0;
 }
 
 # Check whether `this` Semver is a stable release (no prerelease).
 # ---
 # ret: true if stable, false otherwise.
-pub fun (this: &Semver) is_stable() bool {
-    ret this.prerelease == nil || this.prerelease.len() == 0;
+pub fun semver_is_stable(this: &Semver) bool {
+    ret this.prerelease == nil || str_len(this.prerelease) == 0;
 }
 
 # Check whether `this` Semver is a prerelease version.
 # ---
 # ret: true if prerelease, false otherwise.
-pub fun (this: &Semver) is_prerelease() bool {
-    ret !(this.prerelease == nil || this.prerelease.len() == 0);
+pub fun semver_is_prerelease(this: &Semver) bool {
+    ret !(this.prerelease == nil || str_len(this.prerelease) == 0);
 }
 
 # Check whether `this` Semver has build metadata.
 # ---
 # ret: true if has build metadata, false otherwise.
-pub fun (this: &Semver) has_build() bool {
-    ret !(this.build == nil || this.build.len() == 0);
+pub fun semver_has_build(this: &Semver) bool {
+    ret !(this.build == nil || str_len(this.build) == 0);
 }
 
 # Parse an unsigned number from `input` starting at `pos`, updating `pos`.
@@ -226,7 +226,7 @@ fun parse_number(input: str, pos: *usize) Option[u64] {
     var value:       u64   = 0;
     var found_digit: bool  = false;
     
-    for (@pos < input.len()) {
+    for (@pos < str_len(input)) {
         val c: u8 = input[@pos];
         if (!ascii.is_digit(c)) {
             brk;
@@ -271,8 +271,8 @@ fun compare_prerelease(a: str, b: str) i64 {
     var b_pos: usize = 0;
 
     for {
-        val a_len: usize = a.len();
-        val b_len: usize = b.len();
+        val a_len: usize = str_len(a);
+        val b_len: usize = str_len(b);
 
         if (a_pos >= a_len && b_pos >= b_len) {
             ret 0;
@@ -343,7 +343,7 @@ fun compare_identifier(a: str, b: str) i64 {
     }
     
     # both alphanumeric: lexical comparison
-    ret a.compare(b);
+    ret str_compare(a, b);
 }
 
 # Check whether a string consists entirely of digits.
@@ -351,7 +351,7 @@ fun compare_identifier(a: str, b: str) i64 {
 # s: string to check.
 # ret: true if all digits, false otherwise.
 fun is_numeric(s: str) bool {
-    if (s.len() == 0) {
+    if (str_len(s) == 0) {
         ret false;
     }
     

--- a/src/types/string.mach
+++ b/src/types/string.mach
@@ -12,7 +12,7 @@ pub def str:  &char;
 # Calculate the length of a null-terminated string
 # ---
 # ret: Length of the string (not including null terminator)
-pub fun (this: str) len() usize {
+pub fun str_len(this: str) usize {
     var len: usize = 0;
     for (this[len] != 0) {
         len = len + 1;
@@ -23,15 +23,15 @@ pub fun (this: str) len() usize {
 # Return true if the string is empty
 # ---
 # ret: true if the string has zero length, false otherwise
-pub fun (this: str) empty() bool {
-    ret this.len() == 0;
+pub fun str_empty(this: str) bool {
+    ret str_len(this) == 0;
 }
 
 # Compare two null-terminated strings for equality
 # ---
 # other: The other string to compare against
 # ret:   true if the strings are equal, false otherwise
-pub fun (this: str) equals(other: str) bool {
+pub fun str_equals(this: str, other: str) bool {
     var i: usize = 0;
     for (this[i] != 0 && other[i] != 0) {
         if (this[i] != other[i]) {
@@ -46,7 +46,7 @@ pub fun (this: str) equals(other: str) bool {
 # ---
 # other: The other string to compare against
 # ret:   <0 if this < other, 0 if equal, >0 if this > other
-pub fun (this: str) compare(other: str) i64 {
+pub fun str_compare(this: str, other: str) i64 {
     var i: usize = 0;
     for {
         val a: u8 = this[i];
@@ -69,7 +69,7 @@ pub fun (this: str) compare(other: str) i64 {
 # ---
 # prefix: The prefix to check
 # ret:    true if the string starts with the prefix, false otherwise
-pub fun (this: str) starts_with(prefix: str) bool {
+pub fun str_starts_with(this: str, prefix: str) bool {
     var i: usize = 0;
     for (prefix[i] != 0) {
         if (this[i] != prefix[i]) {
@@ -84,9 +84,9 @@ pub fun (this: str) starts_with(prefix: str) bool {
 # ---
 # suffix: The suffix to check
 # ret:    true if the string ends with the suffix, false otherwise
-pub fun (this: str) ends_with(suffix: str) bool {
-    val this_len: usize = this.len();
-    val suffix_len: usize = suffix.len();
+pub fun str_ends_with(this: str, suffix: str) bool {
+    val this_len: usize = str_len(this);
+    val suffix_len: usize = str_len(suffix);
 
     if (suffix_len > this_len) {
         ret false;
@@ -107,9 +107,9 @@ pub fun (this: str) ends_with(suffix: str) bool {
 # ---
 # sub: The substring to find
 # ret: The index of the substring if found, or an error if not found
-pub fun (this: str) index_of(sub: str) Result[usize, str] {
-    val this_len: usize = this.len();
-    val sub_len:  usize = sub.len();
+pub fun str_index_of(this: str, sub: str) Result[usize, str] {
+    val this_len: usize = str_len(this);
+    val sub_len:  usize = str_len(sub);
 
     if (sub_len == 0 || sub_len > this_len) {
         ret err[usize, str]("invalid substring length");
@@ -142,9 +142,9 @@ pub fun (this: str) index_of(sub: str) Result[usize, str] {
 # ---
 # sub: The substring to find
 # ret: The last index of the substring if found, or an error if not found
-pub fun (this: str) last_index_of(sub: str) Result[usize, str] {
-    val this_len: usize = this.len();
-    val sub_len:  usize = sub.len();
+pub fun str_last_index_of(this: str, sub: str) Result[usize, str] {
+    val this_len: usize = str_len(this);
+    val sub_len:  usize = str_len(sub);
 
     if (sub_len == 0 || sub_len > this_len) {
         ret err[usize, str]("invalid substring length");
@@ -177,201 +177,201 @@ pub fun (this: str) last_index_of(sub: str) Result[usize, str] {
 # ---
 # sub: The substring to check
 # ret: true if the string contains the substring, false otherwise
-pub fun (this: str) contains(sub: str) bool {
-    val index_res: Result[usize, str] = this.index_of(sub);
-    ret index_res.is_ok();
+pub fun str_contains(this: str, sub: str) bool {
+    val index_res: Result[usize, str] = str_index_of(this, sub);
+    ret result_is_ok(index_res);
 }
 
 # --- tests ---
 
 test "string: len of empty string" {
     val s: str = "";
-    if (s.len() != 0) { ret 0; }
+    if (str_len(s) != 0) { ret 0; }
     ret 1;
 }
 
 test "string: len of non-empty string" {
     val s: str = "hello";
-    if (s.len() != 5) { ret 0; }
+    if (str_len(s) != 5) { ret 0; }
     ret 1;
 }
 
 test "string: len of single char" {
     val s: str = "x";
-    if (s.len() != 1) { ret 0; }
+    if (str_len(s) != 1) { ret 0; }
     ret 1;
 }
 
 test "string: empty returns true for empty string" {
     val s: str = "";
-    if (!s.empty()) { ret 0; }
+    if (!str_empty(s)) { ret 0; }
     ret 1;
 }
 
 test "string: empty returns false for non-empty string" {
     val s: str = "hello";
-    if (s.empty()) { ret 0; }
+    if (str_empty(s)) { ret 0; }
     ret 1;
 }
 
 test "string: equals same strings" {
     val a: str = "hello";
     val b: str = "hello";
-    if (!a.equals(b)) { ret 0; }
+    if (!str_equals(a, b)) { ret 0; }
     ret 1;
 }
 
 test "string: equals different strings" {
     val a: str = "hello";
     val b: str = "world";
-    if (a.equals(b)) { ret 0; }
+    if (str_equals(a, b)) { ret 0; }
     ret 1;
 }
 
 test "string: equals different lengths" {
     val a: str = "hello";
     val b: str = "hello world";
-    if (a.equals(b)) { ret 0; }
+    if (str_equals(a, b)) { ret 0; }
     ret 1;
 }
 
 test "string: equals empty strings" {
     val a: str = "";
     val b: str = "";
-    if (!a.equals(b)) { ret 0; }
+    if (!str_equals(a, b)) { ret 0; }
     ret 1;
 }
 
 test "string: compare equal strings" {
     val a: str = "abc";
     val b: str = "abc";
-    if (a.compare(b) != 0) { ret 0; }
+    if (str_compare(a, b) != 0) { ret 0; }
     ret 1;
 }
 
 test "string: compare less than" {
     val a: str = "abc";
     val b: str = "abd";
-    if (a.compare(b) >= 0) { ret 0; }
+    if (str_compare(a, b) >= 0) { ret 0; }
     ret 1;
 }
 
 test "string: compare greater than" {
     val a: str = "abd";
     val b: str = "abc";
-    if (a.compare(b) <= 0) { ret 0; }
+    if (str_compare(a, b) <= 0) { ret 0; }
     ret 1;
 }
 
 test "string: compare prefix is less" {
     val a: str = "abc";
     val b: str = "abcd";
-    if (a.compare(b) >= 0) { ret 0; }
+    if (str_compare(a, b) >= 0) { ret 0; }
     ret 1;
 }
 
 test "string: starts_with matching prefix" {
     val s: str = "hello world";
-    if (!s.starts_with("hello")) { ret 0; }
+    if (!str_starts_with(s, "hello")) { ret 0; }
     ret 1;
 }
 
 test "string: starts_with non-matching prefix" {
     val s: str = "hello world";
-    if (s.starts_with("world")) { ret 0; }
+    if (str_starts_with(s, "world")) { ret 0; }
     ret 1;
 }
 
 test "string: starts_with empty prefix" {
     val s: str = "hello";
-    if (!s.starts_with("")) { ret 0; }
+    if (!str_starts_with(s, "")) { ret 0; }
     ret 1;
 }
 
 test "string: starts_with full string" {
     val s: str = "hello";
-    if (!s.starts_with("hello")) { ret 0; }
+    if (!str_starts_with(s, "hello")) { ret 0; }
     ret 1;
 }
 
 test "string: ends_with matching suffix" {
     val s: str = "hello world";
-    if (!s.ends_with("world")) { ret 0; }
+    if (!str_ends_with(s, "world")) { ret 0; }
     ret 1;
 }
 
 test "string: ends_with non-matching suffix" {
     val s: str = "hello world";
-    if (s.ends_with("hello")) { ret 0; }
+    if (str_ends_with(s, "hello")) { ret 0; }
     ret 1;
 }
 
 test "string: ends_with empty suffix" {
     val s: str = "hello";
-    if (!s.ends_with("")) { ret 0; }
+    if (!str_ends_with(s, "")) { ret 0; }
     ret 1;
 }
 
 test "string: ends_with full string" {
     val s: str = "hello";
-    if (!s.ends_with("hello")) { ret 0; }
+    if (!str_ends_with(s, "hello")) { ret 0; }
     ret 1;
 }
 
 test "string: index_of finds substring at start" {
     val s: str = "hello world";
-    val r: Result[usize, str] = s.index_of("hello");
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 0) { ret 0; }
+    val r: Result[usize, str] = str_index_of(s, "hello");
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 0) { ret 0; }
     ret 1;
 }
 
 test "string: index_of finds substring in middle" {
     val s: str = "hello world";
-    val r: Result[usize, str] = s.index_of("wor");
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 6) { ret 0; }
+    val r: Result[usize, str] = str_index_of(s, "wor");
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 6) { ret 0; }
     ret 1;
 }
 
 test "string: index_of not found" {
     val s: str = "hello world";
-    val r: Result[usize, str] = s.index_of("xyz");
-    if (r.is_ok()) { ret 0; }
+    val r: Result[usize, str] = str_index_of(s, "xyz");
+    if (result_is_ok(r)) { ret 0; }
     ret 1;
 }
 
 test "string: last_index_of finds last occurrence" {
     val s: str = "abcabc";
-    val r: Result[usize, str] = s.last_index_of("abc");
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 3) { ret 0; }
+    val r: Result[usize, str] = str_last_index_of(s, "abc");
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 3) { ret 0; }
     ret 1;
 }
 
 test "string: last_index_of single occurrence" {
     val s: str = "hello world";
-    val r: Result[usize, str] = s.last_index_of("world");
-    if (r.is_err()) { ret 0; }
-    if (r.unwrap_ok() != 6) { ret 0; }
+    val r: Result[usize, str] = str_last_index_of(s, "world");
+    if (result_is_err(r)) { ret 0; }
+    if (result_unwrap_ok(r) != 6) { ret 0; }
     ret 1;
 }
 
 test "string: contains found" {
     val s: str = "hello world";
-    if (!s.contains("wor")) { ret 0; }
+    if (!str_contains(s, "wor")) { ret 0; }
     ret 1;
 }
 
 test "string: contains not found" {
     val s: str = "hello world";
-    if (s.contains("xyz")) { ret 0; }
+    if (str_contains(s, "xyz")) { ret 0; }
     ret 1;
 }
 
 test "string: contains empty substring" {
     val s: str = "hello";
     # empty substring should not be found (per current implementation)
-    if (s.contains("")) { ret 0; }
+    if (str_contains(s, "")) { ret 0; }
     ret 1;
 }


### PR DESCRIPTION
Closes #4

Convert all method-call sugar to explicit free function calls across 20 files (~1000 call sites). Required for cmach compatibility after method support removal.