### PR TITLE
Add explicit generic params to all stdlib function declarations

### DIFF
--- a/src/allocator.mach
+++ b/src/allocator.mach
@@ -96,11 +96,11 @@ pub fun allocator_alloc(this: *Allocator)[T](count: usize) Result[*T, AllocError
     }
 
     val r: Result[ptr, AllocError] = allocator_alloc_bytes(this, total, $align_of(T));
-    if (result_is_err(r)) {
-        ret err[*T, AllocError](result_unwrap_err(r));
+    if (result_is_err[ptr, AllocError](r)) {
+        ret err[*T, AllocError](result_unwrap_err[ptr, AllocError](r));
     }
 
-    ret ok[*T, AllocError](result_unwrap_ok(r)::*T);
+    ret ok[*T, AllocError](result_unwrap_ok[ptr, AllocError](r)::*T);
 }
 
 # Allocate and zero-initialize count elements of T.
@@ -109,11 +109,11 @@ pub fun allocator_alloc(this: *Allocator)[T](count: usize) Result[*T, AllocError
 # ret: Ok(*T) pointer (nil for count == 0) or Err(AllocError) on OOM or overflow.
 pub fun allocator_zalloc(this: *Allocator)[T](count: usize) Result[*T, AllocError] {
     val r: Result[*T, AllocError] = allocator_alloc[T](this, count);
-    if (result_is_err(r)) {
+    if (result_is_err[*T, AllocError](r)) {
         ret r;
     }
 
-    val p: *T = result_unwrap_ok(r);
+    val p: *T = result_unwrap_ok[*T, AllocError](r);
     if (p != nil && count != 0) {
         val total: usize = $size_of(T) * count;
         val bytes: *u8 = p::ptr::*u8;
@@ -161,11 +161,11 @@ pub fun allocator_resize(this: *Allocator)[T](p: *T, old_count: usize, new_count
     }
 
     val r: Result[ptr, AllocError] = allocator_resize_bytes(this, p::ptr, old_size, new_size, $align_of(T));
-    if (result_is_err(r)) {
-        ret err[*T, AllocError](result_unwrap_err(r));
+    if (result_is_err[ptr, AllocError](r)) {
+        ret err[*T, AllocError](result_unwrap_err[ptr, AllocError](r));
     }
 
-    ret ok[*T, AllocError](result_unwrap_ok(r)::*T);
+    ret ok[*T, AllocError](result_unwrap_ok[ptr, AllocError](r)::*T);
 }
 
 # default allocator (page-granular) backed by platform memory.
@@ -230,8 +230,8 @@ test "allocator: default returns valid allocator" {
 test "allocator: alloc_bytes allocates memory" {
     var a: Allocator = page_allocator();
     val r: Result[ptr, AllocError] = allocator_alloc_bytes(a, 64, 8);
-    if (result_is_err(r)) { ret 0; }
-    val p: ptr = result_unwrap_ok(r);
+    if (result_is_err[ptr, AllocError](r)) { ret 0; }
+    val p: ptr = result_unwrap_ok[ptr, AllocError](r);
     if (p == nil) { ret 0; }
     val ok: bool = allocator_free_bytes(a, p, 64, 8);
     if (!ok) { ret 0; }
@@ -241,8 +241,8 @@ test "allocator: alloc_bytes allocates memory" {
 test "allocator: alloc_bytes with size zero returns nil" {
     var a: Allocator = page_allocator();
     val r: Result[ptr, AllocError] = allocator_alloc_bytes(a, 0, 8);
-    if (result_is_err(r)) { ret 0; }
-    val p: ptr = result_unwrap_ok(r);
+    if (result_is_err[ptr, AllocError](r)) { ret 0; }
+    val p: ptr = result_unwrap_ok[ptr, AllocError](r);
     if (p != nil) { ret 0; }
     ret 1;
 }
@@ -250,8 +250,8 @@ test "allocator: alloc_bytes with size zero returns nil" {
 test "allocator: alloc typed allocation" {
     var a: Allocator = page_allocator();
     val r: Result[*i64, AllocError] = allocator_alloc[i64](a, 4);
-    if (result_is_err(r)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(r);
+    if (result_is_err[*i64, AllocError](r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, AllocError](r);
     if (p == nil) { ret 0; }
 
     # write and read back
@@ -270,8 +270,8 @@ test "allocator: alloc typed allocation" {
 test "allocator: alloc with count zero returns nil" {
     var a: Allocator = page_allocator();
     val r: Result[*i64, AllocError] = allocator_alloc[i64](a, 0);
-    if (result_is_err(r)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(r);
+    if (result_is_err[*i64, AllocError](r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, AllocError](r);
     if (p != nil) { ret 0; }
     ret 1;
 }
@@ -279,8 +279,8 @@ test "allocator: alloc with count zero returns nil" {
 test "allocator: zalloc zero-initializes memory" {
     var a: Allocator = page_allocator();
     val r: Result[*i64, AllocError] = allocator_zalloc[i64](a, 4);
-    if (result_is_err(r)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(r);
+    if (result_is_err[*i64, AllocError](r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, AllocError](r);
     if (p == nil) { ret 0; }
 
     # all values should be zero
@@ -297,8 +297,8 @@ test "allocator: zalloc zero-initializes memory" {
 test "allocator: zalloc with count zero returns nil" {
     var a: Allocator = page_allocator();
     val r: Result[*i64, AllocError] = allocator_zalloc[i64](a, 0);
-    if (result_is_err(r)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(r);
+    if (result_is_err[*i64, AllocError](r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, AllocError](r);
     if (p != nil) { ret 0; }
     ret 1;
 }
@@ -313,8 +313,8 @@ test "allocator: free with nil pointer succeeds" {
 test "allocator: free with count zero succeeds" {
     var a: Allocator = page_allocator();
     val r: Result[*i64, AllocError] = allocator_alloc[i64](a, 4);
-    if (result_is_err(r)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(r);
+    if (result_is_err[*i64, AllocError](r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, AllocError](r);
     # free with count 0 should succeed (noop)
     val ok: bool = allocator_free[i64](a, p, 0);
     if (!ok) { ret 0; }
@@ -327,14 +327,14 @@ test "allocator: free with count zero succeeds" {
 test "allocator: resize grows allocation" {
     var a: Allocator = page_allocator();
     val r1: Result[*i64, AllocError] = allocator_alloc[i64](a, 2);
-    if (result_is_err(r1)) { ret 0; }
-    val p1: *i64 = result_unwrap_ok(r1);
+    if (result_is_err[*i64, AllocError](r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok[*i64, AllocError](r1);
     p1[0] = 111;
     p1[1] = 222;
 
     val r2: Result[*i64, AllocError] = allocator_resize[i64](a, p1, 2, 4);
-    if (result_is_err(r2)) { ret 0; }
-    val p2: *i64 = result_unwrap_ok(r2);
+    if (result_is_err[*i64, AllocError](r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok[*i64, AllocError](r2);
     if (p2 == nil) { ret 0; }
 
     # original data should be preserved
@@ -349,12 +349,12 @@ test "allocator: resize grows allocation" {
 test "allocator: resize to zero frees and returns nil" {
     var a: Allocator = page_allocator();
     val r1: Result[*i64, AllocError] = allocator_alloc[i64](a, 4);
-    if (result_is_err(r1)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(r1);
+    if (result_is_err[*i64, AllocError](r1)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, AllocError](r1);
 
     val r2: Result[*i64, AllocError] = allocator_resize[i64](a, p, 4, 0);
-    if (result_is_err(r2)) { ret 0; }
-    val p2: *i64 = result_unwrap_ok(r2);
+    if (result_is_err[*i64, AllocError](r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok[*i64, AllocError](r2);
     if (p2 != nil) { ret 0; }
     ret 1;
 }
@@ -362,8 +362,8 @@ test "allocator: resize to zero frees and returns nil" {
 test "allocator: resize from nil allocates new" {
     var a: Allocator = page_allocator();
     val r: Result[*i64, AllocError] = allocator_resize[i64](a, nil, 0, 4);
-    if (result_is_err(r)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(r);
+    if (result_is_err[*i64, AllocError](r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, AllocError](r);
     if (p == nil) { ret 0; }
 
     p[0] = 42;

--- a/src/allocator/arena.mach
+++ b/src/allocator/arena.mach
@@ -185,8 +185,8 @@ pub fun arena_allocator(this: *Arena) a.Allocator {
 test "arena: init with zero capacity succeeds" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 0);
-    if (result_is_err(r)) { ret 0; }
-    var ar: Arena = result_unwrap_ok(r);
+    if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
     val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
@@ -195,8 +195,8 @@ test "arena: init with zero capacity succeeds" {
 test "arena: init with capacity allocates backing storage" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 1024);
-    if (result_is_err(r)) { ret 0; }
-    var ar: Arena = result_unwrap_ok(r);
+    if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
     val ok: bool = arena_deinit(?ar);
     if (!ok) { ret 0; }
     ret 1;
@@ -205,13 +205,13 @@ test "arena: init with capacity allocates backing storage" {
 test "arena: allocator returns functional allocator" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (result_is_err(r)) { ret 0; }
-    var ar: Arena = result_unwrap_ok(r);
+    if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
 
     var alloc: a.Allocator = arena_allocator(?ar);
     val alloc_r: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 4);
-    if (result_is_err(alloc_r)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(alloc_r);
+    if (result_is_err[*i64, a.AllocError](alloc_r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, a.AllocError](alloc_r);
     if (p == nil) { ret 0; }
 
     p[0] = 100;
@@ -227,17 +227,17 @@ test "arena: allocator returns functional allocator" {
 test "arena: multiple allocations bump offset" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (result_is_err(r)) { ret 0; }
-    var ar: Arena = result_unwrap_ok(r);
+    if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
     var alloc: a.Allocator = arena_allocator(?ar);
 
     val r1: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
-    if (result_is_err(r1)) { ret 0; }
-    val p1: *i64 = result_unwrap_ok(r1);
+    if (result_is_err[*i64, a.AllocError](r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok[*i64, a.AllocError](r1);
 
     val r2: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
-    if (result_is_err(r2)) { ret 0; }
-    val p2: *i64 = result_unwrap_ok(r2);
+    if (result_is_err[*i64, a.AllocError](r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok[*i64, a.AllocError](r2);
 
     # p2 should be after p1 in memory
     if (p2::usize <= p1::usize) { ret 0; }
@@ -255,22 +255,22 @@ test "arena: multiple allocations bump offset" {
 test "arena: reset clears allocations" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (result_is_err(r)) { ret 0; }
-    var ar: Arena = result_unwrap_ok(r);
+    if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
     var alloc: a.Allocator = arena_allocator(?ar);
 
     # allocate some memory
     val r1: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 100);
-    if (result_is_err(r1)) { ret 0; }
-    val p1: *i64 = result_unwrap_ok(r1);
+    if (result_is_err[*i64, a.AllocError](r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok[*i64, a.AllocError](r1);
 
     # reset
     arena_reset(?ar);
 
     # allocate again - should get same (or similar) address
     val r2: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 100);
-    if (result_is_err(r2)) { ret 0; }
-    val p2: *i64 = result_unwrap_ok(r2);
+    if (result_is_err[*i64, a.AllocError](r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok[*i64, a.AllocError](r2);
 
     # after reset, new allocation should start from beginning
     # so p2 should be at or near the same address as p1
@@ -284,17 +284,17 @@ test "arena: reset clears allocations" {
 test "arena: free is noop for non-last allocation" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (result_is_err(r)) { ret 0; }
-    var ar: Arena = result_unwrap_ok(r);
+    if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
     var alloc: a.Allocator = arena_allocator(?ar);
 
     val r1: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
-    if (result_is_err(r1)) { ret 0; }
-    val p1: *i64 = result_unwrap_ok(r1);
+    if (result_is_err[*i64, a.AllocError](r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok[*i64, a.AllocError](r1);
 
     val r2: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
-    if (result_is_err(r2)) { ret 0; }
-    val p2: *i64 = result_unwrap_ok(r2);
+    if (result_is_err[*i64, a.AllocError](r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok[*i64, a.AllocError](r2);
 
     # free p1 (not the last allocation) - should be noop
     val ok_free: bool = a.allocator_free[i64](alloc, p1, 2);
@@ -312,17 +312,17 @@ test "arena: free is noop for non-last allocation" {
 test "arena: free last allocation rolls back" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (result_is_err(r)) { ret 0; }
-    var ar: Arena = result_unwrap_ok(r);
+    if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
     var alloc: a.Allocator = arena_allocator(?ar);
 
     val r1: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
-    if (result_is_err(r1)) { ret 0; }
-    val p1: *i64 = result_unwrap_ok(r1);
+    if (result_is_err[*i64, a.AllocError](r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok[*i64, a.AllocError](r1);
 
     val r2: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
-    if (result_is_err(r2)) { ret 0; }
-    val p2: *i64 = result_unwrap_ok(r2);
+    if (result_is_err[*i64, a.AllocError](r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok[*i64, a.AllocError](r2);
 
     # free p2 (last allocation) - should roll back
     val ok_free: bool = a.allocator_free[i64](alloc, p2, 2);
@@ -330,8 +330,8 @@ test "arena: free last allocation rolls back" {
 
     # next allocation should reuse p2's space
     val r3: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
-    if (result_is_err(r3)) { ret 0; }
-    val p3: *i64 = result_unwrap_ok(r3);
+    if (result_is_err[*i64, a.AllocError](r3)) { ret 0; }
+    val p3: *i64 = result_unwrap_ok[*i64, a.AllocError](r3);
 
     if (p3 != p2) { ret 0; }
 
@@ -343,20 +343,20 @@ test "arena: free last allocation rolls back" {
 test "arena: resize last allocation in-place" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (result_is_err(r)) { ret 0; }
-    var ar: Arena = result_unwrap_ok(r);
+    if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
     var alloc: a.Allocator = arena_allocator(?ar);
 
     val r1: Result[*i64, a.AllocError] = a.allocator_alloc[i64](alloc, 2);
-    if (result_is_err(r1)) { ret 0; }
-    val p1: *i64 = result_unwrap_ok(r1);
+    if (result_is_err[*i64, a.AllocError](r1)) { ret 0; }
+    val p1: *i64 = result_unwrap_ok[*i64, a.AllocError](r1);
     p1[0] = 111;
     p1[1] = 222;
 
     # resize in-place (should succeed for last allocation)
     val r2: Result[*i64, a.AllocError] = a.allocator_resize[i64](?alloc, p1, 2, 4);
-    if (result_is_err(r2)) { ret 0; }
-    val p2: *i64 = result_unwrap_ok(r2);
+    if (result_is_err[*i64, a.AllocError](r2)) { ret 0; }
+    val p2: *i64 = result_unwrap_ok[*i64, a.AllocError](r2);
 
     # should be same pointer for in-place resize
     if (p2 != p1) { ret 0; }
@@ -389,18 +389,18 @@ test "arena: deinit on nil arena succeeds" {
 test "arena: allocation respects alignment" {
     var backing: a.Allocator = a.page_allocator();
     val r: Result[Arena, a.AllocError] = init(backing, 4096);
-    if (result_is_err(r)) { ret 0; }
-    var ar: Arena = result_unwrap_ok(r);
+    if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
+    var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
     var alloc: a.Allocator = arena_allocator(?ar);
 
     # allocate 1 byte
     val r1: Result[ptr, a.AllocError] = a.allocator_alloc_bytes(alloc, 1, 1);
-    if (result_is_err(r1)) { ret 0; }
+    if (result_is_err[ptr, a.AllocError](r1)) { ret 0; }
 
     # allocate 8 bytes with 8-byte alignment
     val r2: Result[ptr, a.AllocError] = a.allocator_alloc_bytes(alloc, 8, 8);
-    if (result_is_err(r2)) { ret 0; }
-    val p2: ptr = result_unwrap_ok(r2);
+    if (result_is_err[ptr, a.AllocError](r2)) { ret 0; }
+    val p2: ptr = result_unwrap_ok[ptr, a.AllocError](r2);
 
     # check alignment
     val addr: usize = p2::usize;

--- a/src/collections/map.mach
+++ b/src/collections/map.mach
@@ -61,7 +61,7 @@ pub fun init[K, V](alloc: allocator.Allocator, hash_fn: fun(ptr) u64, eq_fn: fun
 # Free all backing storage and reset the map
 # ---
 # ret: true if memory was freed successfully
-pub fun map_dnit(this: *Map[K, V]) bool {
+pub fun map_dnit[K, V](this: *Map[K, V]) bool {
     if (this == nil) { ret true; }
     if (this.cap == 0) {
         this.keys = nil;
@@ -88,27 +88,27 @@ pub fun map_dnit(this: *Map[K, V]) bool {
 # Check if the map is empty
 # ---
 # ret: true if the map has no entries
-pub fun map_is_empty(this: Map[K, V]) bool {
+pub fun map_is_empty[K, V](this: Map[K, V]) bool {
     ret this.len == 0;
 }
 
 # Return the number of entries in the map
 # ---
 # ret: Number of key-value pairs
-pub fun map_length(this: Map[K, V]) usize {
+pub fun map_length[K, V](this: Map[K, V]) usize {
     ret this.len;
 }
 
 # Return the current capacity
 # ---
 # ret: Capacity in slots
-pub fun map_capacity(this: Map[K, V]) usize {
+pub fun map_capacity[K, V](this: Map[K, V]) usize {
     ret this.cap;
 }
 
 # Clear all entries but keep allocated capacity
 # ---
-pub fun map_clear(this: *Map[K, V]) {
+pub fun map_clear[K, V](this: *Map[K, V]) {
     if (this == nil || this.cap == 0) { ret; }
     mem.raw_fill(this.states::ptr, SLOT_EMPTY, this.cap);
     this.len = 0;
@@ -118,7 +118,7 @@ pub fun map_clear(this: *Map[K, V]) {
 # ---
 # key: Key to search for
 # ret: (index, found) tuple - if found is true, key exists at index
-fun map_find_slot(this: &Map[K, V], key: &K) rec { idx: usize; found: bool; } {
+fun map_find_slot[K, V](this: &Map[K, V], key: &K) rec { idx: usize; found: bool; } {
     var result: rec { idx: usize; found: bool; };
     result.found = false;
     result.idx = 0;
@@ -180,32 +180,32 @@ fun map_find_slot(this: &Map[K, V], key: &K) rec { idx: usize; found: bool; } {
 # ---
 # new_cap: New capacity (must be > current capacity)
 # ret: Ok(new capacity) or Err(error message)
-fun map_grow(this: *Map[K, V], new_cap: usize) Result[usize, str] {
+fun map_grow[K, V](this: *Map[K, V], new_cap: usize) Result[usize, str] {
     if (new_cap <= this.cap) {
         ret ok[usize, str](this.cap);
     }
 
     # allocate new arrays
     val keys_r: Result[*K, allocator.AllocError] = allocator.allocator_alloc[K](this.alloc, new_cap);
-    if (result_is_err(keys_r)) {
-        ret err[usize, str](result_unwrap_err(keys_r));
+    if (result_is_err[*K, allocator.AllocError](keys_r)) {
+        ret err[usize, str](result_unwrap_err[*K, allocator.AllocError](keys_r));
     }
-    val new_keys: *K = result_unwrap_ok(keys_r);
+    val new_keys: *K = result_unwrap_ok[*K, allocator.AllocError](keys_r);
 
     val values_r: Result[*V, allocator.AllocError] = allocator.allocator_alloc[V](this.alloc, new_cap);
-    if (result_is_err(values_r)) {
+    if (result_is_err[*V, allocator.AllocError](values_r)) {
         allocator.allocator_free[K](this.alloc, new_keys, new_cap);
-        ret err[usize, str](result_unwrap_err(values_r));
+        ret err[usize, str](result_unwrap_err[*V, allocator.AllocError](values_r));
     }
-    val new_values: *V = result_unwrap_ok(values_r);
+    val new_values: *V = result_unwrap_ok[*V, allocator.AllocError](values_r);
 
     val states_r: Result[*u8, allocator.AllocError] = allocator.allocator_zalloc[u8](this.alloc, new_cap);
-    if (result_is_err(states_r)) {
+    if (result_is_err[*u8, allocator.AllocError](states_r)) {
         allocator.allocator_free[K](this.alloc, new_keys, new_cap);
         allocator.allocator_free[V](this.alloc, new_values, new_cap);
-        ret err[usize, str](result_unwrap_err(states_r));
+        ret err[usize, str](result_unwrap_err[*u8, allocator.AllocError](states_r));
     }
-    val new_states: *u8 = result_unwrap_ok(states_r);
+    val new_states: *u8 = result_unwrap_ok[*u8, allocator.AllocError](states_r);
 
     # save old arrays
     val old_keys: *K = this.keys;
@@ -254,15 +254,15 @@ fun map_grow(this: *Map[K, V], new_cap: usize) Result[usize, str] {
 # Ensure the map has capacity for at least one more entry
 # ---
 # ret: Ok(capacity) or Err(error message)
-fun map_ensure_capacity(this: *Map[K, V]) Result[usize, str] {
+fun map_ensure_capacity[K, V](this: *Map[K, V]) Result[usize, str] {
     if (this.cap == 0) {
-        ret map_grow(this, DEFAULT_CAPACITY);
+        ret map_grow[K, V](this, DEFAULT_CAPACITY);
     }
 
     # check load factor
     val threshold: usize = (this.cap * LOAD_FACTOR_PERCENT) / 100;
     if (this.len >= threshold) {
-        ret map_grow(this, this.cap * 2);
+        ret map_grow[K, V](this, this.cap * 2);
     }
 
     ret ok[usize, str](this.cap);
@@ -273,13 +273,13 @@ fun map_ensure_capacity(this: *Map[K, V]) Result[usize, str] {
 # key: Key to insert
 # value: Value to associate with the key
 # ret: Ok(true) if inserted new, Ok(false) if updated existing, Err on allocation failure
-pub fun map_insert(this: *Map[K, V], key: K, value: V) Result[bool, str] {
-    val cap_r: Result[usize, str] = map_ensure_capacity(this);
-    if (result_is_err(cap_r)) {
-        ret err[bool, str](result_unwrap_err(cap_r));
+pub fun map_insert[K, V](this: *Map[K, V], key: K, value: V) Result[bool, str] {
+    val cap_r: Result[usize, str] = map_ensure_capacity[K, V](this);
+    if (result_is_err[usize, str](cap_r)) {
+        ret err[bool, str](result_unwrap_err[usize, str](cap_r));
     }
 
-    val slot: rec { idx: usize; found: bool; } = map_find_slot(this, ?key);
+    val slot: rec { idx: usize; found: bool; } = map_find_slot[K, V](this, ?key);
 
     if (slot.found) {
         # update existing
@@ -300,12 +300,12 @@ pub fun map_insert(this: *Map[K, V], key: K, value: V) Result[bool, str] {
 # ---
 # key: Key to look up
 # ret: Ok(pointer to value) or Err("key not found")
-pub fun map_get(this: &Map[K, V], key: &K) Result[*V, str] {
+pub fun map_get[K, V](this: &Map[K, V], key: &K) Result[*V, str] {
     if (this.cap == 0) {
         ret err[*V, str]("key not found");
     }
 
-    val slot: rec { idx: usize; found: bool; } = map_find_slot(this, key);
+    val slot: rec { idx: usize; found: bool; } = map_find_slot[K, V](this, key);
 
     if (!slot.found) {
         ret err[*V, str]("key not found");
@@ -318,12 +318,12 @@ pub fun map_get(this: &Map[K, V], key: &K) Result[*V, str] {
 # ---
 # key: Key to check for
 # ret: true if the key exists in the map
-pub fun map_contains(this: &Map[K, V], key: &K) bool {
+pub fun map_contains[K, V](this: &Map[K, V], key: &K) bool {
     if (this.cap == 0) {
         ret false;
     }
 
-    val slot: rec { idx: usize; found: bool; } = map_find_slot(this, key);
+    val slot: rec { idx: usize; found: bool; } = map_find_slot[K, V](this, key);
     ret slot.found;
 }
 
@@ -331,12 +331,12 @@ pub fun map_contains(this: &Map[K, V], key: &K) bool {
 # ---
 # key: Key to remove
 # ret: Ok(true) if removed, Ok(false) if key not found
-pub fun map_remove(this: *Map[K, V], key: &K) Result[bool, str] {
+pub fun map_remove[K, V](this: *Map[K, V], key: &K) Result[bool, str] {
     if (this.cap == 0) {
         ret ok[bool, str](false);
     }
 
-    val slot: rec { idx: usize; found: bool; } = map_find_slot(this, key);
+    val slot: rec { idx: usize; found: bool; } = map_find_slot[K, V](this, key);
 
     if (!slot.found) {
         ret ok[bool, str](false);
@@ -460,9 +460,9 @@ pub fun eq_u64(pa: ptr, pb: ptr) bool {
 test "map: init creates empty map" {
     var a: allocator.Allocator = allocator.page_allocator();
     val m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
-    if (!map_is_empty(m)) { ret 0; }
-    if (map_length(m) != 0) { ret 0; }
-    if (map_capacity(m) != 0) { ret 0; }
+    if (!map_is_empty[i64, i64](m)) { ret 0; }
+    if (map_length[i64, i64](m) != 0) { ret 0; }
+    if (map_capacity[i64, i64](m) != 0) { ret 0; }
     ret 1;
 }
 
@@ -470,19 +470,19 @@ test "map: insert and get" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    val r: Result[bool, str] = map_insert(?m, 42, 100);
-    if (result_is_err(r)) { ret 0; }
-    if (!result_unwrap_ok(r)) { ret 0; } # should be new insert
+    val r: Result[bool, str] = map_insert[i64, i64](?m, 42, 100);
+    if (result_is_err[bool, str](r)) { ret 0; }
+    if (!result_unwrap_ok[bool, str](r)) { ret 0; } # should be new insert
 
-    if (map_length(m) != 1) { ret 0; }
-    if (map_is_empty(m)) { ret 0; }
+    if (map_length[i64, i64](m) != 1) { ret 0; }
+    if (map_is_empty[i64, i64](m)) { ret 0; }
 
     val key: i64 = 42;
-    val gr: Result[*i64, str] = map_get(?m, ?key);
-    if (result_is_err(gr)) { ret 0; }
-    if (@result_unwrap_ok(gr) != 100) { ret 0; }
+    val gr: Result[*i64, str] = map_get[i64, i64](?m, ?key);
+    if (result_is_err[*i64, str](gr)) { ret 0; }
+    if (@result_unwrap_ok[*i64, str](gr) != 100) { ret 0; }
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -491,19 +491,19 @@ test "map: insert updates existing" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    map_insert(?m, 10, 100);
-    val r: Result[bool, str] = map_insert(?m, 10, 200);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r)) { ret 0; } # should be update, not new
+    map_insert[i64, i64](?m, 10, 100);
+    val r: Result[bool, str] = map_insert[i64, i64](?m, 10, 200);
+    if (result_is_err[bool, str](r)) { ret 0; }
+    if (result_unwrap_ok[bool, str](r)) { ret 0; } # should be update, not new
 
-    if (map_length(m) != 1) { ret 0; }
+    if (map_length[i64, i64](m) != 1) { ret 0; }
 
     val key: i64 = 10;
-    val gr: Result[*i64, str] = map_get(?m, ?key);
-    if (result_is_err(gr)) { ret 0; }
-    if (@result_unwrap_ok(gr) != 200) { ret 0; }
+    val gr: Result[*i64, str] = map_get[i64, i64](?m, ?key);
+    if (result_is_err[*i64, str](gr)) { ret 0; }
+    if (@result_unwrap_ok[*i64, str](gr) != 200) { ret 0; }
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -512,8 +512,8 @@ test "map: contains" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    map_insert(?m, 5, 50);
-    map_insert(?m, 10, 100);
+    map_insert[i64, i64](?m, 5, 50);
+    map_insert[i64, i64](?m, 10, 100);
 
     val k1: i64 = 5;
     val k2: i64 = 10;
@@ -523,7 +523,7 @@ test "map: contains" {
     if (!str_contains(m, ?k2)) { ret 0; }
     if (str_contains(m, ?k3)) { ret 0; }
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -532,18 +532,18 @@ test "map: remove" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    map_insert(?m, 1, 10);
-    map_insert(?m, 2, 20);
-    map_insert(?m, 3, 30);
+    map_insert[i64, i64](?m, 1, 10);
+    map_insert[i64, i64](?m, 2, 20);
+    map_insert[i64, i64](?m, 3, 30);
 
-    if (map_length(m) != 3) { ret 0; }
+    if (map_length[i64, i64](m) != 3) { ret 0; }
 
     val k2: i64 = 2;
-    val rr: Result[bool, str] = map_remove(?m, ?k2);
-    if (result_is_err(rr)) { ret 0; }
-    if (!result_unwrap_ok(rr)) { ret 0; }
+    val rr: Result[bool, str] = map_remove[i64, i64](?m, ?k2);
+    if (result_is_err[bool, str](rr)) { ret 0; }
+    if (!result_unwrap_ok[bool, str](rr)) { ret 0; }
 
-    if (map_length(m) != 2) { ret 0; }
+    if (map_length[i64, i64](m) != 2) { ret 0; }
     if (str_contains(m, ?k2)) { ret 0; }
 
     # other keys should still be there
@@ -552,7 +552,7 @@ test "map: remove" {
     if (!str_contains(m, ?k1)) { ret 0; }
     if (!str_contains(m, ?k3)) { ret 0; }
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -561,14 +561,14 @@ test "map: remove non-existent" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    map_insert(?m, 1, 10);
+    map_insert[i64, i64](?m, 1, 10);
 
     val k: i64 = 999;
-    val rr: Result[bool, str] = map_remove(?m, ?k);
-    if (result_is_err(rr)) { ret 0; }
-    if (result_unwrap_ok(rr)) { ret 0; } # should return false
+    val rr: Result[bool, str] = map_remove[i64, i64](?m, ?k);
+    if (result_is_err[bool, str](rr)) { ret 0; }
+    if (result_unwrap_ok[bool, str](rr)) { ret 0; } # should return false
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -577,13 +577,13 @@ test "map: get non-existent returns error" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    map_insert(?m, 1, 10);
+    map_insert[i64, i64](?m, 1, 10);
 
     val k: i64 = 999;
-    val gr: Result[*i64, str] = map_get(?m, ?k);
-    if (result_is_ok(gr)) { ret 0; }
+    val gr: Result[*i64, str] = map_get[i64, i64](?m, ?k);
+    if (result_is_ok[*i64, str](gr)) { ret 0; }
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -592,18 +592,18 @@ test "map: clear" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    map_insert(?m, 1, 10);
-    map_insert(?m, 2, 20);
-    map_insert(?m, 3, 30);
+    map_insert[i64, i64](?m, 1, 10);
+    map_insert[i64, i64](?m, 2, 20);
+    map_insert[i64, i64](?m, 3, 30);
 
-    val cap_before: usize = map_capacity(m);
-    map_clear(?m);
+    val cap_before: usize = map_capacity[i64, i64](m);
+    map_clear[i64, i64](?m);
 
-    if (map_length(m) != 0) { ret 0; }
-    if (!map_is_empty(m)) { ret 0; }
-    if (map_capacity(m) != cap_before) { ret 0; }
+    if (map_length[i64, i64](m) != 0) { ret 0; }
+    if (!map_is_empty[i64, i64](m)) { ret 0; }
+    if (map_capacity[i64, i64](m) != cap_before) { ret 0; }
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -615,24 +615,24 @@ test "map: many insertions trigger growth" {
     # insert many entries
     var i: i64 = 0;
     for (i < 100) {
-        val r: Result[bool, str] = map_insert(?m, i, i * 10);
-        if (result_is_err(r)) { ret 0; }
+        val r: Result[bool, str] = map_insert[i64, i64](?m, i, i * 10);
+        if (result_is_err[bool, str](r)) { ret 0; }
         i = i + 1;
     }
 
-    if (map_length(m) != 100) { ret 0; }
-    if (map_capacity(m) < 100) { ret 0; }
+    if (map_length[i64, i64](m) != 100) { ret 0; }
+    if (map_capacity[i64, i64](m) < 100) { ret 0; }
 
     # verify all entries
     var j: i64 = 0;
     for (j < 100) {
-        val gr: Result[*i64, str] = map_get(?m, ?j);
-        if (result_is_err(gr)) { ret 0; }
-        if (@result_unwrap_ok(gr) != j * 10) { ret 0; }
+        val gr: Result[*i64, str] = map_get[i64, i64](?m, ?j);
+        if (result_is_err[*i64, str](gr)) { ret 0; }
+        if (@result_unwrap_ok[*i64, str](gr) != j * 10) { ret 0; }
         j = j + 1;
     }
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -641,16 +641,16 @@ test "map: insert after remove reuses tombstone" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    map_insert(?m, 1, 10);
-    map_insert(?m, 2, 20);
+    map_insert[i64, i64](?m, 1, 10);
+    map_insert[i64, i64](?m, 2, 20);
 
     val k: i64 = 1;
-    map_remove(?m, ?k);
+    map_remove[i64, i64](?m, ?k);
 
     # insert new key
-    map_insert(?m, 3, 30);
+    map_insert[i64, i64](?m, 3, 30);
 
-    if (map_length(m) != 2) { ret 0; }
+    if (map_length[i64, i64](m) != 2) { ret 0; }
 
     val k2: i64 = 2;
     val k3: i64 = 3;
@@ -658,7 +658,7 @@ test "map: insert after remove reuses tombstone" {
     if (!str_contains(m, ?k3)) { ret 0; }
     if (str_contains(m, ?k)) { ret 0; }
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -666,7 +666,7 @@ test "map: insert after remove reuses tombstone" {
 test "map: dnit on empty map" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -675,27 +675,27 @@ test "map: string keys" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[str, i64] = init[str, i64](a, hash_str, eq_str);
 
-    map_insert(?m, "hello", 1);
-    map_insert(?m, "world", 2);
-    map_insert(?m, "foo", 3);
+    map_insert[str, i64](?m, "hello", 1);
+    map_insert[str, i64](?m, "world", 2);
+    map_insert[str, i64](?m, "foo", 3);
 
-    if (map_length(m) != 3) { ret 0; }
+    if (map_length[str, i64](m) != 3) { ret 0; }
 
     val k1: str = "hello";
     val k2: str = "world";
     val k3: str = "bar";
 
-    val r1: Result[*i64, str] = map_get(?m, ?k1);
-    if (result_is_err(r1)) { ret 0; }
-    if (@result_unwrap_ok(r1) != 1) { ret 0; }
+    val r1: Result[*i64, str] = map_get[str, i64](?m, ?k1);
+    if (result_is_err[*i64, str](r1)) { ret 0; }
+    if (@result_unwrap_ok[*i64, str](r1) != 1) { ret 0; }
 
-    val r2: Result[*i64, str] = map_get(?m, ?k2);
-    if (result_is_err(r2)) { ret 0; }
-    if (@result_unwrap_ok(r2) != 2) { ret 0; }
+    val r2: Result[*i64, str] = map_get[str, i64](?m, ?k2);
+    if (result_is_err[*i64, str](r2)) { ret 0; }
+    if (@result_unwrap_ok[*i64, str](r2) != 2) { ret 0; }
 
     if (str_contains(m, ?k3)) { ret 0; }
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[str, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -704,20 +704,20 @@ test "map: get allows mutation" {
     var a: allocator.Allocator = allocator.page_allocator();
     var m: Map[i64, i64] = init[i64, i64](a, hash_i64, eq_i64);
 
-    map_insert(?m, 42, 100);
+    map_insert[i64, i64](?m, 42, 100);
 
     val k: i64 = 42;
-    val r: Result[*i64, str] = map_get(?m, ?k);
-    if (result_is_err(r)) { ret 0; }
+    val r: Result[*i64, str] = map_get[i64, i64](?m, ?k);
+    if (result_is_err[*i64, str](r)) { ret 0; }
 
-    val p: *i64 = result_unwrap_ok(r);
+    val p: *i64 = result_unwrap_ok[*i64, str](r);
     @p = 999;
 
-    val r2: Result[*i64, str] = map_get(?m, ?k);
-    if (result_is_err(r2)) { ret 0; }
-    if (@result_unwrap_ok(r2) != 999) { ret 0; }
+    val r2: Result[*i64, str] = map_get[i64, i64](?m, ?k);
+    if (result_is_err[*i64, str](r2)) { ret 0; }
+    if (@result_unwrap_ok[*i64, str](r2) != 999) { ret 0; }
 
-    val ok: bool = map_dnit(?m);
+    val ok: bool = map_dnit[i64, i64](?m);
     if (!ok) { ret 0; }
     ret 1;
 }

--- a/src/collections/slice.mach
+++ b/src/collections/slice.mach
@@ -23,14 +23,14 @@ pub fun slice_make[T](data: *T, size: usize) Slice[T] {
 # Checks if the Slice[T] is empty.
 # ---
 # ret: true if the slice is empty, false otherwise.
-pub fun slice_is_empty(this: Slice[T]) bool {
+pub fun slice_is_empty[T](this: Slice[T]) bool {
     ret this.size == 0;
 }
 
 # Converts the Slice[T] to a View[T].
 # ---
 # ret: A View[T] representing the same data as the slice.
-pub fun slice_as_view(this: Slice[T]) View[T] {
+pub fun slice_as_view[T](this: Slice[T]) View[T] {
     var v: View[T];
     v.data = this.data;
     v.size = this.size;
@@ -50,14 +50,14 @@ test "slice: slice_make creates slice from pointer and size" {
 test "slice: is_empty returns true for zero size" {
     var arr: [4]i64 = [4]i64{1, 2, 3, 4};
     val s: Slice[i64] = slice_make[i64](?arr[0], 0);
-    if (!slice_is_empty(s)) { ret 0; }
+    if (!slice_is_empty[i64](s)) { ret 0; }
     ret 1;
 }
 
 test "slice: is_empty returns false for non-zero size" {
     var arr: [4]i64 = [4]i64{1, 2, 3, 4};
     val s: Slice[i64] = slice_make[i64](?arr[0], 4);
-    if (slice_is_empty(s)) { ret 0; }
+    if (slice_is_empty[i64](s)) { ret 0; }
     ret 1;
 }
 
@@ -81,7 +81,7 @@ test "slice: data is mutable via slice" {
 test "slice: as_view converts to view" {
     var arr: [3]i64 = [3]i64{5, 6, 7};
     val s: Slice[i64] = slice_make[i64](?arr[0], 3);
-    val v: View[i64] = slice_as_view(s);
+    val v: View[i64] = slice_as_view[i64](s);
     if (v.size != 3) { ret 0; }
     if (v.data == nil) { ret 0; }
     ret 1;
@@ -90,7 +90,7 @@ test "slice: as_view converts to view" {
 test "slice: as_view preserves data reference" {
     var arr: [2]i64 = [2]i64{42, 43};
     val s: Slice[i64] = slice_make[i64](?arr[0], 2);
-    val v: View[i64] = slice_as_view(s);
+    val v: View[i64] = slice_as_view[i64](s);
     if (v.data[0] != 42) { ret 0; }
     if (v.data[1] != 43) { ret 0; }
     ret 1;

--- a/src/collections/vector.mach
+++ b/src/collections/vector.mach
@@ -31,7 +31,7 @@ pub fun init[T](alloc: allocator.Allocator) Vector[T] {
 # Free the backing buffer and reset the vector fields
 # ---
 # ret: true if memory was freed successfully, false otherwise
-pub fun vector_deinit(this: *Vector[T]) bool {
+pub fun vector_deinit[T](this: *Vector[T]) bool {
     if (this == nil) { ret true; }
     if (this.cap == 0) {
         this.data = nil;
@@ -52,28 +52,28 @@ pub fun vector_deinit(this: *Vector[T]) bool {
 # Check if the vector is empty
 # ---
 # ret: true if the vector has no elements, false otherwise
-pub fun vector_is_empty(this: Vector[T]) bool {
+pub fun vector_is_empty[T](this: Vector[T]) bool {
     ret this.len == 0;
 }
 
 # Return the current number of elements in the vector
 # ---
 # ret: Number of elements (usize)
-pub fun vector_length(this: Vector[T]) usize {
+pub fun vector_length[T](this: Vector[T]) usize {
     ret this.len;
 }
 
 # Return the current capacity in elements
 # ---
 # ret: Capacity in elements (usize)
-pub fun vector_capacity(this: Vector[T]) usize {
+pub fun vector_capacity[T](this: Vector[T]) usize {
     ret this.cap;
 }
 
 # Clear the vector contents but keep allocated capacity
 # ---
 # ret: None
-pub fun vector_clear(this: *Vector[T]) {
+pub fun vector_clear[T](this: *Vector[T]) {
     if (this == nil) { ret; }
     this.len = 0;
 }
@@ -82,7 +82,7 @@ pub fun vector_clear(this: *Vector[T]) {
 # ---
 # additional: Number of extra elements to reserve space for
 # ret: Ok(new capacity) or Err(error message)
-pub fun vector_reserve(this: *Vector[T], additional: usize) Result[usize, str] {
+pub fun vector_reserve[T](this: *Vector[T], additional: usize) Result[usize, str] {
     if (this == nil) { ret err[usize, str]("vector is nil"); }
 
     val required: usize = this.len + additional;
@@ -111,11 +111,11 @@ pub fun vector_reserve(this: *Vector[T], additional: usize) Result[usize, str] {
     }
 
     val r: Result[*T, allocator.AllocError] = allocator.allocator_resize[T](this.alloc, this.data, this.cap, new_cap);
-    if (result_is_err(r)) {
-        ret err[usize, str](result_unwrap_err(r));
+    if (result_is_err[*T, allocator.AllocError](r)) {
+        ret err[usize, str](result_unwrap_err[*T, allocator.AllocError](r));
     }
 
-    this.data = result_unwrap_ok(r);
+    this.data = result_unwrap_ok[*T, allocator.AllocError](r);
     this.cap = new_cap;
 
     ret ok[usize, str](this.cap);
@@ -125,10 +125,10 @@ pub fun vector_reserve(this: *Vector[T], additional: usize) Result[usize, str] {
 # ---
 # value: Value to append
 # ret: Ok(new length) or Err(error message)
-pub fun vector_push(this: *Vector[T], value: T) Result[usize, str] {
-    val r: Result[usize, str] = vector_reserve(this, 1);
-    if (result_is_err(r)) {
-        ret err[usize, str](result_unwrap_err(r));
+pub fun vector_push[T](this: *Vector[T], value: T) Result[usize, str] {
+    val r: Result[usize, str] = vector_reserve[T](this, 1);
+    if (result_is_err[usize, str](r)) {
+        ret err[usize, str](result_unwrap_err[usize, str](r));
     }
 
     this.data[this.len] = value;
@@ -139,7 +139,7 @@ pub fun vector_push(this: *Vector[T], value: T) Result[usize, str] {
 # Pop the last element from the vector
 # ---
 # ret: Ok(value) or Err(error message if vector is empty)
-pub fun vector_pop(this: *Vector[T]) Result[T, str] {
+pub fun vector_pop[T](this: *Vector[T]) Result[T, str] {
     if (this.len == 0) {
         ret err[T, str]("pop from empty vector");
     }
@@ -152,7 +152,7 @@ pub fun vector_pop(this: *Vector[T]) Result[T, str] {
 # ---
 # index: Element index
 # ret: Ok(pointer) or Err("index out of bounds")
-pub fun vector_get(this: &Vector[T], index: usize) Result[*T, str] {
+pub fun vector_get[T](this: &Vector[T], index: usize) Result[*T, str] {
     if (index >= this.len) {
         ret err[*T, str]("index out of bounds");
     }
@@ -163,7 +163,7 @@ pub fun vector_get(this: &Vector[T], index: usize) Result[*T, str] {
 # ---
 # index: Element index
 # ret: Ok(reference) or Err("index out of bounds")
-pub fun vector_get_ref(this: Vector[T], index: usize) Result[&T, str] {
+pub fun vector_get_ref[T](this: Vector[T], index: usize) Result[&T, str] {
     if (index >= this.len) {
         ret err[&T, str]("index out of bounds");
     }
@@ -175,9 +175,9 @@ pub fun vector_get_ref(this: Vector[T], index: usize) Result[&T, str] {
 test "vector: init creates empty vector" {
     var a: allocator.Allocator = allocator.page_allocator();
     val v: Vector[i64] = init[i64](a);
-    if (!vector_is_empty(v)) { ret 0; }
-    if (vector_length(v) != 0) { ret 0; }
-    if (vector_capacity(v) != 0) { ret 0; }
+    if (!vector_is_empty[i64](v)) { ret 0; }
+    if (vector_length[i64](v) != 0) { ret 0; }
+    if (vector_capacity[i64](v) != 0) { ret 0; }
     ret 1;
 }
 
@@ -185,12 +185,12 @@ test "vector: push adds element" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    val r: Result[usize, str] = vector_push(?v, 42);
-    if (result_is_err(r)) { ret 0; }
-    if (vector_length(v) != 1) { ret 0; }
-    if (vector_is_empty(v)) { ret 0; }
+    val r: Result[usize, str] = vector_push[i64](?v, 42);
+    if (result_is_err[usize, str](r)) { ret 0; }
+    if (vector_length[i64](v) != 1) { ret 0; }
+    if (vector_is_empty[i64](v)) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -200,16 +200,16 @@ test "vector: push multiple elements" {
     var v: Vector[i64] = init[i64](a);
 
     var r: Result[usize, str];
-    r = vector_push(?v, 10);
-    if (result_is_err(r)) { ret 0; }
-    r = vector_push(?v, 20);
-    if (result_is_err(r)) { ret 0; }
-    r = vector_push(?v, 30);
-    if (result_is_err(r)) { ret 0; }
+    r = vector_push[i64](?v, 10);
+    if (result_is_err[usize, str](r)) { ret 0; }
+    r = vector_push[i64](?v, 20);
+    if (result_is_err[usize, str](r)) { ret 0; }
+    r = vector_push[i64](?v, 30);
+    if (result_is_err[usize, str](r)) { ret 0; }
 
-    if (vector_length(v) != 3) { ret 0; }
+    if (vector_length[i64](v) != 3) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -218,16 +218,16 @@ test "vector: pop returns last element" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    vector_push(?v, 100);
-    vector_push(?v, 200);
-    vector_push(?v, 300);
+    vector_push[i64](?v, 100);
+    vector_push[i64](?v, 200);
+    vector_push[i64](?v, 300);
 
-    val r: Result[i64, str] = vector_pop(?v);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 300) { ret 0; }
-    if (vector_length(v) != 2) { ret 0; }
+    val r: Result[i64, str] = vector_pop[i64](?v);
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != 300) { ret 0; }
+    if (vector_length[i64](v) != 2) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -236,10 +236,10 @@ test "vector: pop from empty returns error" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    val r: Result[i64, str] = vector_pop(?v);
-    if (result_is_ok(r)) { ret 0; }
+    val r: Result[i64, str] = vector_pop[i64](?v);
+    if (result_is_ok[i64, str](r)) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -248,16 +248,16 @@ test "vector: get returns pointer to element" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    vector_push(?v, 111);
-    vector_push(?v, 222);
-    vector_push(?v, 333);
+    vector_push[i64](?v, 111);
+    vector_push[i64](?v, 222);
+    vector_push[i64](?v, 333);
 
-    val r: Result[*i64, str] = vector_get(?v, 1);
-    if (result_is_err(r)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(r);
+    val r: Result[*i64, str] = vector_get[i64](?v, 1);
+    if (result_is_err[*i64, str](r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, str](r);
     if (@p != 222) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -266,12 +266,12 @@ test "vector: get out of bounds returns error" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    vector_push(?v, 42);
+    vector_push[i64](?v, 42);
 
-    val r: Result[*i64, str] = vector_get(?v, 5);
-    if (result_is_ok(r)) { ret 0; }
+    val r: Result[*i64, str] = vector_get[i64](?v, 5);
+    if (result_is_ok[*i64, str](r)) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -280,18 +280,18 @@ test "vector: get allows mutation" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    vector_push(?v, 100);
+    vector_push[i64](?v, 100);
 
-    val r: Result[*i64, str] = vector_get(?v, 0);
-    if (result_is_err(r)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(r);
+    val r: Result[*i64, str] = vector_get[i64](?v, 0);
+    if (result_is_err[*i64, str](r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, str](r);
     @p = 999;
 
-    val r2: Result[*i64, str] = vector_get(?v, 0);
-    if (result_is_err(r2)) { ret 0; }
-    if (@result_unwrap_ok(r2) != 999) { ret 0; }
+    val r2: Result[*i64, str] = vector_get[i64](?v, 0);
+    if (result_is_err[*i64, str](r2)) { ret 0; }
+    if (@result_unwrap_ok[*i64, str](r2) != 999) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -300,15 +300,15 @@ test "vector: get_ref returns immutable reference" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    vector_push(?v, 555);
-    vector_push(?v, 666);
+    vector_push[i64](?v, 555);
+    vector_push[i64](?v, 666);
 
-    val r: Result[&i64, str] = vector_get_ref(v, 1);
-    if (result_is_err(r)) { ret 0; }
-    val ref: &i64 = result_unwrap_ok(r);
+    val r: Result[&i64, str] = vector_get_ref[i64](v, 1);
+    if (result_is_err[&i64, str](r)) { ret 0; }
+    val ref: &i64 = result_unwrap_ok[&i64, str](r);
     if (@ref != 666) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -317,12 +317,12 @@ test "vector: get_ref out of bounds returns error" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    vector_push(?v, 42);
+    vector_push[i64](?v, 42);
 
-    val r: Result[&i64, str] = vector_get_ref(v, 10);
-    if (result_is_ok(r)) { ret 0; }
+    val r: Result[&i64, str] = vector_get_ref[i64](v, 10);
+    if (result_is_ok[&i64, str](r)) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -331,12 +331,12 @@ test "vector: reserve increases capacity" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    val r: Result[usize, str] = vector_reserve(?v, 100);
-    if (result_is_err(r)) { ret 0; }
-    if (vector_capacity(v) < 100) { ret 0; }
-    if (vector_length(v) != 0) { ret 0; }
+    val r: Result[usize, str] = vector_reserve[i64](?v, 100);
+    if (result_is_err[usize, str](r)) { ret 0; }
+    if (vector_capacity[i64](v) < 100) { ret 0; }
+    if (vector_length[i64](v) != 0) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -345,15 +345,15 @@ test "vector: reserve when already sufficient is noop" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    vector_reserve(?v, 50);
-    val cap1: usize = vector_capacity(v);
+    vector_reserve[i64](?v, 50);
+    val cap1: usize = vector_capacity[i64](v);
 
-    vector_reserve(?v, 10);
-    val cap2: usize = vector_capacity(v);
+    vector_reserve[i64](?v, 10);
+    val cap2: usize = vector_capacity[i64](v);
 
     if (cap2 != cap1) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -362,18 +362,18 @@ test "vector: clear resets length but keeps capacity" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    vector_push(?v, 1);
-    vector_push(?v, 2);
-    vector_push(?v, 3);
-    val cap_before: usize = vector_capacity(v);
+    vector_push[i64](?v, 1);
+    vector_push[i64](?v, 2);
+    vector_push[i64](?v, 3);
+    val cap_before: usize = vector_capacity[i64](v);
 
-    vector_clear(?v);
+    vector_clear[i64](?v);
 
-    if (vector_length(v) != 0) { ret 0; }
-    if (!vector_is_empty(v)) { ret 0; }
-    if (vector_capacity(v) != cap_before) { ret 0; }
+    if (vector_length[i64](v) != 0) { ret 0; }
+    if (!vector_is_empty[i64](v)) { ret 0; }
+    if (vector_capacity[i64](v) != cap_before) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -381,7 +381,7 @@ test "vector: clear resets length but keeps capacity" {
 test "vector: deinit on empty vector succeeds" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -393,24 +393,24 @@ test "vector: push triggers capacity growth" {
     # push many elements to trigger growth
     var i: i64 = 0;
     for (i < 100) {
-        val r: Result[usize, str] = vector_push(?v, i);
-        if (result_is_err(r)) { ret 0; }
+        val r: Result[usize, str] = vector_push[i64](?v, i);
+        if (result_is_err[usize, str](r)) { ret 0; }
         i = i + 1;
     }
 
-    if (vector_length(v) != 100) { ret 0; }
-    if (vector_capacity(v) < 100) { ret 0; }
+    if (vector_length[i64](v) != 100) { ret 0; }
+    if (vector_capacity[i64](v) < 100) { ret 0; }
 
     # verify all values
     var j: usize = 0;
     for (j < 100) {
-        val r: Result[&i64, str] = vector_get_ref(v, j);
-        if (result_is_err(r)) { ret 0; }
-        if (@result_unwrap_ok(r) != j::i64) { ret 0; }
+        val r: Result[&i64, str] = vector_get_ref[i64](v, j);
+        if (result_is_err[&i64, str](r)) { ret 0; }
+        if (@result_unwrap_ok[&i64, str](r) != j::i64) { ret 0; }
         j = j + 1;
     }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -419,33 +419,33 @@ test "vector: push and pop sequence" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
 
-    vector_push(?v, 1);
-    vector_push(?v, 2);
-    vector_push(?v, 3);
+    vector_push[i64](?v, 1);
+    vector_push[i64](?v, 2);
+    vector_push[i64](?v, 3);
 
     var r: Result[i64, str];
 
-    r = vector_pop(?v);
-    if (result_unwrap_ok(r) != 3) { ret 0; }
+    r = vector_pop[i64](?v);
+    if (result_unwrap_ok[i64, str](r) != 3) { ret 0; }
 
-    vector_push(?v, 4);
-    vector_push(?v, 5);
+    vector_push[i64](?v, 4);
+    vector_push[i64](?v, 5);
 
-    r = vector_pop(?v);
-    if (result_unwrap_ok(r) != 5) { ret 0; }
+    r = vector_pop[i64](?v);
+    if (result_unwrap_ok[i64, str](r) != 5) { ret 0; }
 
-    r = vector_pop(?v);
-    if (result_unwrap_ok(r) != 4) { ret 0; }
+    r = vector_pop[i64](?v);
+    if (result_unwrap_ok[i64, str](r) != 4) { ret 0; }
 
-    r = vector_pop(?v);
-    if (result_unwrap_ok(r) != 2) { ret 0; }
+    r = vector_pop[i64](?v);
+    if (result_unwrap_ok[i64, str](r) != 2) { ret 0; }
 
-    r = vector_pop(?v);
-    if (result_unwrap_ok(r) != 1) { ret 0; }
+    r = vector_pop[i64](?v);
+    if (result_unwrap_ok[i64, str](r) != 1) { ret 0; }
 
-    if (!vector_is_empty(v)) { ret 0; }
+    if (!vector_is_empty[i64](v)) { ret 0; }
 
-    val ok: bool = vector_deinit(?v);
+    val ok: bool = vector_deinit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }

--- a/src/collections/view.mach
+++ b/src/collections/view.mach
@@ -22,7 +22,7 @@ pub fun view_make[T](data: &T, size: usize) View[T] {
 # Checks if the View[T] is empty.
 # ---
 # ret: true if the view is empty, false otherwise.
-pub fun view_is_empty(this: View[T]) bool {
+pub fun view_is_empty[T](this: View[T]) bool {
     ret this.size == 0;
 }
 
@@ -39,14 +39,14 @@ test "view: view_make creates view from pointer and size" {
 test "view: is_empty returns true for zero size" {
     var arr: [4]i64 = [4]i64{1, 2, 3, 4};
     val v: View[i64] = view_make[i64](?arr[0], 0);
-    if (!view_is_empty(v)) { ret 0; }
+    if (!view_is_empty[i64](v)) { ret 0; }
     ret 1;
 }
 
 test "view: is_empty returns false for non-zero size" {
     var arr: [4]i64 = [4]i64{1, 2, 3, 4};
     val v: View[i64] = view_make[i64](?arr[0], 4);
-    if (view_is_empty(v)) { ret 0; }
+    if (view_is_empty[i64](v)) { ret 0; }
     ret 1;
 }
 
@@ -70,6 +70,6 @@ test "view: view of u8 bytes" {
 
 test "view: nil data with zero size is empty" {
     val v: View[i64] = view_make[i64](nil, 0);
-    if (!view_is_empty(v)) { ret 0; }
+    if (!view_is_empty[i64](v)) { ret 0; }
     ret 1;
 }

--- a/src/data/toml.mach
+++ b/src/data/toml.mach
@@ -75,11 +75,11 @@ fun alloc_copy(a: *Allocator, src: str, start: usize, len: usize) Result[str, st
     }
 
     val r: Result[*u8, AllocError] = allocator_alloc[u8](a, len + 1);
-    if (result_is_err(r)) {
-        ret err[str, str](result_unwrap_err(r));
+    if (result_is_err[*u8, AllocError](r)) {
+        ret err[str, str](result_unwrap_err[*u8, AllocError](r));
     }
 
-    val buf: *u8 = result_unwrap_ok(r);
+    val buf: *u8 = result_unwrap_ok[*u8, AllocError](r);
     mem.raw_copy(buf::ptr, (src::usize + start)::ptr, len);
     buf[len] = 0;
     ret ok[str, str](buf::&u8);
@@ -96,11 +96,11 @@ fun concat_key(a: *Allocator, prefix: str, key: str) Result[str, str] {
     # prefix + '.' + key
     val out_len: usize = p_len + 1 + k_len;
     val r: Result[*u8, AllocError] = allocator_alloc[u8](a, out_len + 1);
-    if (result_is_err(r)) {
-        ret err[str, str](result_unwrap_err(r));
+    if (result_is_err[*u8, AllocError](r)) {
+        ret err[str, str](result_unwrap_err[*u8, AllocError](r));
     }
 
-    val buf: *u8 = result_unwrap_ok(r);
+    val buf: *u8 = result_unwrap_ok[*u8, AllocError](r);
     mem.raw_copy(buf::ptr, prefix::ptr, p_len);
     buf[p_len] = 46;
     mem.raw_copy((buf::usize + p_len + 1)::ptr, key::ptr, k_len);
@@ -118,10 +118,10 @@ fun push_entry(a: *Allocator, entries: *Entry, cap: *usize, len: *usize, e: Entr
     if (@cap == 0) {
         @cap = 16;
         val r: Result[*Entry, AllocError] = allocator_alloc[Entry](a, @cap);
-        if (result_is_err(r)) {
-            ret err[*Entry, str](result_unwrap_err(r));
+        if (result_is_err[*Entry, AllocError](r)) {
+            ret err[*Entry, str](result_unwrap_err[*Entry, AllocError](r));
         }
-        out = result_unwrap_ok(r);
+        out = result_unwrap_ok[*Entry, AllocError](r);
     } or (out == nil) {
         ret err[*Entry, str]("internal error");
     }
@@ -130,10 +130,10 @@ fun push_entry(a: *Allocator, entries: *Entry, cap: *usize, len: *usize, e: Entr
         val old: usize = @cap;
         val new_cap: usize = old * 2;
         val r2: Result[*Entry, AllocError] = allocator_resize[Entry](a, out, old, new_cap);
-        if (result_is_err(r2)) {
-            ret err[*Entry, str](result_unwrap_err(r2));
+        if (result_is_err[*Entry, AllocError](r2)) {
+            ret err[*Entry, str](result_unwrap_err[*Entry, AllocError](r2));
         }
-        out = result_unwrap_ok(r2);
+        out = result_unwrap_ok[*Entry, AllocError](r2);
         @cap = new_cap;
     }
 
@@ -178,11 +178,11 @@ fun parse_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
 
     # allocate
     val r: Result[*u8, AllocError] = allocator_alloc[u8](a, out_len + 1);
-    if (result_is_err(r)) {
-        ret err[str, str](result_unwrap_err(r));
+    if (result_is_err[*u8, AllocError](r)) {
+        ret err[str, str](result_unwrap_err[*u8, AllocError](r));
     }
 
-    val buf: *u8 = result_unwrap_ok(r);
+    val buf: *u8 = result_unwrap_ok[*u8, AllocError](r);
 
     # pass 2: copy/translate
     var si: usize = start;
@@ -286,20 +286,20 @@ fun parse_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
     val b: u8 = src[@i];
     if (b == 34) {
         val r: Result[str, str] = parse_string(a, src, i);
-        if (result_is_err(r)) { ret err[Value, str](result_unwrap_err(r)); }
-        ret ok[Value, str](Value{string: result_unwrap_ok(r)});
+        if (result_is_err[str, str](r)) { ret err[Value, str](result_unwrap_err[str, str](r)); }
+        ret ok[Value, str](Value{string: result_unwrap_ok[str, str](r)});
     }
 
     if (b == 45 || (b >= 48 && b <= 57)) {
         val r: Result[i64, str] = parse_int(src, i);
-        if (result_is_err(r)) { ret err[Value, str](result_unwrap_err(r)); }
-        ret ok[Value, str](Value{integer: result_unwrap_ok(r)});
+        if (result_is_err[i64, str](r)) { ret err[Value, str](result_unwrap_err[i64, str](r)); }
+        ret ok[Value, str](Value{integer: result_unwrap_ok[i64, str](r)});
     }
 
     if (b == 116 || b == 102) {
         val r: Result[bool, str] = parse_bool(src, i);
-        if (result_is_err(r)) { ret err[Value, str](result_unwrap_err(r)); }
-        ret ok[Value, str](Value{boolean: result_unwrap_ok(r)});
+        if (result_is_err[bool, str](r)) { ret err[Value, str](result_unwrap_err[bool, str](r)); }
+        ret ok[Value, str](Value{boolean: result_unwrap_ok[bool, str](r)});
     }
 
     if (b == 91) {
@@ -319,25 +319,25 @@ fun parse_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
             }
 
             val vr: Result[Value, str] = parse_value(a, src, i);
-            if (result_is_err(vr)) {
-                ret err[Value, str](result_unwrap_err(vr));
+            if (result_is_err[Value, str](vr)) {
+                ret err[Value, str](result_unwrap_err[Value, str](vr));
             }
 
             if (cap == 0) {
                 cap = 8;
                 val r0: Result[*Value, AllocError] = allocator_alloc[Value](a, cap);
-                if (result_is_err(r0)) { ret err[Value, str](result_unwrap_err(r0)); }
-                items = result_unwrap_ok(r0);
+                if (result_is_err[*Value, AllocError](r0)) { ret err[Value, str](result_unwrap_err[*Value, AllocError](r0)); }
+                items = result_unwrap_ok[*Value, AllocError](r0);
             } or (len >= cap) {
                 val old: usize = cap;
                 val new_cap: usize = cap * 2;
                 val r1: Result[*Value, AllocError] = allocator_resize[Value](a, items, old, new_cap);
-                if (result_is_err(r1)) { ret err[Value, str](result_unwrap_err(r1)); }
-                items = result_unwrap_ok(r1);
+                if (result_is_err[*Value, AllocError](r1)) { ret err[Value, str](result_unwrap_err[*Value, AllocError](r1)); }
+                items = result_unwrap_ok[*Value, AllocError](r1);
                 cap = new_cap;
             }
 
-            items[len] = result_unwrap_ok(vr);
+            items[len] = result_unwrap_ok[Value, str](vr);
             len = len + 1;
 
             skip_ws_and_comments(src, i);
@@ -406,11 +406,11 @@ pub fun parse(a: *Allocator, src: str) Result[Document, str] {
             }
 
             val r: Result[str, str] = alloc_copy(a, src, start, end - start);
-            if (result_is_err(r)) {
-                ret err[Document, str](result_unwrap_err(r));
+            if (result_is_err[str, str](r)) {
+                ret err[Document, str](result_unwrap_err[str, str](r));
             }
 
-            prefix = result_unwrap_ok(r);
+            prefix = result_unwrap_ok[str, str](r);
 
             # consume ']'
             i = i + 1;
@@ -428,8 +428,8 @@ pub fun parse(a: *Allocator, src: str) Result[Document, str] {
 
         # trim key trailing spaces (shouldn't happen for is_ident loop)
         val key_r: Result[str, str] = alloc_copy(a, src, key_start, i - key_start);
-        if (result_is_err(key_r)) {
-            ret err[Document, str](result_unwrap_err(key_r));
+        if (result_is_err[str, str](key_r)) {
+            ret err[Document, str](result_unwrap_err[str, str](key_r));
         }
 
         skip_ws_and_comments(src, ?i);
@@ -439,21 +439,21 @@ pub fun parse(a: *Allocator, src: str) Result[Document, str] {
         i = i + 1;
 
         val vr: Result[Value, str] = parse_value(a, src, ?i);
-        if (result_is_err(vr)) {
-            ret err[Document, str](result_unwrap_err(vr));
+        if (result_is_err[Value, str](vr)) {
+            ret err[Document, str](result_unwrap_err[Value, str](vr));
         }
 
-        val full_key_r: Result[str, str] = concat_key(a, prefix, result_unwrap_ok(key_r));
-        if (result_is_err(full_key_r)) {
-            ret err[Document, str](result_unwrap_err(full_key_r));
+        val full_key_r: Result[str, str] = concat_key(a, prefix, result_unwrap_ok[str, str](key_r));
+        if (result_is_err[str, str](full_key_r)) {
+            ret err[Document, str](result_unwrap_err[str, str](full_key_r));
         }
 
-        val pr: Result[*Entry, str] = push_entry(a, entries, ?cap, ?len, Entry{key: result_unwrap_ok(full_key_r), value: result_unwrap_ok(vr)});
-        if (result_is_err(pr)) {
-            ret err[Document, str](result_unwrap_err(pr));
+        val pr: Result[*Entry, str] = push_entry(a, entries, ?cap, ?len, Entry{key: result_unwrap_ok[str, str](full_key_r), value: result_unwrap_ok[Value, str](vr)});
+        if (result_is_err[*Entry, str](pr)) {
+            ret err[Document, str](result_unwrap_err[*Entry, str](pr));
         }
 
-        entries = result_unwrap_ok(pr);
+        entries = result_unwrap_ok[*Entry, str](pr);
 
         # consume rest of line
         for (src[i] != 0 && src[i] != 10) {

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -252,11 +252,11 @@ pub fun stat_path(path: str) Result[Stat, str] {
 # ret: true if directory, false otherwise
 pub fun is_dir(path: str) bool {
     val st_res: Result[Stat, str] = stat_path(path);
-    if (result_is_err(st_res)) {
+    if (result_is_err[Stat, str](st_res)) {
         ret false;
     }
 
-    val st: Stat = result_unwrap_ok(st_res);
+    val st: Stat = result_unwrap_ok[Stat, str](st_res);
     ret (st.st_mode & c.S_IFMT) == c.S_IFDIR;
 }
 
@@ -266,11 +266,11 @@ pub fun is_dir(path: str) bool {
 # ret: true if regular file, false otherwise
 pub fun is_file(path: str) bool {
     val st_res: Result[Stat, str] = stat_path(path);
-    if (result_is_err(st_res)) {
+    if (result_is_err[Stat, str](st_res)) {
         ret false;
     }
 
-    val st: Stat = result_unwrap_ok(st_res);
+    val st: Stat = result_unwrap_ok[Stat, str](st_res);
     ret (st.st_mode & c.S_IFMT) == c.S_IFREG;
 }
 
@@ -328,28 +328,28 @@ pub fun create_dir_all(path_str: str, mode: i32) Result[bool, str] {
     }
 
     val create_res: Result[bool, str] = create_dir(path_str, mode);
-    if (result_is_ok(create_res)) {
+    if (result_is_ok[bool, str](create_res)) {
         ret create_res;
     }
 
     var a: allocator.Allocator = allocator.default();
     val parent_res: Result[path.Path, allocator.AllocError] = path.parent(?a, path_str);
-    if (result_is_err(parent_res)) {
-        ret err[bool, str](result_unwrap_err(parent_res));
+    if (result_is_err[path.Path, allocator.AllocError](parent_res)) {
+        ret err[bool, str](result_unwrap_err[path.Path, allocator.AllocError](parent_res));
     }
 
-    val parent_path: path.Path = result_unwrap_ok(parent_res);
+    val parent_path: path.Path = result_unwrap_ok[path.Path, allocator.AllocError](parent_res);
     val parent_create_res: Result[bool, str] = create_dir_all(parent_path, mode);
 
     val parent_len: usize = str_len(parent_path);
     allocator_free[u8](a, parent_path::ptr::*u8, parent_len + 1);
 
-    if (result_is_err(parent_create_res)) {
+    if (result_is_err[bool, str](parent_create_res)) {
         ret parent_create_res;
     }
 
     val final_res: Result[bool, str] = create_dir(path_str, mode);
-    if (result_is_ok(final_res)) {
+    if (result_is_ok[bool, str](final_res)) {
         ret final_res;
     }
 
@@ -507,7 +507,7 @@ pub fun temp_file_close_and_remove(this: *TempFile) Result[bool, str] {
     val close_res: Result[bool, str] = file_close(this);
     val remove_res: Result[bool, str] = temp_file_remove(this);
 
-    if (result_is_err(close_res)) {
+    if (result_is_err[bool, str](close_res)) {
         ret close_res;
     }
     ret remove_res;
@@ -517,8 +517,8 @@ pub fun temp_file_close_and_remove(this: *TempFile) Result[bool, str] {
 
 test "filesystem: temp_create creates file" {
     val r: Result[TempFile, str] = temp_create("test");
-    if (result_is_err(r)) { ret 0; }
-    var tf: TempFile = result_unwrap_ok(r);
+    if (result_is_err[TempFile, str](r)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok[TempFile, str](r);
 
     # file should have valid fd
     if (tf.file.fd < 0) { ret 2; }
@@ -528,14 +528,14 @@ test "filesystem: temp_create creates file" {
 
     # clean up
     val cr: Result[bool, str] = temp_file_close_and_remove(?tf);
-    if (result_is_err(cr)) { ret 4; }
+    if (result_is_err[bool, str](cr)) { ret 4; }
     ret 1;
 }
 
 test "filesystem: temp_create path is valid" {
     val r: Result[TempFile, str] = temp_create("myprefix");
-    if (result_is_err(r)) { ret 0; }
-    var tf: TempFile = result_unwrap_ok(r);
+    if (result_is_err[TempFile, str](r)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok[TempFile, str](r);
 
     val p: str = temp_file_path(?tf);
     if (p == nil) { ret 2; }
@@ -552,24 +552,24 @@ test "filesystem: temp_create path is valid" {
 
 test "filesystem: temp file write and read" {
     val r: Result[TempFile, str] = temp_create("rw");
-    if (result_is_err(r)) { ret 0; }
-    var tf: TempFile = result_unwrap_ok(r);
+    if (result_is_err[TempFile, str](r)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok[TempFile, str](r);
 
     # write some data
     val data: str = "hello temp file";
     val wr: Result[usize, str] = file_write(?tf.file, data, str_len(data));
-    if (result_is_err(wr)) { ret 2; }
-    if (result_unwrap_ok(wr) != str_len(data)) { ret 3; }
+    if (result_is_err[usize, str](wr)) { ret 2; }
+    if (result_unwrap_ok[usize, str](wr) != str_len(data)) { ret 3; }
 
     # seek back to start
     val sr: Result[i64, str] = file_seek(?tf.file, 0, c.SEEK_SET);
-    if (result_is_err(sr)) { ret 4; }
+    if (result_is_err[i64, str](sr)) { ret 4; }
 
     # read back
     var buf: [64]u8;
     val rr: Result[usize, str] = file_read(?tf.file, ?buf[0], 64);
-    if (result_is_err(rr)) { ret 5; }
-    if (result_unwrap_ok(rr) != str_len(data)) { ret 6; }
+    if (result_is_err[usize, str](rr)) { ret 5; }
+    if (result_unwrap_ok[usize, str](rr) != str_len(data)) { ret 6; }
 
     # verify content
     val read_str: str = ?buf[0];
@@ -581,49 +581,49 @@ test "filesystem: temp file write and read" {
 
 test "filesystem: temp file close then remove" {
     val r: Result[TempFile, str] = temp_create("closeremove");
-    if (result_is_err(r)) { ret 0; }
-    var tf: TempFile = result_unwrap_ok(r);
+    if (result_is_err[TempFile, str](r)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok[TempFile, str](r);
 
     val cr: Result[bool, str] = file_close(?tf);
-    if (result_is_err(cr)) { ret 2; }
+    if (result_is_err[bool, str](cr)) { ret 2; }
 
     val rr: Result[bool, str] = temp_file_remove(?tf);
-    if (result_is_err(rr)) { ret 3; }
+    if (result_is_err[bool, str](rr)) { ret 3; }
 
     ret 1;
 }
 
 test "filesystem: open non-existent file returns error" {
     val r: Result[File, str] = open("/tmp/this_file_should_not_exist_12345");
-    if (result_is_ok(r)) { ret 0; }
+    if (result_is_ok[File, str](r)) { ret 0; }
     ret 1;
 }
 
 test "filesystem: create write close open read" {
     # create a temp file
     val cr: Result[TempFile, str] = temp_create("fullcycle");
-    if (result_is_err(cr)) { ret 0; }
-    var tf: TempFile = result_unwrap_ok(cr);
+    if (result_is_err[TempFile, str](cr)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok[TempFile, str](cr);
 
     # write data
     val data: str = "test data 12345";
     val wr: Result[usize, str] = file_write(?tf.file, data, str_len(data));
-    if (result_is_err(wr)) { ret 2; }
+    if (result_is_err[usize, str](wr)) { ret 2; }
 
     # close
     val clr: Result[bool, str] = file_close(?tf);
-    if (result_is_err(clr)) { ret 3; }
+    if (result_is_err[bool, str](clr)) { ret 3; }
 
     # open again for reading
     val open_res: Result[File, str] = open(temp_file_path(?tf));
-    if (result_is_err(open_res)) { ret 4; }
-    var f: File = result_unwrap_ok(open_res);
+    if (result_is_err[File, str](open_res)) { ret 4; }
+    var f: File = result_unwrap_ok[File, str](open_res);
 
     # read
     var buf: [64]u8;
     val rr: Result[usize, str] = file_read(?f, ?buf[0], 64);
-    if (result_is_err(rr)) { ret 5; }
-    if (result_unwrap_ok(rr) != str_len(data)) { ret 6; }
+    if (result_is_err[usize, str](rr)) { ret 5; }
+    if (result_unwrap_ok[usize, str](rr) != str_len(data)) { ret 6; }
 
     # close and cleanup
     file_close(?f);
@@ -633,8 +633,8 @@ test "filesystem: create write close open read" {
 
 test "filesystem: stat returns valid metadata" {
     val cr: Result[TempFile, str] = temp_create("stat");
-    if (result_is_err(cr)) { ret 0; }
-    var tf: TempFile = result_unwrap_ok(cr);
+    if (result_is_err[TempFile, str](cr)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok[TempFile, str](cr);
 
     # write some data
     val data: str = "some content";
@@ -642,8 +642,8 @@ test "filesystem: stat returns valid metadata" {
 
     # get stat
     val sr: Result[Stat, str] = file_stat(?tf.file);
-    if (result_is_err(sr)) { ret 2; }
-    val st: Stat = result_unwrap_ok(sr);
+    if (result_is_err[Stat, str](sr)) { ret 2; }
+    val st: Stat = result_unwrap_ok[Stat, str](sr);
 
     # size should match what we wrote
     if (st.st_size != str_len(data)::i64) { ret 3; }
@@ -654,8 +654,8 @@ test "filesystem: stat returns valid metadata" {
 
 test "filesystem: seek repositions file offset" {
     val cr: Result[TempFile, str] = temp_create("seek");
-    if (result_is_err(cr)) { ret 0; }
-    var tf: TempFile = result_unwrap_ok(cr);
+    if (result_is_err[TempFile, str](cr)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok[TempFile, str](cr);
 
     # write data
     val data: str = "0123456789";
@@ -663,14 +663,14 @@ test "filesystem: seek repositions file offset" {
 
     # seek to position 5
     val sr: Result[i64, str] = file_seek(?tf.file, 5, c.SEEK_SET);
-    if (result_is_err(sr)) { ret 2; }
-    if (result_unwrap_ok(sr) != 5) { ret 3; }
+    if (result_is_err[i64, str](sr)) { ret 2; }
+    if (result_unwrap_ok[i64, str](sr) != 5) { ret 3; }
 
     # read from position 5
     var buf: [10]u8;
     val rr: Result[usize, str] = file_read(?tf.file, ?buf[0], 10);
-    if (result_is_err(rr)) { ret 4; }
-    if (result_unwrap_ok(rr) != 5) { ret 5; } # should read "56789"
+    if (result_is_err[usize, str](rr)) { ret 4; }
+    if (result_unwrap_ok[usize, str](rr) != 5) { ret 5; } # should read "56789"
 
     if (buf[0] != 53) { ret 6; } # '5'
     if (buf[4] != 57) { ret 7; } # '9'
@@ -681,19 +681,19 @@ test "filesystem: seek repositions file offset" {
 
 test "filesystem: unlink removes file" {
     val cr: Result[TempFile, str] = temp_create("unlink");
-    if (result_is_err(cr)) { ret 0; }
-    var tf: TempFile = result_unwrap_ok(cr);
+    if (result_is_err[TempFile, str](cr)) { ret 0; }
+    var tf: TempFile = result_unwrap_ok[TempFile, str](cr);
     val p: str = temp_file_path(?tf);
 
     file_close(?tf);
 
     # unlink the file
     val ur: Result[bool, str] = unlink(p);
-    if (result_is_err(ur)) { ret 2; }
+    if (result_is_err[bool, str](ur)) { ret 2; }
 
     # try to open - should fail
     val open_res: Result[File, str] = open(p);
-    if (result_is_ok(open_res)) { ret 3; }
+    if (result_is_ok[File, str](open_res)) { ret 3; }
 
     ret 1;
 }

--- a/src/fmt.mach
+++ b/src/fmt.mach
@@ -94,13 +94,13 @@ pub fun write_i64(w: *stream.Writer, n: i64) Result[usize, str] {
     }
 
     val r1: Result[usize, str] = write_byte(w, 45); # '-'
-    if (result_is_err(r1)) { ret r1; }
+    if (result_is_err[usize, str](r1)) { ret r1; }
 
     val pos: i64 = 0 - n;
     val r2: Result[usize, str] = write_u64(w, pos::u64);
-    if (result_is_err(r2)) { ret r2; }
+    if (result_is_err[usize, str](r2)) { ret r2; }
 
-    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
+    ret ok[usize, str](result_unwrap_ok[usize, str](r1) + result_unwrap_ok[usize, str](r2));
 }
 
 # write_hex_u64: write a 64-bit value in hexadecimal.
@@ -148,12 +148,12 @@ pub fun write_hex_u64(w: *stream.Writer, n: u64, upper: bool) Result[usize, str]
 # ret: Ok(number of bytes written) on success or Err(str) on error.
 pub fun write_ptr(w: *stream.Writer, p: ptr) Result[usize, str] {
     val r1: Result[usize, str] = write_str(w, "0x");
-    if (result_is_err(r1)) { ret r1; }
+    if (result_is_err[usize, str](r1)) { ret r1; }
 
     val r2: Result[usize, str] = write_hex_u64(w, p::usize::u64, false);
-    if (result_is_err(r2)) { ret r2; }
+    if (result_is_err[usize, str](r2)) { ret r2; }
 
-    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
+    ret ok[usize, str](result_unwrap_ok[usize, str](r1) + result_unwrap_ok[usize, str](r2));
 }
 
 # ERR_BAD_FORMAT: returned when a format string is invalid.
@@ -179,8 +179,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         val b: u8 = format[i];
         if (b != 37) { # '%'
             val r: Result[usize, str] = write_byte(w, b);
-            if (result_is_err(r)) { ret r; }
-            total = total + result_unwrap_ok(r);
+            if (result_is_err[usize, str](r)) { ret r; }
+            total = total + result_unwrap_ok[usize, str](r);
             i = i + 1;
             cnt;
         }
@@ -194,8 +194,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
 
         if (c == 37) { # '%%'
             val r: Result[usize, str] = write_byte(w, 37);
-            if (result_is_err(r)) { ret r; }
-            total = total + result_unwrap_ok(r);
+            if (result_is_err[usize, str](r)) { ret r; }
+            total = total + result_unwrap_ok[usize, str](r);
             i = i + 1;
             cnt;
         }
@@ -203,8 +203,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 115) { # %s
             val arg: str = va_arg[str](ap);
             val r: Result[usize, str] = write_str(w, arg);
-            if (result_is_err(r)) { ret r; }
-            total = total + result_unwrap_ok(r);
+            if (result_is_err[usize, str](r)) { ret r; }
+            total = total + result_unwrap_ok[usize, str](r);
             i = i + 1;
             cnt;
         }
@@ -212,8 +212,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 100) { # %d
             val arg: i64 = va_arg[i64](ap);
             val r: Result[usize, str] = write_i64(w, arg);
-            if (result_is_err(r)) { ret r; }
-            total = total + result_unwrap_ok(r);
+            if (result_is_err[usize, str](r)) { ret r; }
+            total = total + result_unwrap_ok[usize, str](r);
             i = i + 1;
             cnt;
         }
@@ -221,8 +221,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 117) { # %u
             val arg: u64 = va_arg[u64](ap);
             val r: Result[usize, str] = write_u64(w, arg);
-            if (result_is_err(r)) { ret r; }
-            total = total + result_unwrap_ok(r);
+            if (result_is_err[usize, str](r)) { ret r; }
+            total = total + result_unwrap_ok[usize, str](r);
             i = i + 1;
             cnt;
         }
@@ -230,8 +230,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 120) { # %x
             val arg: u64 = va_arg[u64](ap);
             val r: Result[usize, str] = write_hex_u64(w, arg, false);
-            if (result_is_err(r)) { ret r; }
-            total = total + result_unwrap_ok(r);
+            if (result_is_err[usize, str](r)) { ret r; }
+            total = total + result_unwrap_ok[usize, str](r);
             i = i + 1;
             cnt;
         }
@@ -239,8 +239,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 88) { # %X
             val arg: u64 = va_arg[u64](ap);
             val r: Result[usize, str] = write_hex_u64(w, arg, true);
-            if (result_is_err(r)) { ret r; }
-            total = total + result_unwrap_ok(r);
+            if (result_is_err[usize, str](r)) { ret r; }
+            total = total + result_unwrap_ok[usize, str](r);
             i = i + 1;
             cnt;
         }
@@ -248,8 +248,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 99) { # %c
             val arg: u8 = va_arg[u8](ap);
             val r: Result[usize, str] = write_byte(w, arg);
-            if (result_is_err(r)) { ret r; }
-            total = total + result_unwrap_ok(r);
+            if (result_is_err[usize, str](r)) { ret r; }
+            total = total + result_unwrap_ok[usize, str](r);
             i = i + 1;
             cnt;
         }
@@ -257,8 +257,8 @@ pub fun vformat(w: *stream.Writer, format: str, ap: *va_list, ...) Result[usize,
         if (c == 112) { # %p
             val arg: ptr = va_arg[ptr](ap);
             val r: Result[usize, str] = write_ptr(w, arg);
-            if (result_is_err(r)) { ret r; }
-            total = total + result_unwrap_ok(r);
+            if (result_is_err[usize, str](r)) { ret r; }
+            total = total + result_unwrap_ok[usize, str](r);
             i = i + 1;
             cnt;
         }

--- a/src/print.mach
+++ b/src/print.mach
@@ -27,12 +27,12 @@ pub fun println(s: str) Result[usize, str] {
     var w: stream.Writer = stdio.stdout();
 
     val r1: Result[usize, str] = f.write_str(?w, s);
-    if (result_is_err(r1)) { ret r1; }
+    if (result_is_err[usize, str](r1)) { ret r1; }
 
     val r2: Result[usize, str] = f.write_newline(?w);
-    if (result_is_err(r2)) { ret r2; }
+    if (result_is_err[usize, str](r2)) { ret r2; }
 
-    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
+    ret ok[usize, str](result_unwrap_ok[usize, str](r1) + result_unwrap_ok[usize, str](r2));
 }
 
 # eprint: write `s` to stderr.
@@ -52,12 +52,12 @@ pub fun eprintln(s: str) Result[usize, str] {
     var w: stream.Writer = stdio.stderr();
 
     val r1: Result[usize, str] = f.write_str(?w, s);
-    if (result_is_err(r1)) { ret r1; }
+    if (result_is_err[usize, str](r1)) { ret r1; }
 
     val r2: Result[usize, str] = f.write_newline(?w);
-    if (result_is_err(r2)) { ret r2; }
+    if (result_is_err[usize, str](r2)) { ret r2; }
 
-    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
+    ret ok[usize, str](result_unwrap_ok[usize, str](r1) + result_unwrap_ok[usize, str](r2));
 }
 
 # u64: write unsigned 64-bit integer n to stdout.
@@ -119,12 +119,12 @@ pub fun printlnf(format: str, ...) Result[usize, str] {
     va_start(?ap);
     val r1: Result[usize, str] = f.vformat(?w, format, ?ap);
     va_end(?ap);
-    if (result_is_err(r1)) { ret r1; }
+    if (result_is_err[usize, str](r1)) { ret r1; }
 
     val r2: Result[usize, str] = f.write_newline(?w);
-    if (result_is_err(r2)) { ret r2; }
+    if (result_is_err[usize, str](r2)) { ret r2; }
 
-    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
+    ret ok[usize, str](result_unwrap_ok[usize, str](r1) + result_unwrap_ok[usize, str](r2));
 }
 
 # eprintlnf: formatted output to stderr followed by a newline.
@@ -138,10 +138,10 @@ pub fun eprintlnf(format: str, ...) Result[usize, str] {
     va_start(?ap);
     val r1: Result[usize, str] = f.vformat(?w, format, ?ap);
     va_end(?ap);
-    if (result_is_err(r1)) { ret r1; }
+    if (result_is_err[usize, str](r1)) { ret r1; }
 
     val r2: Result[usize, str] = f.write_newline(?w);
-    if (result_is_err(r2)) { ret r2; }
+    if (result_is_err[usize, str](r2)) { ret r2; }
 
-    ret ok[usize, str](result_unwrap_ok(r1) + result_unwrap_ok(r2));
+    ret ok[usize, str](result_unwrap_ok[usize, str](r1) + result_unwrap_ok[usize, str](r2));
 }

--- a/src/stream.mach
+++ b/src/stream.mach
@@ -110,9 +110,9 @@ pub fun write_all(w: *Writer, buf: &u8, len: usize) Result[usize, str] {
     for (total < len) {
         val p: &u8 = (buf::usize + total)::&u8;
         val r: Result[usize, str] = writer_write(?w, p, len - total);
-        if (result_is_err(r)) { ret r; }
+        if (result_is_err[usize, str](r)) { ret r; }
 
-        val wrote: usize = result_unwrap_ok(r);
+        val wrote: usize = result_unwrap_ok[usize, str](r);
         if (wrote == 0) { ret err[usize, str](ERR_SHORT_WRITE); }
 
         total = total + wrote;
@@ -133,9 +133,9 @@ pub fun read_exact(r: *Reader, buf: *u8, len: usize) Result[usize, str] {
     for (total < len) {
         val p: *u8 = (buf::usize + total)::*u8;
         val res: Result[usize, str] = reader_read(?r, p, len - total);
-        if (result_is_err(res)) { ret res; }
+        if (result_is_err[usize, str](res)) { ret res; }
 
-        val got: usize = result_unwrap_ok(res);
+        val got: usize = result_unwrap_ok[usize, str](res);
         if (got == 0) { ret err[usize, str](ERR_EOF); }
 
         total = total + got;

--- a/src/text/buffer_writer.mach
+++ b/src/text/buffer_writer.mach
@@ -156,8 +156,8 @@ test "buffer_writer: basic write" {
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
     val r: Result[usize, str] = bw_write(w, "hello", 5);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 5) { ret 2; }
+    if (result_is_err[usize, str](r)) { ret 0; }
+    if (result_unwrap_ok[usize, str](r) != 5) { ret 2; }
     if (bw_length(w) != 5) { ret 3; }
     ret 1;
 }
@@ -169,8 +169,8 @@ test "buffer_writer: write_byte" {
     val r1: Result[usize, str] = bw_write_byte(w, 65); # 'A'
     val r2: Result[usize, str] = bw_write_byte(w, 66); # 'B'
 
-    if (result_is_err(r1)) { ret 0; }
-    if (result_is_err(r2)) { ret 2; }
+    if (result_is_err[usize, str](r1)) { ret 0; }
+    if (result_is_err[usize, str](r2)) { ret 2; }
     if (bw_length(w) != 2) { ret 3; }
     if (buf[0] != 65) { ret 4; }
     if (buf[1] != 66) { ret 5; }
@@ -182,8 +182,8 @@ test "buffer_writer: write_str" {
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
     val r: Result[usize, str] = bw_write_str(w, "hello world");
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 11) { ret 2; }
+    if (result_is_err[usize, str](r)) { ret 0; }
+    if (result_unwrap_ok[usize, str](r) != 11) { ret 2; }
     if (bw_length(w) != 11) { ret 3; }
     ret 1;
 }
@@ -193,10 +193,10 @@ test "buffer_writer: buffer full error" {
     var w: BufferWriter = buffer_writer(?buf[0], 4);
 
     val r1: Result[usize, str] = bw_write(w, "ab", 2);
-    if (result_is_err(r1)) { ret 0; }
+    if (result_is_err[usize, str](r1)) { ret 0; }
 
     val r2: Result[usize, str] = bw_write(w, "cdef", 4);
-    if (result_is_ok(r2)) { ret 2; } # should fail
+    if (result_is_ok[usize, str](r2)) { ret 2; } # should fail
 
     if (bw_length(w) != 2) { ret 3; } # should still be 2
     ret 1;
@@ -209,7 +209,7 @@ test "buffer_writer: remaining" {
     if (bw_remaining(w) != 64) { ret 0; }
 
     val r: Result[usize, str] = bw_write(w, "hello", 5);
-    if (result_is_err(r)) { ret 2; }
+    if (result_is_err[usize, str](r)) { ret 2; }
 
     if (bw_remaining(w) != 59) { ret 3; }
     ret 1;
@@ -220,7 +220,7 @@ test "buffer_writer: reset" {
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
     val r: Result[usize, str] = bw_write(w, "hello", 5);
-    if (result_is_err(r)) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
     if (bw_length(w) != 5) { ret 2; }
 
     bw_reset(w);
@@ -234,7 +234,7 @@ test "buffer_writer: c_str null terminates" {
     var w: BufferWriter = buffer_writer(?buf[0], 64);
 
     val r: Result[usize, str] = bw_write(w, "test", 4);
-    if (result_is_err(r)) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
 
     val s: str = bw_c_str(w);
     if (s == nil) { ret 2; }
@@ -250,8 +250,8 @@ test "buffer_writer: write nil string" {
 
     val s: str = nil;
     val r: Result[usize, str] = bw_write_str(w, s);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 0) { ret 2; }
+    if (result_is_err[usize, str](r)) { ret 0; }
+    if (result_unwrap_ok[usize, str](r) != 0) { ret 2; }
     if (bw_length(w) != 0) { ret 3; }
     ret 1;
 }
@@ -264,9 +264,9 @@ test "buffer_writer: multiple writes" {
     val r2: Result[usize, str] = bw_write_str(w, " ");
     val r3: Result[usize, str] = bw_write_str(w, "world");
 
-    if (result_is_err(r1)) { ret 0; }
-    if (result_is_err(r2)) { ret 2; }
-    if (result_is_err(r3)) { ret 3; }
+    if (result_is_err[usize, str](r1)) { ret 0; }
+    if (result_is_err[usize, str](r2)) { ret 2; }
+    if (result_is_err[usize, str](r3)) { ret 3; }
     if (bw_length(w) != 11) { ret 4; }
 
     val s: str = bw_c_str(w);
@@ -280,7 +280,7 @@ test "buffer_writer: exact capacity" {
     var w: BufferWriter = buffer_writer(?buf[0], 5);
 
     val r: Result[usize, str] = bw_write(w, "hello", 5);
-    if (result_is_err(r)) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
     if (bw_length(w) != 5) { ret 2; }
     if (bw_remaining(w) != 0) { ret 3; }
 

--- a/src/text/builder.mach
+++ b/src/text/builder.mach
@@ -108,9 +108,9 @@ pub fun builder_reserve(this: *Builder, additional: usize) Result[usize, str] {
     }
 
     val r: Result[*u8, allocator.AllocError] = (allocator.allocator_resize[u8](?this.alloc), this.buf, this.cap, new_cap);
-    if (result_is_err(r)) { ret err[usize, str](result_unwrap_err(r)); }
+    if (result_is_err[*u8, allocator.AllocError](r)) { ret err[usize, str](result_unwrap_err[*u8, allocator.AllocError](r)); }
 
-    this.buf = result_unwrap_ok(r);
+    this.buf = result_unwrap_ok[*u8, allocator.AllocError](r);
     this.cap = new_cap;
     this.buf[this.len] = 0;
 
@@ -123,7 +123,7 @@ pub fun builder_reserve(this: *Builder, additional: usize) Result[usize, str] {
 # ret: Ok(new length) or Err(error message)
 pub fun builder_append_byte(this: *Builder, b: u8) Result[usize, str] {
     val r: Result[usize, str] = builder_reserve(this, 1);
-    if (result_is_err(r)) { ret err[usize, str](result_unwrap_err(r)); }
+    if (result_is_err[usize, str](r)) { ret err[usize, str](result_unwrap_err[usize, str](r)); }
 
     this.buf[this.len] = b;
     this.len = this.len + 1;
@@ -140,7 +140,7 @@ pub fun builder_append_bytes(this: *Builder, p: &u8, n: usize) Result[usize, str
     if (n == 0) { ret ok[usize, str](this.len); }
 
     val r: Result[usize, str] = builder_reserve(this, n);
-    if (result_is_err(r)) { ret err[usize, str](result_unwrap_err(r)); }
+    if (result_is_err[usize, str](r)) { ret err[usize, str](result_unwrap_err[usize, str](r)); }
 
     mem.raw_copy((this.buf::usize + this.len)::ptr, p::ptr, n);
     this.len = this.len + n;
@@ -184,7 +184,7 @@ test "builder: append_byte adds single byte" {
     var b: Builder = init(a);
 
     val r: Result[usize, str] = builder_append_byte(?b, 65);
-    if (result_is_err(r)) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
     if (builder_length(b) != 1) { ret 0; }
 
     val ok: bool = builder_deinit(?b);
@@ -211,7 +211,7 @@ test "builder: append_str adds string" {
     var b: Builder = init(a);
 
     val r: Result[usize, str] = builder_append_str(?b, "hello");
-    if (result_is_err(r)) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
     if (builder_length(b) != 5) { ret 0; }
 
     val ok: bool = builder_deinit(?b);
@@ -241,7 +241,7 @@ test "builder: append_bytes adds raw bytes" {
 
     var data: [3]u8 = [3]u8{65, 66, 67};
     val r: Result[usize, str] = builder_append_bytes(?b, ?data[0], 3);
-    if (result_is_err(r)) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
     if (builder_length(b) != 3) { ret 0; }
 
     val ok: bool = builder_deinit(?b);
@@ -273,8 +273,8 @@ test "builder: c_str returns null-terminated string" {
     builder_append_str(?b, "hello");
 
     val r: Result[str, str] = builder_c_str(?b);
-    if (result_is_err(r)) { ret 0; }
-    val s: str = result_unwrap_ok(r);
+    if (result_is_err[str, str](r)) { ret 0; }
+    val s: str = result_unwrap_ok[str, str](r);
     if (!str_equals(s, "hello")) { ret 0; }
     if (str_len(s) != 5) { ret 0; }
 
@@ -288,8 +288,8 @@ test "builder: c_str on empty builder returns empty string" {
     var b: Builder = init(a);
 
     val r: Result[str, str] = builder_c_str(?b);
-    if (result_is_err(r)) { ret 0; }
-    val s: str = result_unwrap_ok(r);
+    if (result_is_err[str, str](r)) { ret 0; }
+    val s: str = result_unwrap_ok[str, str](r);
     if (str_len(s) != 0) { ret 0; }
 
     val ok: bool = builder_deinit(?b);
@@ -302,7 +302,7 @@ test "builder: reserve increases capacity" {
     var b: Builder = init(a);
 
     val r: Result[usize, str] = builder_reserve(?b, 100);
-    if (result_is_err(r)) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
     if (builder_capacity(b) < 100) { ret 0; }
     if (builder_length(b) != 0) { ret 0; }
 
@@ -354,8 +354,8 @@ test "builder: clear then append reuses buffer" {
     builder_append_str(?b, "second");
 
     val r: Result[str, str] = builder_c_str(?b);
-    if (result_is_err(r)) { ret 0; }
-    if (!result_unwrap_ok(str_equals(r), "second")) { ret 0; }
+    if (result_is_err[str, str](r)) { ret 0; }
+    if (!str_equals(result_unwrap_ok[str, str](r), "second")) { ret 0; }
 
     val ok: bool = builder_deinit(?b);
     if (!ok) { ret 0; }
@@ -379,8 +379,8 @@ test "builder: multiple appends build string" {
     builder_append_str(?b, "world");
 
     val r: Result[str, str] = builder_c_str(?b);
-    if (result_is_err(r)) { ret 0; }
-    val s: str = result_unwrap_ok(r);
+    if (result_is_err[str, str](r)) { ret 0; }
+    val s: str = result_unwrap_ok[str, str](r);
     if (!str_equals(s, "hello world")) { ret 0; }
     if (str_len(s) != 11) { ret 0; }
 

--- a/src/text/parse.mach
+++ b/src/text/parse.mach
@@ -157,11 +157,11 @@ pub fun parse_i64(s: str, base: u8) Result[i64, str] {
     val remaining: str = (?s[i])::str;
     val u_result: Result[u64, str] = parse_u64(remaining, base);
 
-    if (result_is_err(u_result)) {
-        ret err[i64, str](result_unwrap_err(u_result));
+    if (result_is_err[u64, str](u_result)) {
+        ret err[i64, str](result_unwrap_err[u64, str](u_result));
     }
 
-    val u_val: u64 = result_unwrap_ok(u_result);
+    val u_val: u64 = result_unwrap_ok[u64, str](u_result);
 
     # i64 range: -9223372036854775808 to 9223372036854775807
     if (negative) {
@@ -188,193 +188,193 @@ pub fun parse_i64(s: str, base: u8) Result[i64, str] {
 
 test "parse: u64 decimal simple" {
     val r: Result[u64, str] = parse_u64("12345", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 12345) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 12345) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 decimal zero" {
     val r: Result[u64, str] = parse_u64("0", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 0) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 0) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 hex lowercase" {
     val r: Result[u64, str] = parse_u64("ff", 16);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 255) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 255) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 hex uppercase" {
     val r: Result[u64, str] = parse_u64("FF", 16);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 255) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 255) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 binary" {
     val r: Result[u64, str] = parse_u64("1010", 2);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 10) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 10) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 octal" {
     val r: Result[u64, str] = parse_u64("77", 8);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 63) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 63) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 auto-detect hex" {
     val r: Result[u64, str] = parse_u64("0xff", 0);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 255) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 255) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 auto-detect binary" {
     val r: Result[u64, str] = parse_u64("0b1010", 0);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 10) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 10) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 auto-detect octal" {
     val r: Result[u64, str] = parse_u64("0o77", 0);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 63) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 63) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 auto-detect decimal" {
     val r: Result[u64, str] = parse_u64("999", 0);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 999) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 999) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 with underscores" {
     val r: Result[u64, str] = parse_u64("1_000_000", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 1000000) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 1000000) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 max value" {
     val r: Result[u64, str] = parse_u64("18446744073709551615", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 18446744073709551615) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 18446744073709551615) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 overflow" {
     val r: Result[u64, str] = parse_u64("18446744073709551616", 10);
-    if (result_is_ok(r)) { ret 0; }
+    if (result_is_ok[u64, str](r)) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 empty string" {
     val r: Result[u64, str] = parse_u64("", 10);
-    if (result_is_ok(r)) { ret 0; }
+    if (result_is_ok[u64, str](r)) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 invalid digit" {
     val r: Result[u64, str] = parse_u64("12g45", 10);
     # should parse up to 'g' and return 12
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 12) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 12) { ret 0; }
     ret 1;
 }
 
 test "parse: u64 leading whitespace" {
     val r: Result[u64, str] = parse_u64("  42", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 42) { ret 0; }
+    if (result_is_err[u64, str](r)) { ret 0; }
+    if (result_unwrap_ok[u64, str](r) != 42) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 positive" {
     val r: Result[i64, str] = parse_i64("12345", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 12345) { ret 0; }
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != 12345) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 negative" {
     val r: Result[i64, str] = parse_i64("-12345", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != -12345) { ret 0; }
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != -12345) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 explicit positive" {
     val r: Result[i64, str] = parse_i64("+42", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 42) { ret 0; }
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != 42) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 zero" {
     val r: Result[i64, str] = parse_i64("0", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 0) { ret 0; }
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != 0) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 negative zero" {
     val r: Result[i64, str] = parse_i64("-0", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 0) { ret 0; }
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != 0) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 max value" {
     val r: Result[i64, str] = parse_i64("9223372036854775807", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 9223372036854775807) { ret 0; }
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != 9223372036854775807) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 min value" {
     val r: Result[i64, str] = parse_i64("-9223372036854775808", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != -9223372036854775808) { ret 0; }
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != -9223372036854775808) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 overflow positive" {
     val r: Result[i64, str] = parse_i64("9223372036854775808", 10);
-    if (result_is_ok(r)) { ret 0; }
+    if (result_is_ok[i64, str](r)) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 overflow negative" {
     val r: Result[i64, str] = parse_i64("-9223372036854775809", 10);
-    if (result_is_ok(r)) { ret 0; }
+    if (result_is_ok[i64, str](r)) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 hex with sign" {
     val r: Result[i64, str] = parse_i64("-0xff", 0);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != -255) { ret 0; }
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != -255) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 with underscores" {
     val r: Result[i64, str] = parse_i64("-1_000_000", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != -1000000) { ret 0; }
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != -1000000) { ret 0; }
     ret 1;
 }
 
 test "parse: i64 leading whitespace" {
     val r: Result[i64, str] = parse_i64("  -42", 10);
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != -42) { ret 0; }
+    if (result_is_err[i64, str](r)) { ret 0; }
+    if (result_unwrap_ok[i64, str](r) != -42) { ret 0; }
     ret 1;
 }

--- a/src/types/option.mach
+++ b/src/types/option.mach
@@ -9,21 +9,21 @@ pub rec Option[T] {
 # Unwraps the Option[T], returning the contained value.
 # ---
 # ret: The contained value.
-pub fun option_unwrap(this: Option[T]) T {
+pub fun option_unwrap[T](this: Option[T]) T {
     ret this.value;
 }
 
 # Checks if the Option[T] is none (no value present).
 # ---
 # ret: true if no value is present, false otherwise.
-pub fun option_is_none(this: Option[T]) bool {
+pub fun option_is_none[T](this: Option[T]) bool {
     ret this.has_value == false;
 }
 
 # Checks if the Option[T] is some (value is present).
 # ---
 # ret: true if a value is present, false otherwise.
-pub fun option_is_some(this: Option[T]) bool {
+pub fun option_is_some[T](this: Option[T]) bool {
     ret this.has_value == true;
 }
 
@@ -51,70 +51,70 @@ pub fun none[T]() Option[T] {
 
 test "option: some creates value with is_some true" {
     val opt: Option[i64] = some[i64](42);
-    if (!option_is_some(opt)) { ret 0; }
+    if (!option_is_some[i64](opt)) { ret 0; }
     ret 1;
 }
 
 test "option: some creates value with is_none false" {
     val opt: Option[i64] = some[i64](42);
-    if (option_is_none(opt)) { ret 0; }
+    if (option_is_none[i64](opt)) { ret 0; }
     ret 1;
 }
 
 test "option: none creates value with is_none true" {
     val opt: Option[i64] = none[i64]();
-    if (!option_is_none(opt)) { ret 0; }
+    if (!option_is_none[i64](opt)) { ret 0; }
     ret 1;
 }
 
 test "option: none creates value with is_some false" {
     val opt: Option[i64] = none[i64]();
-    if (option_is_some(opt)) { ret 0; }
+    if (option_is_some[i64](opt)) { ret 0; }
     ret 1;
 }
 
 test "option: unwrap returns contained value" {
     val opt: Option[i64] = some[i64](123);
-    val v: i64 = option_unwrap(opt);
+    val v: i64 = option_unwrap[i64](opt);
     if (v != 123) { ret 0; }
     ret 1;
 }
 
 test "option: some with zero value" {
     val opt: Option[i64] = some[i64](0);
-    if (!option_is_some(opt)) { ret 0; }
-    if (option_unwrap(opt) != 0) { ret 0; }
+    if (!option_is_some[i64](opt)) { ret 0; }
+    if (option_unwrap[i64](opt) != 0) { ret 0; }
     ret 1;
 }
 
 test "option: some with negative value" {
     val opt: Option[i64] = some[i64](-999);
-    if (!option_is_some(opt)) { ret 0; }
-    if (option_unwrap(opt) != -999) { ret 0; }
+    if (!option_is_some[i64](opt)) { ret 0; }
+    if (option_unwrap[i64](opt) != -999) { ret 0; }
     ret 1;
 }
 
 test "option: some with pointer type" {
     var x: i64 = 42;
     val opt: Option[*i64] = some[*i64](?x);
-    if (!option_is_some(opt)) { ret 0; }
-    val p: *i64 = option_unwrap(opt);
+    if (!option_is_some[*i64](opt)) { ret 0; }
+    val p: *i64 = option_unwrap[*i64](opt);
     if (@p != 42) { ret 0; }
     ret 1;
 }
 
 test "option: none with pointer type" {
     val opt: Option[*i64] = none[*i64]();
-    if (!option_is_none(opt)) { ret 0; }
+    if (!option_is_none[*i64](opt)) { ret 0; }
     ret 1;
 }
 
 test "option: some with bool type" {
     val opt_true: Option[bool] = some[bool](true);
     val opt_false: Option[bool] = some[bool](false);
-    if (!option_is_some(opt_true)) { ret 0; }
-    if (!option_is_some(opt_false)) { ret 0; }
-    if (option_unwrap(opt_true) != true) { ret 0; }
-    if (option_unwrap(opt_false) != false) { ret 0; }
+    if (!option_is_some[bool](opt_true)) { ret 0; }
+    if (!option_is_some[bool](opt_false)) { ret 0; }
+    if (option_unwrap[bool](opt_true) != true) { ret 0; }
+    if (option_unwrap[bool](opt_false) != false) { ret 0; }
     ret 1;
 }

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -59,11 +59,11 @@ pub fun clone(a: *Allocator, p: Path) Result[Path, AllocError] {
 
     val n: usize = str_len(p);
     val r: Result[*u8, AllocError] = allocator_alloc[u8](a, n + 1);
-    if (result_is_err(r)) {
-        ret err[Path, AllocError](result_unwrap_err(r));
+    if (result_is_err[*u8, AllocError](r)) {
+        ret err[Path, AllocError](result_unwrap_err[*u8, AllocError](r));
     }
 
-    val buf: *u8 = result_unwrap_ok(r);
+    val buf: *u8 = result_unwrap_ok[*u8, AllocError](r);
     mem.raw_copy(buf::ptr, p::ptr, n);
     buf[n] = 0;
     ret ok[Path, AllocError](buf::&u8);
@@ -108,11 +108,11 @@ pub fun join(a: *Allocator, left: Path, right: Path) Result[Path, AllocError] {
 
     val out_len: usize = left_len + right_len + extra;
     val r: Result[*u8, AllocError] = allocator_alloc[u8](a, out_len + 1);
-    if (result_is_err(r)) {
-        ret err[Path, AllocError](result_unwrap_err(r));
+    if (result_is_err[*u8, AllocError](r)) {
+        ret err[Path, AllocError](result_unwrap_err[*u8, AllocError](r));
     }
 
-    val buf: *u8 = result_unwrap_ok(r);
+    val buf: *u8 = result_unwrap_ok[*u8, AllocError](r);
     mem.raw_copy(buf::ptr, left::ptr, left_len);
 
     var off: usize = left_len;
@@ -155,10 +155,10 @@ pub fun parent(a: *Allocator, p: Path) Result[Path, AllocError] {
     if (end == 0) {
         # path was all separators (root)
         val r: Result[*u8, AllocError] = allocator_alloc[u8](a, 2);
-        if (result_is_err(r)) {
-            ret err[Path, AllocError](result_unwrap_err(r));
+        if (result_is_err[*u8, AllocError](r)) {
+            ret err[Path, AllocError](result_unwrap_err[*u8, AllocError](r));
         }
-        val buf: *u8 = result_unwrap_ok(r);
+        val buf: *u8 = result_unwrap_ok[*u8, AllocError](r);
         buf[0] = sep;
         buf[1] = 0;
         ret ok[Path, AllocError](buf::&u8);
@@ -181,10 +181,10 @@ pub fun parent(a: *Allocator, p: Path) Result[Path, AllocError] {
     if (i == 0 && p[0] == sep) {
         # separator at start only, parent is root
         val r: Result[*u8, AllocError] = allocator_alloc[u8](a, 2);
-        if (result_is_err(r)) {
-            ret err[Path, AllocError](result_unwrap_err(r));
+        if (result_is_err[*u8, AllocError](r)) {
+            ret err[Path, AllocError](result_unwrap_err[*u8, AllocError](r));
         }
-        val buf: *u8 = result_unwrap_ok(r);
+        val buf: *u8 = result_unwrap_ok[*u8, AllocError](r);
         buf[0] = sep;
         buf[1] = 0;
         ret ok[Path, AllocError](buf::&u8);
@@ -199,10 +199,10 @@ pub fun parent(a: *Allocator, p: Path) Result[Path, AllocError] {
     if (parent_end == 0) {
         # parent is root
         val r: Result[*u8, AllocError] = allocator_alloc[u8](a, 2);
-        if (result_is_err(r)) {
-            ret err[Path, AllocError](result_unwrap_err(r));
+        if (result_is_err[*u8, AllocError](r)) {
+            ret err[Path, AllocError](result_unwrap_err[*u8, AllocError](r));
         }
-        val buf: *u8 = result_unwrap_ok(r);
+        val buf: *u8 = result_unwrap_ok[*u8, AllocError](r);
         buf[0] = sep;
         buf[1] = 0;
         ret ok[Path, AllocError](buf::&u8);
@@ -210,10 +210,10 @@ pub fun parent(a: *Allocator, p: Path) Result[Path, AllocError] {
 
     # allocate and copy parent portion
     val r: Result[*u8, AllocError] = allocator_alloc[u8](a, parent_end + 1);
-    if (result_is_err(r)) {
-        ret err[Path, AllocError](result_unwrap_err(r));
+    if (result_is_err[*u8, AllocError](r)) {
+        ret err[Path, AllocError](result_unwrap_err[*u8, AllocError](r));
     }
-    val buf: *u8 = result_unwrap_ok(r);
+    val buf: *u8 = result_unwrap_ok[*u8, AllocError](r);
     mem.raw_copy(buf::ptr, p::ptr, parent_end);
     buf[parent_end] = 0;
 

--- a/src/types/result.mach
+++ b/src/types/result.mach
@@ -13,28 +13,28 @@ pub rec Result[T, E] {
 # Checks if the Result[T, E] is ok (success).
 # ---
 # ret: true if the result is ok, false otherwise.
-pub fun result_is_ok(this: Result[T, E]) bool {
+pub fun result_is_ok[T, E](this: Result[T, E]) bool {
     ret this.tag;
 }
 
 # Checks if the Result[T, E] is err (error).
 # ---
 # ret: true if the result is an error, false otherwise.
-pub fun result_is_err(this: Result[T, E]) bool {
+pub fun result_is_err[T, E](this: Result[T, E]) bool {
     ret !this.tag;
 }
 
 # Unwraps the Result[T, E], returning the contained ok value.
 # ---
 # ret: The contained ok value if the result is ok; behavior is undefined otherwise.
-pub fun result_unwrap_ok(this: Result[T, E]) T {
+pub fun result_unwrap_ok[T, E](this: Result[T, E]) T {
     ret this.value.ok;
 }
 
 # Unwraps the Result[T, E], returning the contained err value.
 # ---
 # ret: The contained err value if the result is an error; behavior is undefined otherwise.
-pub fun result_unwrap_err(this: Result[T, E]) E {
+pub fun result_unwrap_err[T, E](this: Result[T, E]) E {
     ret this.value.err;
 }
 
@@ -64,87 +64,87 @@ pub fun err[T, E](value: E) Result[T, E] {
 
 test "result: ok creates value with is_ok true" {
     val r: Result[i64, i32] = ok[i64, i32](42);
-    if (!result_is_ok(r)) { ret 0; }
+    if (!result_is_ok[i64, i32](r)) { ret 0; }
     ret 1;
 }
 
 test "result: ok creates value with is_err false" {
     val r: Result[i64, i32] = ok[i64, i32](42);
-    if (result_is_err(r)) { ret 0; }
+    if (result_is_err[i64, i32](r)) { ret 0; }
     ret 1;
 }
 
 test "result: err creates value with is_err true" {
     val r: Result[i64, i32] = err[i64, i32](-1);
-    if (!result_is_err(r)) { ret 0; }
+    if (!result_is_err[i64, i32](r)) { ret 0; }
     ret 1;
 }
 
 test "result: err creates value with is_ok false" {
     val r: Result[i64, i32] = err[i64, i32](-1);
-    if (result_is_ok(r)) { ret 0; }
+    if (result_is_ok[i64, i32](r)) { ret 0; }
     ret 1;
 }
 
 test "result: unwrap_ok returns contained ok value" {
     val r: Result[i64, i32] = ok[i64, i32](123);
-    val v: i64 = result_unwrap_ok(r);
+    val v: i64 = result_unwrap_ok[i64, i32](r);
     if (v != 123) { ret 0; }
     ret 1;
 }
 
 test "result: unwrap_err returns contained err value" {
     val r: Result[i64, i32] = err[i64, i32](-99);
-    val e: i32 = result_unwrap_err(r);
+    val e: i32 = result_unwrap_err[i64, i32](r);
     if (e != -99) { ret 0; }
     ret 1;
 }
 
 test "result: ok with zero value" {
     val r: Result[i64, i32] = ok[i64, i32](0);
-    if (!result_is_ok(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 0) { ret 0; }
+    if (!result_is_ok[i64, i32](r)) { ret 0; }
+    if (result_unwrap_ok[i64, i32](r) != 0) { ret 0; }
     ret 1;
 }
 
 test "result: ok with negative value" {
     val r: Result[i64, i32] = ok[i64, i32](-999);
-    if (!result_is_ok(r)) { ret 0; }
-    if (result_unwrap_ok(r) != -999) { ret 0; }
+    if (!result_is_ok[i64, i32](r)) { ret 0; }
+    if (result_unwrap_ok[i64, i32](r) != -999) { ret 0; }
     ret 1;
 }
 
 test "result: ok with pointer type" {
     var x: i64 = 42;
     val r: Result[*i64, i32] = ok[*i64, i32](?x);
-    if (!result_is_ok(r)) { ret 0; }
-    val p: *i64 = result_unwrap_ok(r);
+    if (!result_is_ok[*i64, i32](r)) { ret 0; }
+    val p: *i64 = result_unwrap_ok[*i64, i32](r);
     if (@p != 42) { ret 0; }
     ret 1;
 }
 
 test "result: err with pointer type" {
     val r: Result[*i64, i32] = err[*i64, i32](-1);
-    if (!result_is_err(r)) { ret 0; }
+    if (!result_is_err[*i64, i32](r)) { ret 0; }
     ret 1;
 }
 
 test "result: ok with bool type" {
     val r_true: Result[bool, i32] = ok[bool, i32](true);
     val r_false: Result[bool, i32] = ok[bool, i32](false);
-    if (!result_is_ok(r_true)) { ret 0; }
-    if (!result_is_ok(r_false)) { ret 0; }
-    if (result_unwrap_ok(r_true) != true) { ret 0; }
-    if (result_unwrap_ok(r_false) != false) { ret 0; }
+    if (!result_is_ok[bool, i32](r_true)) { ret 0; }
+    if (!result_is_ok[bool, i32](r_false)) { ret 0; }
+    if (result_unwrap_ok[bool, i32](r_true) != true) { ret 0; }
+    if (result_unwrap_ok[bool, i32](r_false) != false) { ret 0; }
     ret 1;
 }
 
 test "result: different ok and err types" {
     val r_ok: Result[u64, i32] = ok[u64, i32](100);
     val r_err: Result[u64, i32] = err[u64, i32](-1);
-    if (!result_is_ok(r_ok)) { ret 0; }
-    if (!result_is_err(r_err)) { ret 0; }
-    if (result_unwrap_ok(r_ok) != 100) { ret 0; }
-    if (result_unwrap_err(r_err) != -1) { ret 0; }
+    if (!result_is_ok[u64, i32](r_ok)) { ret 0; }
+    if (!result_is_err[u64, i32](r_err)) { ret 0; }
+    if (result_unwrap_ok[u64, i32](r_ok) != 100) { ret 0; }
+    if (result_unwrap_err[u64, i32](r_err) != -1) { ret 0; }
     ret 1;
 }

--- a/src/types/semver.mach
+++ b/src/types/semver.mach
@@ -36,10 +36,10 @@ pub fun semver_parse(input: str) Result[Semver, str] {
     
     # parse major
     var major_result: Option[u64] = parse_number(input, ?pos);
-    if (option_is_none(major_result)) {
+    if (option_is_none[u64](major_result)) {
         ret err[Semver, str]("invalid major version");
     }
-    v.major = option_unwrap(major_result);
+    v.major = option_unwrap[u64](major_result);
     
     if (pos >= str_len(input) || input[pos] != '.') {
         ret err[Semver, str]("expected '.' after major");
@@ -48,10 +48,10 @@ pub fun semver_parse(input: str) Result[Semver, str] {
     
     # parse minor
     var minor_result: Option[u64] = parse_number(input, ?pos);
-    if (option_is_none(minor_result)) {
+    if (option_is_none[u64](minor_result)) {
         ret err[Semver, str]("invalid minor version");
     }
-    v.minor = option_unwrap(minor_result);
+    v.minor = option_unwrap[u64](minor_result);
     
     if (pos >= str_len(input) || input[pos] != '.') {
         ret err[Semver, str]("expected '.' after minor");
@@ -60,10 +60,10 @@ pub fun semver_parse(input: str) Result[Semver, str] {
     
     # parse patch
     var patch_result: Option[u64] = parse_number(input, ?pos);
-    if (option_is_none(patch_result)) {
+    if (option_is_none[u64](patch_result)) {
         ret err[Semver, str]("invalid patch version");
     }
-    v.patch = option_unwrap(patch_result);
+    v.patch = option_unwrap[u64](patch_result);
     
     # parse optional prerelease (starts with '-')
     if (pos < str_len(input) && input[pos] == '-') {

--- a/src/types/string.mach
+++ b/src/types/string.mach
@@ -179,7 +179,7 @@ pub fun str_last_index_of(this: str, sub: str) Result[usize, str] {
 # ret: true if the string contains the substring, false otherwise
 pub fun str_contains(this: str, sub: str) bool {
     val index_res: Result[usize, str] = str_index_of(this, sub);
-    ret result_is_ok(index_res);
+    ret result_is_ok[usize, str](index_res);
 }
 
 # --- tests ---
@@ -321,39 +321,39 @@ test "string: ends_with full string" {
 test "string: index_of finds substring at start" {
     val s: str = "hello world";
     val r: Result[usize, str] = str_index_of(s, "hello");
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 0) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
+    if (result_unwrap_ok[usize, str](r) != 0) { ret 0; }
     ret 1;
 }
 
 test "string: index_of finds substring in middle" {
     val s: str = "hello world";
     val r: Result[usize, str] = str_index_of(s, "wor");
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 6) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
+    if (result_unwrap_ok[usize, str](r) != 6) { ret 0; }
     ret 1;
 }
 
 test "string: index_of not found" {
     val s: str = "hello world";
     val r: Result[usize, str] = str_index_of(s, "xyz");
-    if (result_is_ok(r)) { ret 0; }
+    if (result_is_ok[usize, str](r)) { ret 0; }
     ret 1;
 }
 
 test "string: last_index_of finds last occurrence" {
     val s: str = "abcabc";
     val r: Result[usize, str] = str_last_index_of(s, "abc");
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 3) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
+    if (result_unwrap_ok[usize, str](r) != 3) { ret 0; }
     ret 1;
 }
 
 test "string: last_index_of single occurrence" {
     val s: str = "hello world";
     val r: Result[usize, str] = str_last_index_of(s, "world");
-    if (result_is_err(r)) { ret 0; }
-    if (result_unwrap_ok(r) != 6) { ret 0; }
+    if (result_is_err[usize, str](r)) { ret 0; }
+    if (result_unwrap_ok[usize, str](r) != 6) { ret 0; }
     ret 1;
 }
 


### PR DESCRIPTION
Closes #6

Add explicit generic type parameter declarations (`[T]`, `[T, E]`, `[K, V]`) to all 32 stdlib functions that previously used implicit generics, and update all internal call sites with explicit type args.