### PR TITLE
Rename deinit to dnit across stdlib

### DIFF
--- a/src/allocator/arena.mach
+++ b/src/allocator/arena.mach
@@ -76,7 +76,7 @@ pub fun init(backing: a.Allocator, cap: usize) Result[Arena, a.AllocError] {
 # Free any backing storage associated with the arena.
 # ---
 # ret: true if the backing allocator reports success; no-op for nil or empty arenas.
-pub fun arena_deinit(this: *Arena) bool {
+pub fun arena_dnit(this: *Arena) bool {
     if (this == nil) { ret true; }
     if (this.buf == nil || this.cap == 0) { ret true; }
 
@@ -187,7 +187,7 @@ test "arena: init with zero capacity succeeds" {
     val r: Result[Arena, a.AllocError] = init(backing, 0);
     if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
     var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
-    val ok: bool = arena_deinit(?ar);
+    val ok: bool = arena_dnit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -197,7 +197,7 @@ test "arena: init with capacity allocates backing storage" {
     val r: Result[Arena, a.AllocError] = init(backing, 1024);
     if (result_is_err[Arena, a.AllocError](r)) { ret 0; }
     var ar: Arena = result_unwrap_ok[Arena, a.AllocError](r);
-    val ok: bool = arena_deinit(?ar);
+    val ok: bool = arena_dnit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -219,7 +219,7 @@ test "arena: allocator returns functional allocator" {
     if (p[0] != 100) { ret 0; }
     if (p[1] != 200) { ret 0; }
 
-    val ok: bool = arena_deinit(?ar);
+    val ok: bool = arena_dnit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -247,7 +247,7 @@ test "arena: multiple allocations bump offset" {
     if (p1[0] != 111) { ret 0; }
     if (p2[0] != 222) { ret 0; }
 
-    val ok: bool = arena_deinit(?ar);
+    val ok: bool = arena_dnit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -276,7 +276,7 @@ test "arena: reset clears allocations" {
     # so p2 should be at or near the same address as p1
     if (p2 != p1) { ret 0; }
 
-    val ok: bool = arena_deinit(?ar);
+    val ok: bool = arena_dnit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -304,7 +304,7 @@ test "arena: free is noop for non-last allocation" {
     p2[0] = 999;
     if (p2[0] != 999) { ret 0; }
 
-    val ok: bool = arena_deinit(?ar);
+    val ok: bool = arena_dnit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -335,7 +335,7 @@ test "arena: free last allocation rolls back" {
 
     if (p3 != p2) { ret 0; }
 
-    val ok: bool = arena_deinit(?ar);
+    val ok: bool = arena_dnit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -371,17 +371,17 @@ test "arena: resize last allocation in-place" {
     if (p2[2] != 333) { ret 0; }
     if (p2[3] != 444) { ret 0; }
 
-    val ok: bool = arena_deinit(?ar);
+    val ok: bool = arena_dnit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
 
-test "arena: deinit on nil arena succeeds" {
+test "arena: dnit on nil arena succeeds" {
     var ar: Arena;
     ar.buf = nil;
     ar.cap = 0;
     ar.off = 0;
-    val ok: bool = arena_deinit(?ar);
+    val ok: bool = arena_dnit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -406,7 +406,7 @@ test "arena: allocation respects alignment" {
     val addr: usize = p2::usize;
     if ((addr % 8) != 0) { ret 0; }
 
-    val ok: bool = arena_deinit(?ar);
+    val ok: bool = arena_dnit(?ar);
     if (!ok) { ret 0; }
     ret 1;
 }

--- a/src/collections/vector.mach
+++ b/src/collections/vector.mach
@@ -31,7 +31,7 @@ pub fun init[T](alloc: allocator.Allocator) Vector[T] {
 # Free the backing buffer and reset the vector fields
 # ---
 # ret: true if memory was freed successfully, false otherwise
-pub fun vector_deinit[T](this: *Vector[T]) bool {
+pub fun vector_dnit[T](this: *Vector[T]) bool {
     if (this == nil) { ret true; }
     if (this.cap == 0) {
         this.data = nil;
@@ -190,7 +190,7 @@ test "vector: push adds element" {
     if (vector_length[i64](v) != 1) { ret 0; }
     if (vector_is_empty[i64](v)) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -209,7 +209,7 @@ test "vector: push multiple elements" {
 
     if (vector_length[i64](v) != 3) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -227,7 +227,7 @@ test "vector: pop returns last element" {
     if (result_unwrap_ok[i64, str](r) != 300) { ret 0; }
     if (vector_length[i64](v) != 2) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -239,7 +239,7 @@ test "vector: pop from empty returns error" {
     val r: Result[i64, str] = vector_pop[i64](?v);
     if (result_is_ok[i64, str](r)) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -257,7 +257,7 @@ test "vector: get returns pointer to element" {
     val p: *i64 = result_unwrap_ok[*i64, str](r);
     if (@p != 222) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -271,7 +271,7 @@ test "vector: get out of bounds returns error" {
     val r: Result[*i64, str] = vector_get[i64](?v, 5);
     if (result_is_ok[*i64, str](r)) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -291,7 +291,7 @@ test "vector: get allows mutation" {
     if (result_is_err[*i64, str](r2)) { ret 0; }
     if (@result_unwrap_ok[*i64, str](r2) != 999) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -308,7 +308,7 @@ test "vector: get_ref returns immutable reference" {
     val ref: &i64 = result_unwrap_ok[&i64, str](r);
     if (@ref != 666) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -322,7 +322,7 @@ test "vector: get_ref out of bounds returns error" {
     val r: Result[&i64, str] = vector_get_ref[i64](v, 10);
     if (result_is_ok[&i64, str](r)) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -336,7 +336,7 @@ test "vector: reserve increases capacity" {
     if (vector_capacity[i64](v) < 100) { ret 0; }
     if (vector_length[i64](v) != 0) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -353,7 +353,7 @@ test "vector: reserve when already sufficient is noop" {
 
     if (cap2 != cap1) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -373,15 +373,15 @@ test "vector: clear resets length but keeps capacity" {
     if (!vector_is_empty[i64](v)) { ret 0; }
     if (vector_capacity[i64](v) != cap_before) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
 
-test "vector: deinit on empty vector succeeds" {
+test "vector: dnit on empty vector succeeds" {
     var a: allocator.Allocator = allocator.page_allocator();
     var v: Vector[i64] = init[i64](a);
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -410,7 +410,7 @@ test "vector: push triggers capacity growth" {
         j = j + 1;
     }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -445,7 +445,7 @@ test "vector: push and pop sequence" {
 
     if (!vector_is_empty[i64](v)) { ret 0; }
 
-    val ok: bool = vector_deinit[i64](?v);
+    val ok: bool = vector_dnit[i64](?v);
     if (!ok) { ret 0; }
     ret 1;
 }

--- a/src/text/builder.mach
+++ b/src/text/builder.mach
@@ -32,7 +32,7 @@ pub fun init(alloc: allocator.Allocator) Builder {
 # Free the builder's buffer and reset fields
 # ---
 # ret: true if memory was freed successfully, false otherwise
-pub fun builder_deinit(this: *Builder) bool {
+pub fun builder_dnit(this: *Builder) bool {
     if (this == nil) { ret true; }
     if (this.cap == 0) {
         this.buf = nil;
@@ -187,7 +187,7 @@ test "builder: append_byte adds single byte" {
     if (result_is_err[usize, str](r)) { ret 0; }
     if (builder_length(b) != 1) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -201,7 +201,7 @@ test "builder: append_byte multiple bytes" {
 
     if (builder_length(b) != 2) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -214,7 +214,7 @@ test "builder: append_str adds string" {
     if (result_is_err[usize, str](r)) { ret 0; }
     if (builder_length(b) != 5) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -230,7 +230,7 @@ test "builder: append_str empty string is noop" {
 
     if (builder_length(b) != len_before) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -244,7 +244,7 @@ test "builder: append_bytes adds raw bytes" {
     if (result_is_err[usize, str](r)) { ret 0; }
     if (builder_length(b) != 3) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -261,7 +261,7 @@ test "builder: append_bytes with zero count is noop" {
 
     if (builder_length(b) != len_before) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -278,7 +278,7 @@ test "builder: c_str returns null-terminated string" {
     if (!str_equals(s, "hello")) { ret 0; }
     if (str_len(s) != 5) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -292,7 +292,7 @@ test "builder: c_str on empty builder returns empty string" {
     val s: str = result_unwrap_ok[str, str](r);
     if (str_len(s) != 0) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -306,7 +306,7 @@ test "builder: reserve increases capacity" {
     if (builder_capacity(b) < 100) { ret 0; }
     if (builder_length(b) != 0) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -323,7 +323,7 @@ test "builder: reserve when sufficient is noop" {
 
     if (cap2 != cap1) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -340,7 +340,7 @@ test "builder: clear resets length but keeps capacity" {
     if (builder_length(b) != 0) { ret 0; }
     if (builder_capacity(b) != cap_before) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -357,15 +357,15 @@ test "builder: clear then append reuses buffer" {
     if (result_is_err[str, str](r)) { ret 0; }
     if (!str_equals(result_unwrap_ok[str, str](r), "second")) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
 
-test "builder: deinit on empty builder succeeds" {
+test "builder: dnit on empty builder succeeds" {
     var a: allocator.Allocator = allocator.page_allocator();
     var b: Builder = init(a);
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -384,7 +384,7 @@ test "builder: multiple appends build string" {
     if (!str_equals(s, "hello world")) { ret 0; }
     if (str_len(s) != 11) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }
@@ -403,7 +403,7 @@ test "builder: capacity grows on append" {
     if (builder_length(b) != 200) { ret 0; }
     if (builder_capacity(b) < 200) { ret 0; }
 
-    val ok: bool = builder_deinit(?b);
+    val ok: bool = builder_dnit(?b);
     if (!ok) { ret 0; }
     ret 1;
 }


### PR DESCRIPTION
Closes #8

Standardize destructor naming from `deinit` to `dnit` across mach-std.