### PR TITLE
fix: fix remaining method→function conversion errors

### DIFF
--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -342,7 +342,7 @@ pub fun create_dir_all(path_str: str, mode: i32) Result[bool, str] {
     val parent_create_res: Result[bool, str] = create_dir_all(parent_path, mode);
 
     val parent_len: usize = str_len(parent_path);
-    allocator_free[u8](a, parent_path::ptr::*u8, parent_len + 1);
+    allocator.allocator_free[u8](?a, parent_path::ptr::*u8, parent_len + 1);
 
     if (result_is_err[bool, str](parent_create_res)) {
         ret parent_create_res;
@@ -381,7 +381,7 @@ pub fun temp_create(prefix: str) Result[TempFile, str] {
     for (attempt < TEMP_MAX_ATTEMPTS) {
         # get current time for uniqueness
         val t: time.Time = time.now();
-        val ns: i64 = t.unix_nano();
+        val ns: i64 = time.time_unix_nano(t);
 
         # increment counter
         temp_counter = temp_counter + 1;
@@ -504,7 +504,7 @@ pub fun temp_file_remove(this: *TempFile) Result[bool, str] {
 # ---
 # ret: Ok(true) on success or Err(str) on failure (returns first error).
 pub fun temp_file_close_and_remove(this: *TempFile) Result[bool, str] {
-    val close_res: Result[bool, str] = file_close(this);
+    val close_res: Result[bool, str] = file_close(?this.file);
     val remove_res: Result[bool, str] = temp_file_remove(this);
 
     if (result_is_err[bool, str](close_res)) {

--- a/src/stream.mach
+++ b/src/stream.mach
@@ -109,7 +109,7 @@ pub fun write_all(w: *Writer, buf: &u8, len: usize) Result[usize, str] {
     var total: usize = 0;
     for (total < len) {
         val p: &u8 = (buf::usize + total)::&u8;
-        val r: Result[usize, str] = writer_write(?w, p, len - total);
+        val r: Result[usize, str] = writer_write(w, p, len - total);
         if (result_is_err[usize, str](r)) { ret r; }
 
         val wrote: usize = result_unwrap_ok[usize, str](r);
@@ -132,7 +132,7 @@ pub fun read_exact(r: *Reader, buf: *u8, len: usize) Result[usize, str] {
     var total: usize = 0;
     for (total < len) {
         val p: *u8 = (buf::usize + total)::*u8;
-        val res: Result[usize, str] = reader_read(?r, p, len - total);
+        val res: Result[usize, str] = reader_read(r, p, len - total);
         if (result_is_err[usize, str](res)) { ret res; }
 
         val got: usize = result_unwrap_ok[usize, str](res);

--- a/src/time.mach
+++ b/src/time.mach
@@ -87,7 +87,7 @@ pub fun unix(sec: i64, nsec: i64) Time {
 # t: start time
 # ret: Duration since t (equivalent to now().sub(t))
 pub fun since(t: Time) Duration {
-    ret now().sub(t);
+    ret time_sub(now(), t);
 }
 
 # until: returns the duration until t.


### PR DESCRIPTION
Closes #14

Fix remaining method-to-function conversion errors in stream, time, and filesystem modules:

- stream.mach: Remove extra `?` from `writer_write`/`reader_read` calls (already pointers)
- time.mach: Convert `now().sub(t)` to `time_sub(now(), t)`
- filesystem.mach: Add `allocator.` prefix and `?` to `allocator_free` call
- filesystem.mach: Convert `t.unix_nano()` to `time.time_unix_nano(t)`
- filesystem.mach: Fix `file_close(this)` to `file_close(?this.file)` in `temp_file_close_and_remove`