### PR TITLE
fix: Rename `val` parameter in sock_setopt across all platforms

### DIFF
--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -696,8 +696,8 @@ pub fun sock_shutdown(fd: i32, how: i32) i64 {
     ret syscall2(c.SYS_SHUTDOWN, fd::isize::usize, how::u32::usize);
 }
 
-pub fun sock_setopt(fd: i32, level: i32, opt: i32, val: *u8, vallen: usize) i64 {
-    ret syscall5(c.SYS_SETSOCKOPT, fd::isize::usize, level::u32::usize, opt::u32::usize, val::usize, vallen);
+pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
+    ret syscall5(c.SYS_SETSOCKOPT, fd::isize::usize, level::u32::usize, opt::u32::usize, value::usize, vallen);
 }
 
 # random

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -689,8 +689,8 @@ pub fun sock_shutdown(fd: i32, how: i32) i64 {
     ret syscall2(c.SYS_SHUTDOWN, fd::isize::usize, how::u32::usize);
 }
 
-pub fun sock_setopt(fd: i32, level: i32, opt: i32, val: *u8, vallen: usize) i64 {
-    ret syscall5(c.SYS_SETSOCKOPT, fd::isize::usize, level::u32::usize, opt::u32::usize, val::usize, vallen);
+pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
+    ret syscall5(c.SYS_SETSOCKOPT, fd::isize::usize, level::u32::usize, opt::u32::usize, value::usize, vallen);
 }
 
 # random

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -1076,11 +1076,11 @@ pub fun sock_shutdown(fd: i32, how: i32) i64 {
 # fd:     socket fd
 # level:  option level (SOL_SOCKET, etc.)
 # opt:    option name (SO_REUSEADDR, etc.)
-# val:    pointer to option value
+# value:  pointer to option value
 # vallen: size of option value
 # ret:    0 on success, or negative errno
-pub fun sock_setopt(fd: i32, level: i32, opt: i32, val: *u8, vallen: usize) i64 {
-    ret syscall5(c.SYS_SETSOCKOPT, fd::isize::usize, level::u32::usize, opt::u32::usize, val::usize, vallen);
+pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
+    ret syscall5(c.SYS_SETSOCKOPT, fd::isize::usize, level::u32::usize, opt::u32::usize, value::usize, vallen);
 }
 
 # random

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -1214,8 +1214,8 @@ pub fun sock_shutdown(fd: i32, how: i32) i64 {
     ret 0;
 }
 
-pub fun sock_setopt(fd: i32, level: i32, opt: i32, val: *u8, vallen: usize) i64 {
-    val res: i32 = ws2_setsockopt(fd::usize, level, opt, val, vallen::i32);
+pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
+    val res: i32 = ws2_setsockopt(fd::usize, level, opt, value, vallen::i32);
     if (res == c.SOCKET_ERROR) { ret c.EIO; }
     ret 0;
 }


### PR DESCRIPTION
Closes #46