### PR TITLE
fix: Option/Result unwrap silently returns zero on wrong variant

### DIFF
--- a/src/types/option.mach
+++ b/src/types/option.mach
@@ -1,6 +1,8 @@
 # optional value type
 
 use std.types.bool;
+use std.types.string;
+use os: std.system.os;
 
 # Option[T]: represents an optional value that may or may not be present.
 # ---
@@ -42,9 +44,16 @@ pub fun is_none[T](opt: Option[T]) bool {
 }
 
 # unwrap: return the contained value.
+#
+# aborts the process if no value is present.
 # ---
-# ret: the contained value; behavior is undefined if no value is present
+# ret: the contained value
 pub fun unwrap[T](opt: Option[T]) T {
+    if (!opt.has_value) {
+        val msg: str = "unwrap called on None\n";
+        os.write(os.STDERR_FD, msg::&u8, str_len(msg));
+        os.abort();
+    }
     ret opt.value;
 }
 

--- a/src/types/result.mach
+++ b/src/types/result.mach
@@ -1,6 +1,8 @@
 # std.types.result: success-or-error value type
 
 use std.types.bool;
+use std.types.string;
+use os: std.system.os;
 
 # Result[T, E]: represents either success (ok) containing T, or error (err) containing E.
 # ---
@@ -47,16 +49,30 @@ pub fun is_err[T, E](res: Result[T, E]) bool {
 }
 
 # unwrap_ok: return the contained ok value.
+#
+# aborts the process if the result is err.
 # ---
-# ret: the contained ok value; behavior is undefined if the result is err
+# ret: the contained ok value
 pub fun unwrap_ok[T, E](res: Result[T, E]) T {
+    if (!res.tag) {
+        val msg: str = "unwrap_ok called on Err\n";
+        os.write(os.STDERR_FD, msg::&u8, str_len(msg));
+        os.abort();
+    }
     ret res.value.ok;
 }
 
 # unwrap_err: return the contained err value.
+#
+# aborts the process if the result is ok.
 # ---
-# ret: the contained err value; behavior is undefined if the result is ok
+# ret: the contained err value
 pub fun unwrap_err[T, E](res: Result[T, E]) E {
+    if (res.tag) {
+        val msg: str = "unwrap_err called on Ok\n";
+        os.write(os.STDERR_FD, msg::&u8, str_len(msg));
+        os.abort();
+    }
     ret res.value.err;
 }
 


### PR DESCRIPTION
Closes #80