### PR TITLE
refactor: deduplicate str_len/getenv, add NOT_FOUND sentinel

### DIFF
--- a/src/process/env.mach
+++ b/src/process/env.mach
@@ -11,7 +11,7 @@ use os: std.system.os;
 # name: variable name
 # buf:  destination buffer
 # cap:  buffer capacity in bytes
-# ret:  length of value, or -1 if not found
+# ret:  length of value, or NOT_FOUND (-1)
 pub fun get(name: str, buf: *u8, cap: usize) i64 {
     ret os.getenv(name, buf, cap);
 }

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -206,7 +206,9 @@ pub fun realtime(out: *Timespec) i64 {
     ret 0;
 }
 
-<<<<<<< HEAD
+# sentinels
+pub fwd NOT_FOUND: shared.NOT_FOUND;
+
 # monotonic: read the monotonic clock.
 # ---
 # out: pointer to Timespec to populate

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -319,8 +319,8 @@ pub fun sync_file(p: ptr, size: usize) bool {
     ret syscall3(c.SYS_MSYNC, p::usize, size, c.MS_SYNC::u32::usize) == 0;
 }
 
-# environment (set by runtime at program start)
-pub var _envp: usize = 0;
+# environment
+pub fwd os_shared._envp;
 
 # filesystem
 
@@ -497,53 +497,7 @@ pub fun getcwd(buf: *u8, size: usize) i64 {
     ret syscall2(c.SYS___GETCWD, buf::usize, size);
 }
 
-fun str_len(s: &u8) usize {
-    var i: usize = 0;
-    for (s[i] != 0) {
-        i = i + 1;
-    }
-    ret i;
-}
-
-fun str_eq_n(a: &u8, b: &u8, n: usize) bool {
-    var i: usize = 0;
-    for (i < n) {
-        if (a[i] != b[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
-}
-
-# getenv: look up an environment variable by name.
-# ---
-# name: null-terminated variable name
-# buf:  destination buffer for the value
-# cap:  buffer capacity in bytes
-# ret:  length of value on success, or ENOENT if not found
-pub fun getenv(name: &u8, buf: *u8, cap: usize) i64 {
-    if (_envp == 0) { ret c.ENOENT; }
-    val envp: &&u8 = _envp::&&u8;
-    val name_len: usize = str_len(name);
-    var i: usize = 0;
-    for (envp[i]::usize != 0) {
-        val entry: &u8 = envp[i];
-        if (str_len(entry) > name_len && entry[name_len] == '='::u8 && str_eq_n(entry, name, name_len)) {
-            if (cap == 0) { ret 0; }
-            val val_start: usize = name_len + 1;
-            var j: usize = 0;
-            for (entry[val_start + j] != 0 && j < cap - 1) {
-                buf[j] = entry[val_start + j];
-                j = j + 1;
-            }
-            if (j < cap) {
-                buf[j] = 0;
-            }
-            ret j::i64;
-        }
-        i = i + 1;
-    }
-    ret c.ENOENT;
-}
+pub fwd os_shared.getenv;
 
 # threads
 

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -319,8 +319,8 @@ pub fun sync_file(p: ptr, size: usize) bool {
     ret syscall3(c.SYS_MSYNC, p::usize, size, c.MS_SYNC::u32::usize) == 0;
 }
 
-# environment
-pub fwd os_shared._envp;
+# environment (set by runtime at program start)
+pub var _envp: usize = 0;
 
 # filesystem
 
@@ -497,7 +497,36 @@ pub fun getcwd(buf: *u8, size: usize) i64 {
     ret syscall2(c.SYS___GETCWD, buf::usize, size);
 }
 
-pub fwd os_shared.getenv;
+# getenv: look up an environment variable by name.
+# ---
+# name: null-terminated variable name
+# buf:  destination buffer for the value
+# cap:  buffer capacity in bytes
+# ret:  length of value on success, or NOT_FOUND
+pub fun getenv(name: &u8, buf: *u8, cap: usize) i64 {
+    if (_envp == 0) { ret os_shared.NOT_FOUND; }
+    val envp: &&u8 = _envp::&&u8;
+    val name_len: usize = str_len(name);
+    var i: usize = 0;
+    for (envp[i]::usize != 0) {
+        val entry: &u8 = envp[i];
+        if (str_starts_with(entry, name) && entry[name_len] == '='::u8) {
+            if (cap == 0) { ret 0; }
+            val val_start: usize = name_len + 1;
+            var j: usize = 0;
+            for (entry[val_start + j] != 0 && j < cap - 1) {
+                buf[j] = entry[val_start + j];
+                j = j + 1;
+            }
+            if (j < cap) {
+                buf[j] = 0;
+            }
+            ret j::i64;
+        }
+        i = i + 1;
+    }
+    ret os_shared.NOT_FOUND;
+}
 
 # threads
 

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -657,8 +657,8 @@ pub fun seek(fd: i32, offset: i64, whence: i32) i64 {
     ret syscall3(c.SYS_LSEEK, fd::isize::usize, offset::isize::usize, whence::u32::usize);
 }
 
-# environment (set by runtime at program start)
-pub var _envp: usize = 0;
+# environment
+pub fwd os_shared._envp;
 
 # process
 
@@ -842,53 +842,7 @@ pub fun getcwd(buf: *u8, size: usize) i64 {
     ret syscall2(c.SYS_GETCWD, buf::usize, size);
 }
 
-fun str_len(s: &u8) usize {
-    var i: usize = 0;
-    for (s[i] != 0) {
-        i = i + 1;
-    }
-    ret i;
-}
-
-fun str_eq_n(a: &u8, b: &u8, n: usize) bool {
-    var i: usize = 0;
-    for (i < n) {
-        if (a[i] != b[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
-}
-
-# getenv: look up an environment variable by name.
-# ---
-# name: null-terminated variable name
-# buf:  destination buffer for the value
-# cap:  buffer capacity in bytes
-# ret:  length of value on success, or ENOENT if not found
-pub fun getenv(name: &u8, buf: *u8, cap: usize) i64 {
-    if (_envp == 0) { ret c.ENOENT; }
-    val envp: &&u8 = _envp::&&u8;
-    val name_len: usize = str_len(name);
-    var i: usize = 0;
-    for (envp[i]::usize != 0) {
-        val entry: &u8 = envp[i];
-        if (str_len(entry) > name_len && entry[name_len] == '='::u8 && str_eq_n(entry, name, name_len)) {
-            if (cap == 0) { ret 0; }
-            val val_start: usize = name_len + 1;
-            var j: usize = 0;
-            for (entry[val_start + j] != 0 && j < cap - 1) {
-                buf[j] = entry[val_start + j];
-                j = j + 1;
-            }
-            if (j < cap) {
-                buf[j] = 0;
-            }
-            ret j::i64;
-        }
-        i = i + 1;
-    }
-    ret c.ENOENT;
-}
+pub fwd os_shared.getenv;
 
 # threads
 

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -657,8 +657,8 @@ pub fun seek(fd: i32, offset: i64, whence: i32) i64 {
     ret syscall3(c.SYS_LSEEK, fd::isize::usize, offset::isize::usize, whence::u32::usize);
 }
 
-# environment
-pub fwd os_shared._envp;
+# environment (set by runtime at program start)
+pub var _envp: usize = 0;
 
 # process
 
@@ -842,7 +842,36 @@ pub fun getcwd(buf: *u8, size: usize) i64 {
     ret syscall2(c.SYS_GETCWD, buf::usize, size);
 }
 
-pub fwd os_shared.getenv;
+# getenv: look up an environment variable by name.
+# ---
+# name: null-terminated variable name
+# buf:  destination buffer for the value
+# cap:  buffer capacity in bytes
+# ret:  length of value on success, or NOT_FOUND
+pub fun getenv(name: &u8, buf: *u8, cap: usize) i64 {
+    if (_envp == 0) { ret os_shared.NOT_FOUND; }
+    val envp: &&u8 = _envp::&&u8;
+    val name_len: usize = str_len(name);
+    var i: usize = 0;
+    for (envp[i]::usize != 0) {
+        val entry: &u8 = envp[i];
+        if (str_starts_with(entry, name) && entry[name_len] == '='::u8) {
+            if (cap == 0) { ret 0; }
+            val val_start: usize = name_len + 1;
+            var j: usize = 0;
+            for (entry[val_start + j] != 0 && j < cap - 1) {
+                buf[j] = entry[val_start + j];
+                j = j + 1;
+            }
+            if (j < cap) {
+                buf[j] = 0;
+            }
+            ret j::i64;
+        }
+        i = i + 1;
+    }
+    ret os_shared.NOT_FOUND;
+}
 
 # threads
 

--- a/src/system/os/shared.mach
+++ b/src/system/os/shared.mach
@@ -1,8 +1,6 @@
 # std.system.os.shared: abstract types and constants for the OS interface.
 #
 # types here are target-independent. every OS implementation populates them.
-# also contains pure utility functions (str_len, str_eq_n, getenv) that are
-# identical across all POSIX-like platforms.
 
 use std.types.size;
 use std.types.bool;
@@ -41,56 +39,5 @@ pub val HUGE_1GB: usize = 1073741824;
 # heap region reserve size (256MB)
 pub val HEAP_RESERVE: usize = 268435456;
 
-# POSIX errno constants (identical across linux, darwin, windows)
-pub val ENOENT: i64 = -2;
-
-# environment (set by runtime at program start)
-pub var _envp: usize = 0;
-
-pub fun str_len(s: &u8) usize {
-    var i: usize = 0;
-    for (s[i] != 0) {
-        i = i + 1;
-    }
-    ret i;
-}
-
-pub fun str_eq_n(a: &u8, b: &u8, n: usize) bool {
-    var i: usize = 0;
-    for (i < n) {
-        if (a[i] != b[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
-}
-
-# getenv: look up an environment variable by name.
-# ---
-# name: null-terminated variable name
-# buf:  destination buffer for the value
-# cap:  buffer capacity in bytes
-# ret:  length of value on success, or ENOENT if not found
-pub fun getenv(name: &u8, buf: *u8, cap: usize) i64 {
-    if (_envp == 0) { ret ENOENT; }
-    val envp: &&u8 = _envp::&&u8;
-    val name_len: usize = str_len(name);
-    var i: usize = 0;
-    for (envp[i]::usize != 0) {
-        val entry: &u8 = envp[i];
-        if (str_len(entry) > name_len && entry[name_len] == '='::u8 && str_eq_n(entry, name, name_len)) {
-            if (cap == 0) { ret 0; }
-            val val_start: usize = name_len + 1;
-            var j: usize = 0;
-            for (entry[val_start + j] != 0 && j < cap - 1) {
-                buf[j] = entry[val_start + j];
-                j = j + 1;
-            }
-            if (j < cap) {
-                buf[j] = 0;
-            }
-            ret j::i64;
-        }
-        i = i + 1;
-    }
-    ret ENOENT;
-}
+# platform-agnostic sentinels
+pub val NOT_FOUND: i64 = -1;

--- a/src/system/os/shared.mach
+++ b/src/system/os/shared.mach
@@ -1,8 +1,11 @@
 # std.system.os.shared: abstract types and constants for the OS interface.
 #
 # types here are target-independent. every OS implementation populates them.
+# also contains pure utility functions (str_len, str_eq_n, getenv) that are
+# identical across all POSIX-like platforms.
 
 use std.types.size;
+use std.types.bool;
 
 # Timespec: seconds and nanoseconds from a clock source.
 # ---
@@ -37,3 +40,57 @@ pub val HUGE_1GB: usize = 1073741824;
 
 # heap region reserve size (256MB)
 pub val HEAP_RESERVE: usize = 268435456;
+
+# POSIX errno constants (identical across linux, darwin, windows)
+pub val ENOENT: i64 = -2;
+
+# environment (set by runtime at program start)
+pub var _envp: usize = 0;
+
+pub fun str_len(s: &u8) usize {
+    var i: usize = 0;
+    for (s[i] != 0) {
+        i = i + 1;
+    }
+    ret i;
+}
+
+pub fun str_eq_n(a: &u8, b: &u8, n: usize) bool {
+    var i: usize = 0;
+    for (i < n) {
+        if (a[i] != b[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# getenv: look up an environment variable by name.
+# ---
+# name: null-terminated variable name
+# buf:  destination buffer for the value
+# cap:  buffer capacity in bytes
+# ret:  length of value on success, or ENOENT if not found
+pub fun getenv(name: &u8, buf: *u8, cap: usize) i64 {
+    if (_envp == 0) { ret ENOENT; }
+    val envp: &&u8 = _envp::&&u8;
+    val name_len: usize = str_len(name);
+    var i: usize = 0;
+    for (envp[i]::usize != 0) {
+        val entry: &u8 = envp[i];
+        if (str_len(entry) > name_len && entry[name_len] == '='::u8 && str_eq_n(entry, name, name_len)) {
+            if (cap == 0) { ret 0; }
+            val val_start: usize = name_len + 1;
+            var j: usize = 0;
+            for (entry[val_start + j] != 0 && j < cap - 1) {
+                buf[j] = entry[val_start + j];
+                j = j + 1;
+            }
+            if (j < cap) {
+                buf[j] = 0;
+            }
+            ret j::i64;
+        }
+        i = i + 1;
+    }
+    ret ENOENT;
+}

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -1032,13 +1032,13 @@ pub fun getcwd(buf: *u8, size: usize) i64 {
 # name: null-terminated variable name
 # buf:  destination buffer for the value
 # cap:  buffer capacity in bytes
-# ret:  length of value on success, or ENOENT if not found
+# ret:  length of value on success, or NOT_FOUND
 pub fun getenv(name: &u8, buf: *u8, cap: usize) i64 {
     val len: u32 = GetEnvironmentVariableA(name, buf, cap::u32);
     if (len == 0) {
         val err: u32 = GetLastError();
         if (err == 203) {
-            ret c.ENOENT;
+            ret os_shared.NOT_FOUND;
         }
         ret c.EIO;
     }


### PR DESCRIPTION
## Summary
- Remove duplicated `str_len`/`str_eq_n` from OS modules — use `std.types.string` instead
- Replace platform-specific `ENOENT` returns from `getenv` with `NOT_FOUND` sentinel in `os/shared.mach`
- Keep `getenv` in platform modules (Windows uses `GetEnvironmentVariableA`)

Closes #81

## Test plan
- [ ] Verify `getenv` returns `NOT_FOUND` (-1) for missing vars
- [ ] Verify `str_starts_with` works correctly for env var name matching