### PR TITLE
refactor: deduplicate wait status macros into os/shared

### DIFF
--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -82,8 +82,7 @@ pub fun code(status: ExitStatus) i32 {
 # status: exit status to inspect
 # ret:    true if terminated by signal
 pub fun signaled(status: ExitStatus) bool {
-    val sig: i32 = status.raw & 0x7f;
-    ret sig != 0 && sig != 0x7f;
+    ret os.was_signaled(status.raw);
 }
 
 # signal: get the signal number that killed the process.
@@ -91,7 +90,7 @@ pub fun signaled(status: ExitStatus) bool {
 # status: exit status to inspect
 # ret:    signal number
 pub fun signal(status: ExitStatus) i32 {
-    ret status.raw & 0x7f;
+    ret os.term_signal(status.raw);
 }
 
 # exit: terminate the current process.

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -420,35 +420,14 @@ pub fun wait_pid(pid: i64, wstatus: *i32, options: i32) i64 {
     ret wait(pid, wstatus, options, nil);
 }
 
-# wait status macros (same POSIX encoding across all darwin arches)
-pub fun has_exited(status: i32) bool {
-    ret (status & 0x7f) == 0;
-}
-
-pub fun exit_code(status: i32) i32 {
-    ret (status >> 8) & 0xff;
-}
-
-pub fun was_signaled(status: i32) bool {
-    val sig: i32 = status & 0x7f;
-    ret sig != 0 && sig != 0x7f;
-}
-
-pub fun term_signal(status: i32) i32 {
-    ret status & 0x7f;
-}
-
-pub fun was_stopped(status: i32) bool {
-    ret (status & 0xff) == 0x7f;
-}
-
-pub fun stop_signal(status: i32) i32 {
-    ret (status >> 8) & 0xff;
-}
-
-pub fun was_continued(status: i32) bool {
-    ret status == 0xffff;
-}
+# wait status (POSIX encoding, shared across all targets)
+pub fwd os_shared.has_exited;
+pub fwd os_shared.exit_code;
+pub fwd os_shared.was_signaled;
+pub fwd os_shared.term_signal;
+pub fwd os_shared.was_stopped;
+pub fwd os_shared.stop_signal;
+pub fwd os_shared.was_continued;
 
 # spawn: create a child process running the given program.
 # ---

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -732,62 +732,14 @@ pub fun wait_pid(pid: i64, wstatus: *i32, options: i32) i64 {
     ret wait(pid, wstatus, options, nil);
 }
 
-# wifexited: check if child exited normally.
-# ---
-# status: status from wait
-# ret:    true if exited normally
-pub fun has_exited(status: i32) bool {
-    ret (status & 0x7f) == 0;
-}
-
-# wexitstatus: get exit code from wait status.
-# ---
-# status: status from wait
-# ret:    exit code (0-255)
-pub fun exit_code(status: i32) i32 {
-    ret (status >> 8) & 0xff;
-}
-
-# wifsignaled: check if child was terminated by a signal.
-# ---
-# status: status from wait
-# ret:    true if terminated by signal
-pub fun was_signaled(status: i32) bool {
-    val sig: i32 = status & 0x7f;
-    ret sig != 0 && sig != 0x7f;
-}
-
-# wtermsig: get signal number that terminated the child.
-# ---
-# status: status from wait
-# ret:    signal number
-pub fun term_signal(status: i32) i32 {
-    ret status & 0x7f;
-}
-
-# wifstopped: check if child is currently stopped.
-# ---
-# status: status from wait
-# ret:    true if stopped
-pub fun was_stopped(status: i32) bool {
-    ret (status & 0xff) == 0x7f;
-}
-
-# wstopsig: get signal number that stopped the child.
-# ---
-# status: status from wait
-# ret:    signal number
-pub fun stop_signal(status: i32) i32 {
-    ret (status >> 8) & 0xff;
-}
-
-# wifcontinued: check if child was resumed by SIGCONT.
-# ---
-# status: status from wait
-# ret:    true if continued
-pub fun was_continued(status: i32) bool {
-    ret status == 0xffff;
-}
+# wait status (POSIX encoding, shared across all targets)
+pub fwd os_shared.has_exited;
+pub fwd os_shared.exit_code;
+pub fwd os_shared.was_signaled;
+pub fwd os_shared.term_signal;
+pub fwd os_shared.was_stopped;
+pub fwd os_shared.stop_signal;
+pub fwd os_shared.was_continued;
 
 # spawn: create a child process running the given program.
 # ---

--- a/src/system/os/shared.mach
+++ b/src/system/os/shared.mach
@@ -41,3 +41,34 @@ pub val HEAP_RESERVE: usize = 268435456;
 
 # platform-agnostic sentinels
 pub val NOT_FOUND: i64 = -1;
+
+# wait status decoding (POSIX encoding, identical across all POSIX targets)
+
+pub fun has_exited(status: i32) bool {
+    ret (status & 0x7f) == 0;
+}
+
+pub fun exit_code(status: i32) i32 {
+    ret (status >> 8) & 0xff;
+}
+
+pub fun was_signaled(status: i32) bool {
+    val sig: i32 = status & 0x7f;
+    ret sig != 0 && sig != 0x7f;
+}
+
+pub fun term_signal(status: i32) i32 {
+    ret status & 0x7f;
+}
+
+pub fun was_stopped(status: i32) bool {
+    ret (status & 0xff) == 0x7f;
+}
+
+pub fun stop_signal(status: i32) i32 {
+    ret (status >> 8) & 0xff;
+}
+
+pub fun was_continued(status: i32) bool {
+    ret status == 0xffff;
+}


### PR DESCRIPTION
## Summary
- Move 7 POSIX wait status functions to `os/shared.mach` (single canonical implementation)
- Platform modules re-export via `pub fwd`
- Update `process/exec.mach` to delegate to `os.was_signaled`/`os.term_signal`
- Windows intentionally kept separate (different semantics)

Closes #83

## Test plan
- [ ] Verify wait status functions work through forwarding chain