### PR TITLE
fix: windows socket errors all mapped to EIO, losing error specificity

### DIFF
--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -1269,19 +1269,38 @@ pub fun sock_addr_read(sa: &u8, port: *u16, addr: *u8) {
 pub fun sock_send(fd: i32, buf: &u8, len: usize) i64 {
     if (!ensure_wsa()) { ret c.EIO; }
     val res: i32 = ws2_send(fd::usize, buf, len::i32, 0);
-    if (res == c.SOCKET_ERROR) { ret c.EIO; }
+    if (res == c.SOCKET_ERROR) { ret wsa_last_error(); }
     ret res::i64;
 }
 
 pub fun sock_recv(fd: i32, buf: *u8, len: usize) i64 {
     if (!ensure_wsa()) { ret c.EIO; }
     val res: i32 = ws2_recv(fd::usize, buf, len::i32, 0);
-    if (res == c.SOCKET_ERROR) { ret c.EIO; }
+    if (res == c.SOCKET_ERROR) { ret wsa_last_error(); }
     ret res::i64;
 }
 
 pub fun sock_close(fd: i32) i64 {
     ret closesocket(fd::usize)::i64;
+}
+
+fun wsa_last_error() i64 {
+    val err: i32 = WSAGetLastError();
+    if (err == c.WSAECONNREFUSED)  { ret c.ECONNREFUSED; }
+    or (err == c.WSAETIMEDOUT)     { ret c.ETIMEDOUT; }
+    or (err == c.WSAECONNRESET)    { ret c.ECONNRESET; }
+    or (err == c.WSAECONNABORTED)  { ret c.ECONNABORTED; }
+    or (err == c.WSAENOTCONN)      { ret c.ENOTCONN; }
+    or (err == c.WSAENETUNREACH)   { ret c.ENETUNREACH; }
+    or (err == c.WSAEHOSTUNREACH)  { ret c.EHOSTUNREACH; }
+    or (err == c.WSAEADDRINUSE)    { ret c.EADDRINUSE; }
+    or (err == c.WSAEADDRNOTAVAIL) { ret c.EADDRNOTAVAIL; }
+    or (err == c.WSAEWOULDBLOCK)   { ret c.EAGAIN; }
+    or (err == c.WSAEINPROGRESS)   { ret c.EINPROGRESS; }
+    or (err == c.WSAENOTSOCK)      { ret c.ENOTSOCK; }
+    or (err == c.WSAEMSGSIZE)      { ret c.EMSGSIZE; }
+    or (err == c.WSAEAFNOSUPPORT)  { ret c.EAFNOSUPPORT; }
+    or { ret c.EIO; }
 }
 
 var wsa_initialized: i64 = 0;
@@ -1298,55 +1317,55 @@ fun ensure_wsa() bool {
 pub fun sock_create(domain: i32, typ: i32, protocol: i32) i64 {
     if (!ensure_wsa()) { ret c.EIO; }
     val s: usize = ws2_socket(domain, typ, protocol);
-    if (s == c.INVALID_SOCKET) { ret c.EIO; }
+    if (s == c.INVALID_SOCKET) { ret wsa_last_error(); }
     ret s::i64;
 }
 
 pub fun sock_bind(fd: i32, addr: *u8, addrlen: usize) i64 {
     val res: i32 = ws2_bind(fd::usize, addr, addrlen::i32);
-    if (res == c.SOCKET_ERROR) { ret c.EIO; }
+    if (res == c.SOCKET_ERROR) { ret wsa_last_error(); }
     ret 0;
 }
 
 pub fun sock_listen(fd: i32, backlog: i32) i64 {
     val res: i32 = ws2_listen(fd::usize, backlog);
-    if (res == c.SOCKET_ERROR) { ret c.EIO; }
+    if (res == c.SOCKET_ERROR) { ret wsa_last_error(); }
     ret 0;
 }
 
 pub fun sock_accept(fd: i32, addr: *u8, addrlen: *u32) i64 {
     val s: usize = ws2_accept(fd::usize, addr, addrlen::*i32);
-    if (s == c.INVALID_SOCKET) { ret c.EIO; }
+    if (s == c.INVALID_SOCKET) { ret wsa_last_error(); }
     ret s::i64;
 }
 
 pub fun sock_connect(fd: i32, addr: *u8, addrlen: usize) i64 {
     val res: i32 = ws2_connect(fd::usize, addr, addrlen::i32);
-    if (res == c.SOCKET_ERROR) { ret c.EIO; }
+    if (res == c.SOCKET_ERROR) { ret wsa_last_error(); }
     ret 0;
 }
 
 pub fun sock_sendto(fd: i32, buf: &u8, len: usize, flags: i32, addr: *u8, addrlen: usize) i64 {
     val res: i32 = ws2_sendto(fd::usize, buf, len::i32, flags, addr, addrlen::i32);
-    if (res == c.SOCKET_ERROR) { ret c.EIO; }
+    if (res == c.SOCKET_ERROR) { ret wsa_last_error(); }
     ret res::i64;
 }
 
 pub fun sock_recvfrom(fd: i32, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: *u32) i64 {
     val res: i32 = ws2_recvfrom(fd::usize, buf, len::i32, flags, addr, addrlen::*i32);
-    if (res == c.SOCKET_ERROR) { ret c.EIO; }
+    if (res == c.SOCKET_ERROR) { ret wsa_last_error(); }
     ret res::i64;
 }
 
 pub fun sock_shutdown(fd: i32, how: i32) i64 {
     val res: i32 = ws2_shutdown(fd::usize, how);
-    if (res == c.SOCKET_ERROR) { ret c.EIO; }
+    if (res == c.SOCKET_ERROR) { ret wsa_last_error(); }
     ret 0;
 }
 
 pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
     val res: i32 = ws2_setsockopt(fd::usize, level, opt, value, vallen::i32);
-    if (res == c.SOCKET_ERROR) { ret c.EIO; }
+    if (res == c.SOCKET_ERROR) { ret wsa_last_error(); }
     ret 0;
 }
 

--- a/src/system/os/windows/x86_64/constants.mach
+++ b/src/system/os/windows/x86_64/constants.mach
@@ -192,5 +192,34 @@ pub val SHUT_RDWR:    i32 = 2;
 pub val INVALID_SOCKET: usize = (-1)::isize::usize;
 pub val SOCKET_ERROR:   i32 = -1;
 
+pub val WSAEWOULDBLOCK:    i32 = 10035;
+pub val WSAEINPROGRESS:    i32 = 10036;
+pub val WSAENOTSOCK:       i32 = 10038;
+pub val WSAEMSGSIZE:       i32 = 10040;
+pub val WSAEAFNOSUPPORT:   i32 = 10047;
+pub val WSAEADDRINUSE:     i32 = 10048;
+pub val WSAEADDRNOTAVAIL:  i32 = 10049;
+pub val WSAENETUNREACH:    i32 = 10051;
+pub val WSAECONNABORTED:   i32 = 10053;
+pub val WSAECONNRESET:     i32 = 10054;
+pub val WSAENOTCONN:       i32 = 10057;
+pub val WSAETIMEDOUT:      i32 = 10060;
+pub val WSAECONNREFUSED:   i32 = 10061;
+pub val WSAEHOSTUNREACH:   i32 = 10065;
+
+pub val ECONNREFUSED:  i64 = -111;
+pub val ETIMEDOUT:     i64 = -110;
+pub val ECONNRESET:    i64 = -104;
+pub val ECONNABORTED:  i64 = -103;
+pub val ENETUNREACH:   i64 = -101;
+pub val EADDRINUSE:    i64 = -98;
+pub val EADDRNOTAVAIL: i64 = -99;
+pub val EHOSTUNREACH:  i64 = -113;
+pub val ENOTCONN:      i64 = -107;
+pub val EMSGSIZE:      i64 = -90;
+pub val EAFNOSUPPORT:  i64 = -97;
+pub val EINPROGRESS:   i64 = -115;
+pub val ENOTSOCK:      i64 = -88;
+
 # retry limit for EINTR handling
 pub val EINTR_MAX_RETRIES: usize = 8;


### PR DESCRIPTION
Closes #141