### PR TITLE
refactor: use {var} syntax for local variable references in asm blocks

### DIFF
--- a/src/sync/atomic.mach
+++ b/src/sync/atomic.mach
@@ -12,7 +12,7 @@ use std.types.size;
 # ret: loaded value
 pub fun load(ptr: *i64) i64 {
     var result: i64 = 0;
-    asm { atomic.load.seq_cst result, ptr }
+    asm { atomic.load.seq_cst {result}, {ptr} }
     ret result;
 }
 
@@ -21,7 +21,7 @@ pub fun load(ptr: *i64) i64 {
 # ptr: address to store to
 # v:   value to store
 pub fun store(ptr: *i64, v: i64) {
-    asm { atomic.store.seq_cst ptr, v }
+    asm { atomic.store.seq_cst {ptr}, {v} }
 }
 
 # atomic compare-and-swap.
@@ -35,7 +35,7 @@ pub fun store(ptr: *i64, v: i64) {
 pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
     var old: i64 = 0;
     val exp: i64 = @expected;
-    asm { atomic.cas.seq_cst old, ptr, exp, desired }
+    asm { atomic.cas.seq_cst {old}, {ptr}, {exp}, {desired} }
     if (old == exp) { ret true; }
     @expected = old;
     ret false;
@@ -48,7 +48,7 @@ pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
 # ret: previous value
 pub fun fetch_add(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
-    asm { atomic.rmw.add.seq_cst old, ptr, v }
+    asm { atomic.rmw.add.seq_cst {old}, {ptr}, {v} }
     ret old;
 }
 
@@ -59,7 +59,7 @@ pub fun fetch_add(ptr: *i64, v: i64) i64 {
 # ret: previous value
 pub fun fetch_sub(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
-    asm { atomic.rmw.sub.seq_cst old, ptr, v }
+    asm { atomic.rmw.sub.seq_cst {old}, {ptr}, {v} }
     ret old;
 }
 
@@ -70,7 +70,7 @@ pub fun fetch_sub(ptr: *i64, v: i64) i64 {
 # ret: previous value
 pub fun exchange(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
-    asm { atomic.rmw.xchg.seq_cst old, ptr, v }
+    asm { atomic.rmw.xchg.seq_cst {old}, {ptr}, {v} }
     ret old;
 }
 

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -38,7 +38,7 @@ pub fun pipe(fds: *i32) i64 {
     1:
         neg x0, x0
     2:
-        str x0, [result]
+        str x0, {result}
     }
     ret result;
 }

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -213,43 +213,43 @@ pub val EINTR_MAX_RETRIES: usize = 8;
 
 pub fun syscall0(n: usize) i64 {
     var out: i64;
-    asm { syscall out, n }
+    asm { syscall {out}, {n} }
     ret out;
 }
 
 pub fun syscall1(n: usize, a0: usize) i64 {
     var out: i64;
-    asm { syscall out, n, a0 }
+    asm { syscall {out}, {n}, {a0} }
     ret out;
 }
 
 pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
     var out: i64;
-    asm { syscall out, n, a0, a1 }
+    asm { syscall {out}, {n}, {a0}, {a1} }
     ret out;
 }
 
 pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
     var out: i64;
-    asm { syscall out, n, a0, a1, a2 }
+    asm { syscall {out}, {n}, {a0}, {a1}, {a2} }
     ret out;
 }
 
 pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
     var out: i64;
-    asm { syscall out, n, a0, a1, a2, a3 }
+    asm { syscall {out}, {n}, {a0}, {a1}, {a2}, {a3} }
     ret out;
 }
 
 pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize) i64 {
     var out: i64;
-    asm { syscall out, n, a0, a1, a2, a3, a4 }
+    asm { syscall {out}, {n}, {a0}, {a1}, {a2}, {a3}, {a4} }
     ret out;
 }
 
 pub fun syscall6(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) i64 {
     var out: i64;
-    asm { syscall out, n, a0, a1, a2, a3, a4, a5 }
+    asm { syscall {out}, {n}, {a0}, {a1}, {a2}, {a3}, {a4}, {a5} }
     ret out;
 }
 

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -38,7 +38,7 @@ pub fun pipe(fds: *i32) i64 {
     1:
         neg rax
     2:
-        mov [result], rax
+        mov {result}, rax
     }
     ret result;
 }

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -227,7 +227,7 @@ pub val EINTR_MAX_RETRIES: usize = 8;
 pub fun syscall0(n: usize) i64 {
     var out: i64;
     asm {
-        syscall out, n
+        syscall {out}, {n}
     }
     ret out;
 }
@@ -240,7 +240,7 @@ pub fun syscall0(n: usize) i64 {
 pub fun syscall1(n: usize, a0: usize) i64 {
     var out: i64;
     asm {
-        syscall out, n, a0
+        syscall {out}, {n}, {a0}
     }
     ret out;
 }
@@ -254,7 +254,7 @@ pub fun syscall1(n: usize, a0: usize) i64 {
 pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
     var out: i64;
     asm {
-        syscall out, n, a0, a1
+        syscall {out}, {n}, {a0}, {a1}
     }
     ret out;
 }
@@ -269,7 +269,7 @@ pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
 pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
     var out: i64;
     asm {
-        syscall out, n, a0, a1, a2
+        syscall {out}, {n}, {a0}, {a1}, {a2}
     }
     ret out;
 }
@@ -285,7 +285,7 @@ pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
 pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
     var out: i64;
     asm {
-        syscall out, n, a0, a1, a2, a3
+        syscall {out}, {n}, {a0}, {a1}, {a2}, {a3}
     }
     ret out;
 }
@@ -302,7 +302,7 @@ pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
 pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize) i64 {
     var out: i64;
     asm {
-        syscall out, n, a0, a1, a2, a3, a4
+        syscall {out}, {n}, {a0}, {a1}, {a2}, {a3}, {a4}
     }
     ret out;
 }
@@ -320,7 +320,7 @@ pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
 pub fun syscall6(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) i64 {
     var out: i64;
     asm {
-        syscall out, n, a0, a1, a2, a3, a4, a5
+        syscall {out}, {n}, {a0}, {a1}, {a2}, {a3}, {a4}, {a5}
     }
     ret out;
 }

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -31,13 +31,13 @@ fun thread_trampoline() {
     var stack_size: usize = 0;
     asm x86_64 {
         mov rax, [rbp+8]
-        mov [fn_addr], rax
+        mov {fn_addr}, rax
         mov rax, [rbp+16]
-        mov [done_addr], rax
+        mov {done_addr}, rax
         mov rax, [rbp+24]
-        mov [stack_base], rax
+        mov {stack_base}, rax
         mov rax, [rbp+32]
-        mov [stack_size], rax
+        mov {stack_size}, rax
     }
     val fn_ptr: fun() = fn_addr::fun();
     fn_ptr();
@@ -46,8 +46,8 @@ fun thread_trampoline() {
     shared.syscall6(shared.SYS_FUTEX, done_addr, shared.FUTEX_WAKE, 1, 0, 0, 0);
     asm x86_64 {
         # munmap stack then exit
-        mov rdi, [stack_base]
-        mov rsi, [stack_size]
+        mov rdi, {stack_base}
+        mov rsi, {stack_size}
         mov rax, 11           # SYS_munmap
         syscall
         mov rdi, 0
@@ -85,14 +85,14 @@ pub fun thread_spawn(f: fun(), done_ptr: *i64, stack_base: usize, stack_size: us
 
     asm { fence.seq_cst }
     asm x86_64 {
-        mov rdi, [flags]
-        mov rsi, [stack_ptr]
+        mov rdi, {flags}
+        mov rsi, {stack_ptr}
         xor rdx, rdx
         xor r10, r10
         xor r8, r8
         mov rax, 56           # SYS_clone
         syscall
-        mov [result], rax
+        mov {result}, rax
     }
 
     if (result == 0) {

--- a/src/system/panic.mach
+++ b/src/system/panic.mach
@@ -17,8 +17,8 @@ pub fun panic(msg: *u8) {
         asm x86_64 {
             mov eax, 1        # SYS_write
             mov edi, 2        # fd = stderr
-            mov rsi, [msg]
-            mov rdx, [len]
+            mov rsi, {msg}
+            mov rdx, {len}
             syscall
         }
     }
@@ -27,8 +27,8 @@ pub fun panic(msg: *u8) {
             asm x86_64 {
                 mov eax, 0x2000004  # SYS_write (darwin)
                 mov edi, 2          # fd = stderr
-                mov rsi, [msg]
-                mov rdx, [len]
+                mov rsi, {msg}
+                mov rdx, {len}
                 syscall
             }
         }
@@ -36,8 +36,8 @@ pub fun panic(msg: *u8) {
             asm aarch64 {
                 mov x16, 4    # SYS_write (darwin aarch64)
                 mov x0, 2     # fd = stderr
-                ldr x1, [msg]
-                ldr x2, [len]
+                ldr x1, {msg}
+                ldr x2, {len}
                 svc 0x80
             }
         }


### PR DESCRIPTION
Closes #177

Update all asm blocks in mach-std to use `{name}` syntax for referencing local variables (function parameters, local var/val declarations). This distinguishes locals from globals (`[name]`) and register-based addressing (`[reg + offset]`).

**ISA-specific asm** (`asm x86_64 { ... }`, `asm aarch64 { ... }`):
- `src/system/panic.mach` -- `[msg]`/`[len]` to `{msg}`/`{len}` in all three asm blocks
- `src/system/os/linux/x86_64.mach` -- locals in thread_trampoline and thread_spawn
- `src/system/os/darwin/aarch64.mach` -- `[result]` to `{result}` in pipe()
- `src/system/os/darwin/x86_64.mach` -- `[result]` to `{result}` in pipe()

**Generic (MASM) asm** (`asm { ... }`):
- `src/system/os/linux/shared.mach` -- all 7 syscall wrappers
- `src/system/os/darwin/shared.mach` -- all 7 syscall wrappers
- `src/sync/atomic.mach` -- load, store, cas, fetch_add, fetch_sub, exchange

Not changed (correctly left as `[name]`):
- Module-level globals (`_rt_argc`, `_rt_argv`, `_rt_envp`, `argc`, `argv_ptrs`)
- Register-based addressing (`[rbp+8]`, `[r8]`, `[r8+4]`, `[x9]`, `[x9, 4]`, `[rax]`, `[rsi + rcx*8]`)
- Labels and function names in call/branch instructions