### PR TITLE
feat: fat-str migration with zstr for null-terminated strings

### DIFF
--- a/src/collections/map.mach
+++ b/src/collections/map.mach
@@ -359,11 +359,12 @@ pub fun hash_str(p: ptr) u64 {
     var hash: u64 = FNV_OFFSET;
     val sp: str = @s;
 
-    if (sp == nil) { ret hash; }
+    if (sp.data == nil) { ret hash; }
 
+    val n: usize = sp.len::usize;
     var i: usize = 0;
-    for (sp[i] != 0) {
-        val byte: u64 = sp[i]::u64;
+    for (i < n) {
+        val byte: u64 = sp.data[i]::u64;
         hash = hash ^ byte;
         hash = hash * FNV_PRIME;
         i = i + 1;

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -162,7 +162,12 @@ pub fun value_get(v: *Value, index: usize) *Value {
 # index: zero-based index
 # ret:   key string (null-terminated), or nil if out of bounds
 pub fun value_key(v: *Value, index: usize) str {
-    if (v.kind != OBJECT || index >= v.count) { ret nil; }
+    if (v.kind != OBJECT || index >= v.count) {
+        var empty: str;
+        empty.len  = 0;
+        empty.data = nil;
+        ret empty;
+    }
     ret v.keys[index];
 }
 
@@ -202,7 +207,8 @@ fun make_null() Value {
     v.kind = NULL;
     v.bool_val = 0;
     v.num_val = 0;
-    v.str_val = nil;
+    v.str_val.len  = 0;
+    v.str_val.data = nil;
     v.str_len = 0;
     v.children = nil;
     v.keys = nil;
@@ -369,7 +375,9 @@ fun parse_string(p: *Parser) Result[Value, str] {
         }
         if (c == '"') {
             val slen: usize = p.pos - start;
-            val sptr: str = (p.src::usize + start)::str;
+            var sptr: str;
+            sptr.len  = slen::u32;
+            sptr.data = (p.src::usize + start)::*u8;
             p.pos = p.pos + 1;
             ret ok[Value, str](make_string(sptr, slen));
         }
@@ -527,9 +535,10 @@ fun emit_bytes(e: *Emitter, s: *u8, slen: usize) {
 }
 
 fun emit_str(e: *Emitter, s: str) {
+    val n: usize = s.len::usize;
     var i: usize = 0;
-    for (s[i] != 0) {
-        emit_byte(e, s[i]);
+    for (i < n) {
+        emit_byte(e, s.data[i]);
         i = i + 1;
     }
 }

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -312,6 +312,9 @@ fun parse_null(p: *Parser) Result[Value, str] {
 }
 
 fun parse_bool(p: *Parser) Result[Value, str] {
+    if (p.pos >= p.len) {
+        ret err[Value, str]("unexpected end of input in boolean");
+    }
     if (p.src[p.pos] == 't') {
         if (p.pos + 4 > p.len) {
             ret err[Value, str]("unexpected end of input in true");

--- a/src/data/toml.mach
+++ b/src/data/toml.mach
@@ -21,6 +21,7 @@ pub val TYPE_ARRAY:   u8 = 4;
 pub val TYPE_TABLE:   u8 = 5;
 
 val VALUE_SIZE: usize = $size_of(Value);
+val STR_SIZE:   usize = $size_of(str);
 
 # Value: tagged TOML value.
 # ---
@@ -113,7 +114,7 @@ fun table_set(a: *Allocator, t: *Table, key: str, val_: Value) Result[bool, str]
             }
         }
 
-        val kr: Result[*u8, str] = allocate[u8](a, new_cap * 8);
+        val kr: Result[*u8, str] = allocate[u8](a, new_cap * STR_SIZE);
         if (is_err[*u8, str](kr)) { ret err[bool, str](unwrap_err[*u8, str](kr)); }
         val new_keys: *str = unwrap_ok[*u8, str](kr)::*str;
 
@@ -122,7 +123,7 @@ fun table_set(a: *Allocator, t: *Table, key: str, val_: Value) Result[bool, str]
         val new_vals: *Value = unwrap_ok[*u8, str](vr)::*Value;
 
         if (t.len > 0) {
-            mem.raw_copy(new_keys::ptr, t.keys, t.len * 8);
+            mem.raw_copy(new_keys::ptr, t.keys, t.len * STR_SIZE);
             mem.raw_copy(new_vals::ptr, t.values, t.len * VALUE_SIZE);
         }
 
@@ -256,11 +257,11 @@ fun keysegs_push(a: *Allocator, ks: *KeySegs, seg: str) Result[bool, str] {
             }
         }
 
-        val r: Result[*u8, str] = allocate[u8](a, new_cap * 8);
+        val r: Result[*u8, str] = allocate[u8](a, new_cap * STR_SIZE);
         if (is_err[*u8, str](r)) { ret err[bool, str](unwrap_err[*u8, str](r)); }
         val new_segs: *str = unwrap_ok[*u8, str](r)::*str;
         if (ks.len > 0) {
-            mem.raw_copy(new_segs::ptr, ks.segs::ptr, ks.len * 8);
+            mem.raw_copy(new_segs::ptr, ks.segs::ptr, ks.len * STR_SIZE);
         }
         ks.segs = new_segs;
         ks.cap = new_cap;
@@ -321,15 +322,19 @@ fun value_array(a: Array) Value {
 # path: dotted key path (e.g. "project.name")
 # ret:  pointer to the value, or nil if not found
 pub fun get(t: *Table, path: str) *Value {
-    if (t == nil || path == nil) { ret nil; }
+    if (t == nil || path.data == nil) { ret nil; }
 
     var current: *Table = t;
     var start: usize = 0;
     var i: usize = 0;
+    val plen: usize = path.len::usize;
 
-    for (path[i] != 0) {
-        if (path[i] == '.') {
-            val v: *Value = find_by_seg(current, (path::usize + start)::str, i - start);
+    for (i < plen) {
+        if (path.data[i] == '.') {
+            var seg: str;
+            seg.len  = (i - start)::u32;
+            seg.data = (path.data::usize + start)::*u8;
+            val v: *Value = find_by_seg(current, seg, i - start);
             if (v == nil || v.tag != TYPE_TABLE) { ret nil; }
             current = ?v.data.table;
             start = i + 1;
@@ -337,7 +342,10 @@ pub fun get(t: *Table, path: str) *Value {
         i = i + 1;
     }
 
-    ret find_by_seg(current, (path::usize + start)::str, i - start);
+    var seg: str;
+    seg.len  = (i - start)::u32;
+    seg.data = (path.data::usize + start)::*u8;
+    ret find_by_seg(current, seg, i - start);
 }
 
 # find_by_seg: find a value by key prefix and length.
@@ -364,7 +372,7 @@ fun find_by_seg(t: *Table, seg: str, seg_len: usize) *Value {
 fun str_eq_n(a: str, b: str, n: usize) bool {
     var i: usize = 0;
     for (i < n) {
-        if (a[i] != b[i]) { ret false; }
+        if (a.data[i] != b.data[i]) { ret false; }
         i = i + 1;
     }
     ret true;
@@ -377,7 +385,12 @@ fun str_eq_n(a: str, b: str, n: usize) bool {
 # ret:  the string value, or nil if not found or wrong type
 pub fun get_str(t: *Table, path: str) str {
     val v: *Value = get(t, path);
-    if (v == nil || v.tag != TYPE_STRING) { ret nil; }
+    if (v == nil || v.tag != TYPE_STRING) {
+        var empty: str;
+        empty.len  = 0;
+        empty.data = nil;
+        ret empty;
+    }
     ret v.data.string;
 }
 
@@ -462,7 +475,12 @@ pub fun table_len(t: *Table) usize {
 # index: position (0-based)
 # ret:   key string, or nil if out of bounds
 pub fun table_key(t: *Table, index: usize) str {
-    if (t == nil || index >= t.len) { ret nil; }
+    if (t == nil || index >= t.len) {
+        var empty: str;
+        empty.len  = 0;
+        empty.data = nil;
+        ret empty;
+    }
     val keys: *str = t.keys::*str;
     ret keys[index];
 }
@@ -503,20 +521,20 @@ fun is_bare_key_char(b: u8) bool {
 }
 
 fun skip_ws(src: str, i: *usize) {
-    for (is_ws(src[@i])) {
+    for (is_ws(src.data[@i])) {
         @i = @i + 1;
     }
 }
 
 fun skip_ws_and_newlines(src: str, i: *usize) {
-    for (is_ws_or_newline(src[@i])) {
+    for (is_ws_or_newline(src.data[@i])) {
         @i = @i + 1;
     }
 }
 
 fun skip_comment(src: str, i: *usize) {
-    if (src[@i] == '#') {
-        for (src[@i] != 0 && src[@i] != '\n') {
+    if (src.data[@i] == '#') {
+        for (src.data[@i] != 0 && src.data[@i] != '\n') {
             @i = @i + 1;
         }
     }
@@ -525,7 +543,7 @@ fun skip_comment(src: str, i: *usize) {
 fun skip_ws_comments_newlines(src: str, i: *usize) {
     for {
         skip_ws_and_newlines(src, i);
-        if (src[@i] == '#') {
+        if (src.data[@i] == '#') {
             skip_comment(src, i);
             cnt;
         }
@@ -536,8 +554,8 @@ fun skip_ws_comments_newlines(src: str, i: *usize) {
 fun skip_to_newline(src: str, i: *usize) {
     skip_ws(src, i);
     skip_comment(src, i);
-    if (src[@i] == '\r') { @i = @i + 1; }
-    if (src[@i] == '\n') { @i = @i + 1; }
+    if (src.data[@i] == '\r') { @i = @i + 1; }
+    if (src.data[@i] == '\n') { @i = @i + 1; }
 }
 
 # alloc_str: allocate a copy of a substring.
@@ -553,9 +571,12 @@ fun alloc_str(a: *Allocator, src: str, start: usize, len: usize) Result[str, str
         ret err[str, str](unwrap_err[*u8, str](r));
     }
     val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, (src::usize + start)::ptr, len);
+    mem.raw_copy(buf::ptr, (src.data::usize + start)::ptr, len);
     buf[len] = 0;
-    ret ok[str, str](buf::*u8);
+    var out: str;
+    out.len  = len::u32;
+    out.data = buf;
+    ret ok[str, str](out);
 }
 
 # hex_digit: return the numeric value of a hex character, or -1.
@@ -570,7 +591,7 @@ fun hex_digit(c: u8) i32 {
 # advances si past the escape. returns 0 on invalid escape, otherwise
 # the number of bytes written (1 for simple escapes, 1-4 for unicode).
 fun decode_escape(src: str, si: *usize, buf: *u8, di: usize) usize {
-    val e: u8 = src[@si];
+    val e: u8 = src.data[@si];
 
     if (e == 'n')   { buf[di] = '\n'; @si = @si + 1; ret 1; }
     if (e == 't')   { buf[di] = '\t'; @si = @si + 1; ret 1; }
@@ -587,7 +608,7 @@ fun decode_escape(src: str, si: *usize, buf: *u8, di: usize) usize {
         var code: u32 = 0;
         var k: usize = 0;
         for (k < ndig) {
-            val d: i32 = hex_digit(src[@si + 1 + k]);
+            val d: i32 = hex_digit(src.data[@si + 1 + k]);
             if (d < 0) { ret 0; }
             code = (code << 4) | d::u32;
             k = k + 1;
@@ -602,17 +623,17 @@ fun decode_escape(src: str, si: *usize, buf: *u8, di: usize) usize {
     ret 0;
 }
 
-# count_escape_len: count output bytes for an escape at src[@i].
+# count_escape_len: count output bytes for an escape at src.data[@i].
 # advances i past the escape sequence.
 fun count_escape_len(src: str, i: *usize) usize {
-    val e: u8 = src[@i];
+    val e: u8 = src.data[@i];
     if (e == 'u' || e == 'U') {
         var ndig: usize = 4;
         if (e == 'U') { ndig = 8; }
         var code: u32 = 0;
         var k: usize = 0;
         for (k < ndig) {
-            val d: i32 = hex_digit(src[@i + 1 + k]);
+            val d: i32 = hex_digit(src.data[@i + 1 + k]);
             if (d >= 0) { code = (code << 4) | d::u32; }
             k = k + 1;
         }
@@ -666,7 +687,7 @@ fun encode_utf8(buf: *u8, di: usize, code: u32) usize {
 fun parse_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     @i = @i + 1;
 
-    if (src[@i] == '"' && src[@i + 1] == '"') {
+    if (src.data[@i] == '"' && src.data[@i + 1] == '"') {
         @i = @i + 2;
         ret parse_ml_basic_string(a, src, i);
     }
@@ -676,12 +697,12 @@ fun parse_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     # pass 1: compute output length
     var out_len: usize = 0;
     for {
-        val b: u8 = src[@i];
+        val b: u8 = src.data[@i];
         if (b == 0 || b == '\n') { ret err[str, str]("unterminated string"); }
         if (b == '"') { brk; }
         if (b == '\\') {
             @i = @i + 1;
-            if (src[@i] == 0) { ret err[str, str]("unterminated escape"); }
+            if (src.data[@i] == 0) { ret err[str, str]("unterminated escape"); }
             out_len = out_len + count_escape_len(src, i);
             cnt;
         }
@@ -697,8 +718,8 @@ fun parse_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     var si: usize = start;
     var di: usize = 0;
     for {
-        if (src[si] == '"') { brk; }
-        if (src[si] == '\\') {
+        if (src.data[si] == '"') { brk; }
+        if (src.data[si] == '\\') {
             si = si + 1;
             val esc_len: usize = decode_escape(src, ?si, buf, di);
             if (esc_len == 0) {
@@ -707,14 +728,17 @@ fun parse_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
             di = di + esc_len;
             cnt;
         }
-        buf[di] = src[si];
+        buf[di] = src.data[si];
         di = di + 1;
         si = si + 1;
     }
 
     buf[out_len] = 0;
     @i = @i + 1;
-    ret ok[str, str](buf::*u8);
+    var out: str;
+    out.len  = out_len::u32;
+    out.data = buf;
+    ret ok[str, str](out);
 }
 
 # parse_ml_basic_string: parse a triple-quoted basic string.
@@ -726,21 +750,21 @@ fun parse_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
 # ret: the parsed string, or an error
 fun parse_ml_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     # skip immediate newline after opening """
-    if (src[@i] == '\n') { @i = @i + 1; }
-    or (src[@i] == '\r' && src[@i + 1] == '\n') { @i = @i + 2; }
+    if (src.data[@i] == '\n') { @i = @i + 1; }
+    or (src.data[@i] == '\r' && src.data[@i + 1] == '\n') { @i = @i + 2; }
 
     val start: usize = @i;
     var out_len: usize = 0;
 
     # pass 1: compute output length
     for {
-        if (src[@i] == 0) { ret err[str, str]("unterminated multi-line string"); }
-        if (src[@i] == '"' && src[@i + 1] == '"' && src[@i + 2] == '"') { brk; }
-        if (src[@i] == '\\') {
+        if (src.data[@i] == 0) { ret err[str, str]("unterminated multi-line string"); }
+        if (src.data[@i] == '"' && src.data[@i + 1] == '"' && src.data[@i + 2] == '"') { brk; }
+        if (src.data[@i] == '\\') {
             @i = @i + 1;
             # line-ending backslash: skip trailing whitespace
-            if (is_ws_or_newline(src[@i])) {
-                for (is_ws_or_newline(src[@i])) { @i = @i + 1; }
+            if (is_ws_or_newline(src.data[@i])) {
+                for (is_ws_or_newline(src.data[@i])) { @i = @i + 1; }
                 cnt;
             }
             out_len = out_len + count_escape_len(src, i);
@@ -758,24 +782,27 @@ fun parse_ml_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     var si: usize = start;
     var di: usize = 0;
     for {
-        if (src[si] == '"' && src[si + 1] == '"' && src[si + 2] == '"') { brk; }
-        if (src[si] == '\\') {
+        if (src.data[si] == '"' && src.data[si + 1] == '"' && src.data[si + 2] == '"') { brk; }
+        if (src.data[si] == '\\') {
             si = si + 1;
-            if (is_ws_or_newline(src[si])) {
-                for (is_ws_or_newline(src[si])) { si = si + 1; }
+            if (is_ws_or_newline(src.data[si])) {
+                for (is_ws_or_newline(src.data[si])) { si = si + 1; }
                 cnt;
             }
             di = di + decode_escape(src, ?si, buf, di);
             cnt;
         }
-        buf[di] = src[si];
+        buf[di] = src.data[si];
         di = di + 1;
         si = si + 1;
     }
 
     buf[out_len] = 0;
     @i = @i + 3;
-    ret ok[str, str](buf::*u8);
+    var out: str;
+    out.len  = out_len::u32;
+    out.data = buf;
+    ret ok[str, str](out);
 }
 
 # parse_literal_string: parse a single-quoted string (no escapes).
@@ -788,16 +815,16 @@ fun parse_ml_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
 fun parse_literal_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     @i = @i + 1;
 
-    if (src[@i] == '\'' && src[@i + 1] == '\'') {
+    if (src.data[@i] == '\'' && src.data[@i + 1] == '\'') {
         @i = @i + 2;
         ret parse_ml_literal_string(a, src, i);
     }
 
     val start: usize = @i;
-    for (src[@i] != 0 && src[@i] != '\'' && src[@i] != '\n') {
+    for (src.data[@i] != 0 && src.data[@i] != '\'' && src.data[@i] != '\n') {
         @i = @i + 1;
     }
-    if (src[@i] != '\'') { ret err[str, str]("unterminated literal string"); }
+    if (src.data[@i] != '\'') { ret err[str, str]("unterminated literal string"); }
 
     val len: usize = @i - start;
     @i = @i + 1;
@@ -812,13 +839,13 @@ fun parse_literal_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
 # i:   cursor position
 # ret: the parsed string, or an error
 fun parse_ml_literal_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
-    if (src[@i] == '\n') { @i = @i + 1; }
-    or (src[@i] == '\r' && src[@i + 1] == '\n') { @i = @i + 2; }
+    if (src.data[@i] == '\n') { @i = @i + 1; }
+    or (src.data[@i] == '\r' && src.data[@i + 1] == '\n') { @i = @i + 2; }
 
     val start: usize = @i;
     for {
-        if (src[@i] == 0) { ret err[str, str]("unterminated multi-line literal string"); }
-        if (src[@i] == '\'' && src[@i + 1] == '\'' && src[@i + 2] == '\'') { brk; }
+        if (src.data[@i] == 0) { ret err[str, str]("unterminated multi-line literal string"); }
+        if (src.data[@i] == '\'' && src.data[@i + 1] == '\'' && src.data[@i + 2] == '\'') { brk; }
         @i = @i + 1;
     }
 
@@ -836,11 +863,11 @@ fun parse_ml_literal_string(a: *Allocator, src: str, i: *usize) Result[str, str]
 # ret: parsed Value, or an error
 fun parse_number(src: str, i: *usize) Result[Value, str] {
     var sign: i64 = 1;
-    if (src[@i] == '+') { @i = @i + 1; }
-    or (src[@i] == '-') { sign = -1; @i = @i + 1; }
+    if (src.data[@i] == '+') { @i = @i + 1; }
+    or (src.data[@i] == '-') { sign = -1; @i = @i + 1; }
 
     # inf
-    if (src[@i] == 'i' && src[@i + 1] == 'n' && src[@i + 2] == 'f') {
+    if (src.data[@i] == 'i' && src.data[@i + 1] == 'n' && src.data[@i + 2] == 'f') {
         @i = @i + 3;
         var bits: u64 = 0x7FF0000000000000;
         if (sign < 0) { bits = 0xFFF0000000000000; }
@@ -850,7 +877,7 @@ fun parse_number(src: str, i: *usize) Result[Value, str] {
     }
 
     # nan
-    if (src[@i] == 'n' && src[@i + 1] == 'a' && src[@i + 2] == 'n') {
+    if (src.data[@i] == 'n' && src.data[@i + 1] == 'a' && src.data[@i + 2] == 'n') {
         @i = @i + 3;
         var bits: u64 = 0x7FF8000000000000;
         if (sign < 0) { bits = 0xFFF8000000000000; }
@@ -860,8 +887,8 @@ fun parse_number(src: str, i: *usize) Result[Value, str] {
     }
 
     # hex, octal, binary prefixes
-    if (src[@i] == '0') {
-        val next: u8 = src[@i + 1];
+    if (src.data[@i] == '0') {
+        val next: u8 = src.data[@i + 1];
         if (next == 'x' || next == 'X') {
             @i = @i + 2;
             ret parse_hex_int(src, i, sign);
@@ -880,7 +907,7 @@ fun parse_number(src: str, i: *usize) Result[Value, str] {
     var x: u64 = 0;
     var any: bool = false;
     for {
-        val b: u8 = src[@i];
+        val b: u8 = src.data[@i];
         if (b == '_') { @i = @i + 1; cnt; }
         if (b < '0' || b > '9') { brk; }
         any = true;
@@ -896,12 +923,12 @@ fun parse_number(src: str, i: *usize) Result[Value, str] {
     if (!any) { ret err[Value, str]("expected number"); }
 
     # fractional part
-    if (src[@i] == '.' && src[@i + 1] >= '0' && src[@i + 1] <= '9') {
+    if (src.data[@i] == '.' && src.data[@i + 1] >= '0' && src.data[@i + 1] <= '9') {
         ret parse_float_frac(src, i, x::i64, sign);
     }
 
     # exponent without fraction
-    if (src[@i] == 'e' || src[@i] == 'E') {
+    if (src.data[@i] == 'e' || src.data[@i] == 'E') {
         ret parse_float_exp(src, i, x::f64 * sign::f64);
     }
 
@@ -921,7 +948,7 @@ fun parse_float_frac(src: str, i: *usize, int_part: i64, sign: i64) Result[Value
     var divisor: f64 = 1.0;
 
     for {
-        val b: u8 = src[@i];
+        val b: u8 = src.data[@i];
         if (b == '_') { @i = @i + 1; cnt; }
         if (b < '0' || b > '9') { brk; }
         frac = frac * 10.0 + (b - '0')::u64::f64;
@@ -931,7 +958,7 @@ fun parse_float_frac(src: str, i: *usize, int_part: i64, sign: i64) Result[Value
 
     var result: f64 = (int_part::f64 + frac / divisor) * sign::f64;
 
-    if (src[@i] == 'e' || src[@i] == 'E') {
+    if (src.data[@i] == 'e' || src.data[@i] == 'E') {
         ret parse_float_exp(src, i, result);
     }
 
@@ -947,13 +974,13 @@ fun parse_float_frac(src: str, i: *usize, int_part: i64, sign: i64) Result[Value
 fun parse_float_exp(src: str, i: *usize, mantissa: f64) Result[Value, str] {
     @i = @i + 1;
     var exp_sign: i64 = 1;
-    if (src[@i] == '+') { @i = @i + 1; }
-    or (src[@i] == '-') { exp_sign = -1; @i = @i + 1; }
+    if (src.data[@i] == '+') { @i = @i + 1; }
+    or (src.data[@i] == '-') { exp_sign = -1; @i = @i + 1; }
 
     var exp: i64 = 0;
     var any: bool = false;
     for {
-        val b: u8 = src[@i];
+        val b: u8 = src.data[@i];
         if (b == '_') { @i = @i + 1; cnt; }
         if (b < '0' || b > '9') { brk; }
         any = true;
@@ -1013,7 +1040,7 @@ fun parse_hex_int(src: str, i: *usize, sign: i64) Result[Value, str] {
     var x: u64 = 0;
     var any: bool = false;
     for {
-        val b: u8 = src[@i];
+        val b: u8 = src.data[@i];
         if (b == '_') { @i = @i + 1; cnt; }
         val d: i32 = hex_digit(b);
         if (d < 0) { brk; }
@@ -1031,7 +1058,7 @@ fun parse_oct_int(src: str, i: *usize, sign: i64) Result[Value, str] {
     var x: u64 = 0;
     var any: bool = false;
     for {
-        val b: u8 = src[@i];
+        val b: u8 = src.data[@i];
         if (b == '_') { @i = @i + 1; cnt; }
         if (b < '0' || b > '7') { brk; }
         any = true;
@@ -1048,7 +1075,7 @@ fun parse_bin_int(src: str, i: *usize, sign: i64) Result[Value, str] {
     var x: u64 = 0;
     var any: bool = false;
     for {
-        val b: u8 = src[@i];
+        val b: u8 = src.data[@i];
         if (b == '_') { @i = @i + 1; cnt; }
         if (b != '0' && b != '1') { brk; }
         any = true;
@@ -1068,13 +1095,13 @@ fun is_value_term(b: u8) bool {
 
 # parse_bool_val: parse "true" or "false".
 fun parse_bool_val(src: str, i: *usize) Result[Value, str] {
-    if (src[@i] == 't' && src[@i + 1] == 'r' && src[@i + 2] == 'u' && src[@i + 3] == 'e') {
-        if (!is_value_term(src[@i + 4])) { ret err[Value, str]("expected boolean"); }
+    if (src.data[@i] == 't' && src.data[@i + 1] == 'r' && src.data[@i + 2] == 'u' && src.data[@i + 3] == 'e') {
+        if (!is_value_term(src.data[@i + 4])) { ret err[Value, str]("expected boolean"); }
         @i = @i + 4;
         ret ok[Value, str](value_bool(true));
     }
-    if (src[@i] == 'f' && src[@i + 1] == 'a' && src[@i + 2] == 'l' && src[@i + 3] == 's' && src[@i + 4] == 'e') {
-        if (!is_value_term(src[@i + 5])) { ret err[Value, str]("expected boolean"); }
+    if (src.data[@i] == 'f' && src.data[@i + 1] == 'a' && src.data[@i + 2] == 'l' && src.data[@i + 3] == 's' && src.data[@i + 4] == 'e') {
+        if (!is_value_term(src.data[@i + 5])) { ret err[Value, str]("expected boolean"); }
         @i = @i + 5;
         ret ok[Value, str](value_bool(false));
     }
@@ -1088,15 +1115,15 @@ fun parse_bool_val(src: str, i: *usize) Result[Value, str] {
 # i:   cursor position
 # ret: the key string, or an error
 fun parse_key_segment(a: *Allocator, src: str, i: *usize) Result[str, str] {
-    if (src[@i] == '"') {
+    if (src.data[@i] == '"') {
         ret parse_basic_string(a, src, i);
     }
-    if (src[@i] == '\'') {
+    if (src.data[@i] == '\'') {
         ret parse_literal_string(a, src, i);
     }
 
     val start: usize = @i;
-    for (is_bare_key_char(src[@i])) {
+    for (is_bare_key_char(src.data[@i])) {
         @i = @i + 1;
     }
     if (@i == start) { ret err[str, str]("expected key"); }
@@ -1122,7 +1149,7 @@ fun parse_key_path(a: *Allocator, src: str, i: *usize) Result[KeySegs, str] {
     val pr: Result[bool, str] = keysegs_push(a, ?ks, unwrap_ok[str, str](first));
     if (is_err[bool, str](pr)) { ret err[KeySegs, str](unwrap_err[bool, str](pr)); }
 
-    for (src[@i] == '.') {
+    for (src.data[@i] == '.') {
         @i = @i + 1;
         val seg: Result[str, str] = parse_key_segment(a, src, i);
         if (is_err[str, str](seg)) { ret err[KeySegs, str](unwrap_err[str, str](seg)); }
@@ -1162,7 +1189,7 @@ fun navigate_segs(a: *Allocator, t: *Table, ks: *KeySegs) Result[*Table, str] {
 fun parse_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
     skip_ws(src, i);
 
-    val b: u8 = src[@i];
+    val b: u8 = src.data[@i];
 
     if (b == '"') {
         val r: Result[str, str] = parse_basic_string(a, src, i);
@@ -1207,7 +1234,7 @@ fun parse_array_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
 
     for {
         skip_ws_comments_newlines(src, i);
-        if (src[@i] == ']') {
+        if (src.data[@i] == ']') {
             @i = @i + 1;
             brk;
         }
@@ -1219,7 +1246,7 @@ fun parse_array_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
         if (is_err[bool, str](pr)) { ret err[Value, str](unwrap_err[bool, str](pr)); }
 
         skip_ws_comments_newlines(src, i);
-        if (src[@i] == ',') {
+        if (src.data[@i] == ',') {
             @i = @i + 1;
             cnt;
         }
@@ -1239,7 +1266,7 @@ fun parse_inline_table(a: *Allocator, src: str, i: *usize) Result[Value, str] {
     var t: Table = table_make();
 
     skip_ws(src, i);
-    if (src[@i] == '}') {
+    if (src.data[@i] == '}') {
         @i = @i + 1;
         ret ok[Value, str](value_table(t));
     }
@@ -1252,7 +1279,7 @@ fun parse_inline_table(a: *Allocator, src: str, i: *usize) Result[Value, str] {
         var ks: KeySegs = unwrap_ok[KeySegs, str](ksr);
 
         skip_ws(src, i);
-        if (src[@i] != '=') { ret err[Value, str]("expected '=' in inline table"); }
+        if (src.data[@i] != '=') { ret err[Value, str]("expected '=' in inline table"); }
         @i = @i + 1;
 
         val vr: Result[Value, str] = parse_value(a, src, i);
@@ -1265,11 +1292,11 @@ fun parse_inline_table(a: *Allocator, src: str, i: *usize) Result[Value, str] {
         if (is_err[bool, str](sr)) { ret err[Value, str](unwrap_err[bool, str](sr)); }
 
         skip_ws(src, i);
-        if (src[@i] == ',') {
+        if (src.data[@i] == ',') {
             @i = @i + 1;
             cnt;
         }
-        if (src[@i] == '}') {
+        if (src.data[@i] == '}') {
             @i = @i + 1;
             brk;
         }
@@ -1368,7 +1395,7 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
     if (a == nil) {
         ret err[Table, str]("allocator is nil");
     }
-    if (src == nil) {
+    if (src.data == nil) {
         ret err[Table, str]("source is nil");
     }
 
@@ -1378,10 +1405,10 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
 
     for {
         skip_ws_comments_newlines(src, ?i);
-        if (src[i] == 0) { brk; }
+        if (src.data[i] == 0) { brk; }
 
         # array of tables: [[key]]
-        if (src[i] == '[' && src[i + 1] == '[') {
+        if (src.data[i] == '[' && src.data[i + 1] == '[') {
             i = i + 2;
             skip_ws(src, ?i);
 
@@ -1390,7 +1417,7 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
             var ks: KeySegs = unwrap_ok[KeySegs, str](ksr);
 
             skip_ws(src, ?i);
-            if (src[i] != ']' || src[i + 1] != ']') {
+            if (src.data[i] != ']' || src.data[i + 1] != ']') {
                 ret err[Table, str]("expected ']]'");
             }
             i = i + 2;
@@ -1404,7 +1431,7 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
         }
 
         # table header: [key]
-        if (src[i] == '[') {
+        if (src.data[i] == '[') {
             i = i + 1;
             skip_ws(src, ?i);
 
@@ -1413,7 +1440,7 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
             var ks: KeySegs = unwrap_ok[KeySegs, str](ksr);
 
             skip_ws(src, ?i);
-            if (src[i] != ']') {
+            if (src.data[i] != ']') {
                 ret err[Table, str]("expected ']'");
             }
             i = i + 1;
@@ -1438,7 +1465,7 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
         var ks: KeySegs = unwrap_ok[KeySegs, str](ksr);
 
         skip_ws(src, ?i);
-        if (src[i] != '=') {
+        if (src.data[i] != '=') {
             ret err[Table, str]("expected '='");
         }
         i = i + 1;

--- a/src/data/toml.mach
+++ b/src/data/toml.mach
@@ -505,6 +505,17 @@ pub fun array_len(arr: *Array) usize {
     ret arr.len;
 }
 
+# peek_at: read a byte from src.data, returning 0 for out-of-range.
+#
+# every parser site that previously checked `peek_at(src, @i) == 0` for EOF
+# now goes through peek_at instead. this preserves the established
+# "null byte means stop" idiom while making it independent of whether
+# the input buffer happens to carry a trailing null.
+fun peek_at(src: str, i: usize) u8 {
+    if (i >= src.len::usize) { ret 0; }
+    ret peek_at(src, i);
+}
+
 fun is_ws(b: u8) bool {
     ret b == ' ' || b == '\t';
 }
@@ -521,20 +532,20 @@ fun is_bare_key_char(b: u8) bool {
 }
 
 fun skip_ws(src: str, i: *usize) {
-    for (is_ws(src.data[@i])) {
+    for (is_ws(peek_at(src, @i))) {
         @i = @i + 1;
     }
 }
 
 fun skip_ws_and_newlines(src: str, i: *usize) {
-    for (is_ws_or_newline(src.data[@i])) {
+    for (is_ws_or_newline(peek_at(src, @i))) {
         @i = @i + 1;
     }
 }
 
 fun skip_comment(src: str, i: *usize) {
-    if (src.data[@i] == '#') {
-        for (src.data[@i] != 0 && src.data[@i] != '\n') {
+    if (peek_at(src, @i) == '#') {
+        for (peek_at(src, @i) != 0 && peek_at(src, @i) != '\n') {
             @i = @i + 1;
         }
     }
@@ -543,7 +554,7 @@ fun skip_comment(src: str, i: *usize) {
 fun skip_ws_comments_newlines(src: str, i: *usize) {
     for {
         skip_ws_and_newlines(src, i);
-        if (src.data[@i] == '#') {
+        if (peek_at(src, @i) == '#') {
             skip_comment(src, i);
             cnt;
         }
@@ -554,8 +565,8 @@ fun skip_ws_comments_newlines(src: str, i: *usize) {
 fun skip_to_newline(src: str, i: *usize) {
     skip_ws(src, i);
     skip_comment(src, i);
-    if (src.data[@i] == '\r') { @i = @i + 1; }
-    if (src.data[@i] == '\n') { @i = @i + 1; }
+    if (peek_at(src, @i) == '\r') { @i = @i + 1; }
+    if (peek_at(src, @i) == '\n') { @i = @i + 1; }
 }
 
 # alloc_str: allocate a copy of a substring.
@@ -591,7 +602,7 @@ fun hex_digit(c: u8) i32 {
 # advances si past the escape. returns 0 on invalid escape, otherwise
 # the number of bytes written (1 for simple escapes, 1-4 for unicode).
 fun decode_escape(src: str, si: *usize, buf: *u8, di: usize) usize {
-    val e: u8 = src.data[@si];
+    val e: u8 = peek_at(src, @si);
 
     if (e == 'n')   { buf[di] = '\n'; @si = @si + 1; ret 1; }
     if (e == 't')   { buf[di] = '\t'; @si = @si + 1; ret 1; }
@@ -608,7 +619,7 @@ fun decode_escape(src: str, si: *usize, buf: *u8, di: usize) usize {
         var code: u32 = 0;
         var k: usize = 0;
         for (k < ndig) {
-            val d: i32 = hex_digit(src.data[@si + 1 + k]);
+            val d: i32 = hex_digit(peek_at(src, @si + 1 + k));
             if (d < 0) { ret 0; }
             code = (code << 4) | d::u32;
             k = k + 1;
@@ -623,17 +634,17 @@ fun decode_escape(src: str, si: *usize, buf: *u8, di: usize) usize {
     ret 0;
 }
 
-# count_escape_len: count output bytes for an escape at src.data[@i].
+# count_escape_len: count output bytes for an escape at peek_at(src, @i).
 # advances i past the escape sequence.
 fun count_escape_len(src: str, i: *usize) usize {
-    val e: u8 = src.data[@i];
+    val e: u8 = peek_at(src, @i);
     if (e == 'u' || e == 'U') {
         var ndig: usize = 4;
         if (e == 'U') { ndig = 8; }
         var code: u32 = 0;
         var k: usize = 0;
         for (k < ndig) {
-            val d: i32 = hex_digit(src.data[@i + 1 + k]);
+            val d: i32 = hex_digit(peek_at(src, @i + 1 + k));
             if (d >= 0) { code = (code << 4) | d::u32; }
             k = k + 1;
         }
@@ -687,7 +698,7 @@ fun encode_utf8(buf: *u8, di: usize, code: u32) usize {
 fun parse_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     @i = @i + 1;
 
-    if (src.data[@i] == '"' && src.data[@i + 1] == '"') {
+    if (peek_at(src, @i) == '"' && peek_at(src, @i + 1) == '"') {
         @i = @i + 2;
         ret parse_ml_basic_string(a, src, i);
     }
@@ -697,12 +708,12 @@ fun parse_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     # pass 1: compute output length
     var out_len: usize = 0;
     for {
-        val b: u8 = src.data[@i];
+        val b: u8 = peek_at(src, @i);
         if (b == 0 || b == '\n') { ret err[str, str]("unterminated string"); }
         if (b == '"') { brk; }
         if (b == '\\') {
             @i = @i + 1;
-            if (src.data[@i] == 0) { ret err[str, str]("unterminated escape"); }
+            if (peek_at(src, @i) == 0) { ret err[str, str]("unterminated escape"); }
             out_len = out_len + count_escape_len(src, i);
             cnt;
         }
@@ -718,8 +729,8 @@ fun parse_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     var si: usize = start;
     var di: usize = 0;
     for {
-        if (src.data[si] == '"') { brk; }
-        if (src.data[si] == '\\') {
+        if (peek_at(src, si) == '"') { brk; }
+        if (peek_at(src, si) == '\\') {
             si = si + 1;
             val esc_len: usize = decode_escape(src, ?si, buf, di);
             if (esc_len == 0) {
@@ -728,7 +739,7 @@ fun parse_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
             di = di + esc_len;
             cnt;
         }
-        buf[di] = src.data[si];
+        buf[di] = peek_at(src, si);
         di = di + 1;
         si = si + 1;
     }
@@ -750,21 +761,21 @@ fun parse_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
 # ret: the parsed string, or an error
 fun parse_ml_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     # skip immediate newline after opening """
-    if (src.data[@i] == '\n') { @i = @i + 1; }
-    or (src.data[@i] == '\r' && src.data[@i + 1] == '\n') { @i = @i + 2; }
+    if (peek_at(src, @i) == '\n') { @i = @i + 1; }
+    or (peek_at(src, @i) == '\r' && peek_at(src, @i + 1) == '\n') { @i = @i + 2; }
 
     val start: usize = @i;
     var out_len: usize = 0;
 
     # pass 1: compute output length
     for {
-        if (src.data[@i] == 0) { ret err[str, str]("unterminated multi-line string"); }
-        if (src.data[@i] == '"' && src.data[@i + 1] == '"' && src.data[@i + 2] == '"') { brk; }
-        if (src.data[@i] == '\\') {
+        if (peek_at(src, @i) == 0) { ret err[str, str]("unterminated multi-line string"); }
+        if (peek_at(src, @i) == '"' && peek_at(src, @i + 1) == '"' && peek_at(src, @i + 2) == '"') { brk; }
+        if (peek_at(src, @i) == '\\') {
             @i = @i + 1;
             # line-ending backslash: skip trailing whitespace
-            if (is_ws_or_newline(src.data[@i])) {
-                for (is_ws_or_newline(src.data[@i])) { @i = @i + 1; }
+            if (is_ws_or_newline(peek_at(src, @i))) {
+                for (is_ws_or_newline(peek_at(src, @i))) { @i = @i + 1; }
                 cnt;
             }
             out_len = out_len + count_escape_len(src, i);
@@ -782,17 +793,17 @@ fun parse_ml_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     var si: usize = start;
     var di: usize = 0;
     for {
-        if (src.data[si] == '"' && src.data[si + 1] == '"' && src.data[si + 2] == '"') { brk; }
-        if (src.data[si] == '\\') {
+        if (peek_at(src, si) == '"' && peek_at(src, si + 1) == '"' && peek_at(src, si + 2) == '"') { brk; }
+        if (peek_at(src, si) == '\\') {
             si = si + 1;
-            if (is_ws_or_newline(src.data[si])) {
-                for (is_ws_or_newline(src.data[si])) { si = si + 1; }
+            if (is_ws_or_newline(peek_at(src, si))) {
+                for (is_ws_or_newline(peek_at(src, si))) { si = si + 1; }
                 cnt;
             }
             di = di + decode_escape(src, ?si, buf, di);
             cnt;
         }
-        buf[di] = src.data[si];
+        buf[di] = peek_at(src, si);
         di = di + 1;
         si = si + 1;
     }
@@ -815,16 +826,16 @@ fun parse_ml_basic_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
 fun parse_literal_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
     @i = @i + 1;
 
-    if (src.data[@i] == '\'' && src.data[@i + 1] == '\'') {
+    if (peek_at(src, @i) == '\'' && peek_at(src, @i + 1) == '\'') {
         @i = @i + 2;
         ret parse_ml_literal_string(a, src, i);
     }
 
     val start: usize = @i;
-    for (src.data[@i] != 0 && src.data[@i] != '\'' && src.data[@i] != '\n') {
+    for (peek_at(src, @i) != 0 && peek_at(src, @i) != '\'' && peek_at(src, @i) != '\n') {
         @i = @i + 1;
     }
-    if (src.data[@i] != '\'') { ret err[str, str]("unterminated literal string"); }
+    if (peek_at(src, @i) != '\'') { ret err[str, str]("unterminated literal string"); }
 
     val len: usize = @i - start;
     @i = @i + 1;
@@ -839,13 +850,13 @@ fun parse_literal_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
 # i:   cursor position
 # ret: the parsed string, or an error
 fun parse_ml_literal_string(a: *Allocator, src: str, i: *usize) Result[str, str] {
-    if (src.data[@i] == '\n') { @i = @i + 1; }
-    or (src.data[@i] == '\r' && src.data[@i + 1] == '\n') { @i = @i + 2; }
+    if (peek_at(src, @i) == '\n') { @i = @i + 1; }
+    or (peek_at(src, @i) == '\r' && peek_at(src, @i + 1) == '\n') { @i = @i + 2; }
 
     val start: usize = @i;
     for {
-        if (src.data[@i] == 0) { ret err[str, str]("unterminated multi-line literal string"); }
-        if (src.data[@i] == '\'' && src.data[@i + 1] == '\'' && src.data[@i + 2] == '\'') { brk; }
+        if (peek_at(src, @i) == 0) { ret err[str, str]("unterminated multi-line literal string"); }
+        if (peek_at(src, @i) == '\'' && peek_at(src, @i + 1) == '\'' && peek_at(src, @i + 2) == '\'') { brk; }
         @i = @i + 1;
     }
 
@@ -863,11 +874,11 @@ fun parse_ml_literal_string(a: *Allocator, src: str, i: *usize) Result[str, str]
 # ret: parsed Value, or an error
 fun parse_number(src: str, i: *usize) Result[Value, str] {
     var sign: i64 = 1;
-    if (src.data[@i] == '+') { @i = @i + 1; }
-    or (src.data[@i] == '-') { sign = -1; @i = @i + 1; }
+    if (peek_at(src, @i) == '+') { @i = @i + 1; }
+    or (peek_at(src, @i) == '-') { sign = -1; @i = @i + 1; }
 
     # inf
-    if (src.data[@i] == 'i' && src.data[@i + 1] == 'n' && src.data[@i + 2] == 'f') {
+    if (peek_at(src, @i) == 'i' && peek_at(src, @i + 1) == 'n' && peek_at(src, @i + 2) == 'f') {
         @i = @i + 3;
         var bits: u64 = 0x7FF0000000000000;
         if (sign < 0) { bits = 0xFFF0000000000000; }
@@ -877,7 +888,7 @@ fun parse_number(src: str, i: *usize) Result[Value, str] {
     }
 
     # nan
-    if (src.data[@i] == 'n' && src.data[@i + 1] == 'a' && src.data[@i + 2] == 'n') {
+    if (peek_at(src, @i) == 'n' && peek_at(src, @i + 1) == 'a' && peek_at(src, @i + 2) == 'n') {
         @i = @i + 3;
         var bits: u64 = 0x7FF8000000000000;
         if (sign < 0) { bits = 0xFFF8000000000000; }
@@ -887,8 +898,8 @@ fun parse_number(src: str, i: *usize) Result[Value, str] {
     }
 
     # hex, octal, binary prefixes
-    if (src.data[@i] == '0') {
-        val next: u8 = src.data[@i + 1];
+    if (peek_at(src, @i) == '0') {
+        val next: u8 = peek_at(src, @i + 1);
         if (next == 'x' || next == 'X') {
             @i = @i + 2;
             ret parse_hex_int(src, i, sign);
@@ -907,7 +918,7 @@ fun parse_number(src: str, i: *usize) Result[Value, str] {
     var x: u64 = 0;
     var any: bool = false;
     for {
-        val b: u8 = src.data[@i];
+        val b: u8 = peek_at(src, @i);
         if (b == '_') { @i = @i + 1; cnt; }
         if (b < '0' || b > '9') { brk; }
         any = true;
@@ -923,12 +934,12 @@ fun parse_number(src: str, i: *usize) Result[Value, str] {
     if (!any) { ret err[Value, str]("expected number"); }
 
     # fractional part
-    if (src.data[@i] == '.' && src.data[@i + 1] >= '0' && src.data[@i + 1] <= '9') {
+    if (peek_at(src, @i) == '.' && peek_at(src, @i + 1) >= '0' && peek_at(src, @i + 1) <= '9') {
         ret parse_float_frac(src, i, x::i64, sign);
     }
 
     # exponent without fraction
-    if (src.data[@i] == 'e' || src.data[@i] == 'E') {
+    if (peek_at(src, @i) == 'e' || peek_at(src, @i) == 'E') {
         ret parse_float_exp(src, i, x::f64 * sign::f64);
     }
 
@@ -948,7 +959,7 @@ fun parse_float_frac(src: str, i: *usize, int_part: i64, sign: i64) Result[Value
     var divisor: f64 = 1.0;
 
     for {
-        val b: u8 = src.data[@i];
+        val b: u8 = peek_at(src, @i);
         if (b == '_') { @i = @i + 1; cnt; }
         if (b < '0' || b > '9') { brk; }
         frac = frac * 10.0 + (b - '0')::u64::f64;
@@ -958,7 +969,7 @@ fun parse_float_frac(src: str, i: *usize, int_part: i64, sign: i64) Result[Value
 
     var result: f64 = (int_part::f64 + frac / divisor) * sign::f64;
 
-    if (src.data[@i] == 'e' || src.data[@i] == 'E') {
+    if (peek_at(src, @i) == 'e' || peek_at(src, @i) == 'E') {
         ret parse_float_exp(src, i, result);
     }
 
@@ -974,13 +985,13 @@ fun parse_float_frac(src: str, i: *usize, int_part: i64, sign: i64) Result[Value
 fun parse_float_exp(src: str, i: *usize, mantissa: f64) Result[Value, str] {
     @i = @i + 1;
     var exp_sign: i64 = 1;
-    if (src.data[@i] == '+') { @i = @i + 1; }
-    or (src.data[@i] == '-') { exp_sign = -1; @i = @i + 1; }
+    if (peek_at(src, @i) == '+') { @i = @i + 1; }
+    or (peek_at(src, @i) == '-') { exp_sign = -1; @i = @i + 1; }
 
     var exp: i64 = 0;
     var any: bool = false;
     for {
-        val b: u8 = src.data[@i];
+        val b: u8 = peek_at(src, @i);
         if (b == '_') { @i = @i + 1; cnt; }
         if (b < '0' || b > '9') { brk; }
         any = true;
@@ -1040,7 +1051,7 @@ fun parse_hex_int(src: str, i: *usize, sign: i64) Result[Value, str] {
     var x: u64 = 0;
     var any: bool = false;
     for {
-        val b: u8 = src.data[@i];
+        val b: u8 = peek_at(src, @i);
         if (b == '_') { @i = @i + 1; cnt; }
         val d: i32 = hex_digit(b);
         if (d < 0) { brk; }
@@ -1058,7 +1069,7 @@ fun parse_oct_int(src: str, i: *usize, sign: i64) Result[Value, str] {
     var x: u64 = 0;
     var any: bool = false;
     for {
-        val b: u8 = src.data[@i];
+        val b: u8 = peek_at(src, @i);
         if (b == '_') { @i = @i + 1; cnt; }
         if (b < '0' || b > '7') { brk; }
         any = true;
@@ -1075,7 +1086,7 @@ fun parse_bin_int(src: str, i: *usize, sign: i64) Result[Value, str] {
     var x: u64 = 0;
     var any: bool = false;
     for {
-        val b: u8 = src.data[@i];
+        val b: u8 = peek_at(src, @i);
         if (b == '_') { @i = @i + 1; cnt; }
         if (b != '0' && b != '1') { brk; }
         any = true;
@@ -1095,13 +1106,13 @@ fun is_value_term(b: u8) bool {
 
 # parse_bool_val: parse "true" or "false".
 fun parse_bool_val(src: str, i: *usize) Result[Value, str] {
-    if (src.data[@i] == 't' && src.data[@i + 1] == 'r' && src.data[@i + 2] == 'u' && src.data[@i + 3] == 'e') {
-        if (!is_value_term(src.data[@i + 4])) { ret err[Value, str]("expected boolean"); }
+    if (peek_at(src, @i) == 't' && peek_at(src, @i + 1) == 'r' && peek_at(src, @i + 2) == 'u' && peek_at(src, @i + 3) == 'e') {
+        if (!is_value_term(peek_at(src, @i + 4))) { ret err[Value, str]("expected boolean"); }
         @i = @i + 4;
         ret ok[Value, str](value_bool(true));
     }
-    if (src.data[@i] == 'f' && src.data[@i + 1] == 'a' && src.data[@i + 2] == 'l' && src.data[@i + 3] == 's' && src.data[@i + 4] == 'e') {
-        if (!is_value_term(src.data[@i + 5])) { ret err[Value, str]("expected boolean"); }
+    if (peek_at(src, @i) == 'f' && peek_at(src, @i + 1) == 'a' && peek_at(src, @i + 2) == 'l' && peek_at(src, @i + 3) == 's' && peek_at(src, @i + 4) == 'e') {
+        if (!is_value_term(peek_at(src, @i + 5))) { ret err[Value, str]("expected boolean"); }
         @i = @i + 5;
         ret ok[Value, str](value_bool(false));
     }
@@ -1115,15 +1126,15 @@ fun parse_bool_val(src: str, i: *usize) Result[Value, str] {
 # i:   cursor position
 # ret: the key string, or an error
 fun parse_key_segment(a: *Allocator, src: str, i: *usize) Result[str, str] {
-    if (src.data[@i] == '"') {
+    if (peek_at(src, @i) == '"') {
         ret parse_basic_string(a, src, i);
     }
-    if (src.data[@i] == '\'') {
+    if (peek_at(src, @i) == '\'') {
         ret parse_literal_string(a, src, i);
     }
 
     val start: usize = @i;
-    for (is_bare_key_char(src.data[@i])) {
+    for (is_bare_key_char(peek_at(src, @i))) {
         @i = @i + 1;
     }
     if (@i == start) { ret err[str, str]("expected key"); }
@@ -1149,7 +1160,7 @@ fun parse_key_path(a: *Allocator, src: str, i: *usize) Result[KeySegs, str] {
     val pr: Result[bool, str] = keysegs_push(a, ?ks, unwrap_ok[str, str](first));
     if (is_err[bool, str](pr)) { ret err[KeySegs, str](unwrap_err[bool, str](pr)); }
 
-    for (src.data[@i] == '.') {
+    for (peek_at(src, @i) == '.') {
         @i = @i + 1;
         val seg: Result[str, str] = parse_key_segment(a, src, i);
         if (is_err[str, str](seg)) { ret err[KeySegs, str](unwrap_err[str, str](seg)); }
@@ -1189,7 +1200,7 @@ fun navigate_segs(a: *Allocator, t: *Table, ks: *KeySegs) Result[*Table, str] {
 fun parse_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
     skip_ws(src, i);
 
-    val b: u8 = src.data[@i];
+    val b: u8 = peek_at(src, @i);
 
     if (b == '"') {
         val r: Result[str, str] = parse_basic_string(a, src, i);
@@ -1234,7 +1245,7 @@ fun parse_array_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
 
     for {
         skip_ws_comments_newlines(src, i);
-        if (src.data[@i] == ']') {
+        if (peek_at(src, @i) == ']') {
             @i = @i + 1;
             brk;
         }
@@ -1246,7 +1257,7 @@ fun parse_array_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
         if (is_err[bool, str](pr)) { ret err[Value, str](unwrap_err[bool, str](pr)); }
 
         skip_ws_comments_newlines(src, i);
-        if (src.data[@i] == ',') {
+        if (peek_at(src, @i) == ',') {
             @i = @i + 1;
             cnt;
         }
@@ -1266,7 +1277,7 @@ fun parse_inline_table(a: *Allocator, src: str, i: *usize) Result[Value, str] {
     var t: Table = table_make();
 
     skip_ws(src, i);
-    if (src.data[@i] == '}') {
+    if (peek_at(src, @i) == '}') {
         @i = @i + 1;
         ret ok[Value, str](value_table(t));
     }
@@ -1279,7 +1290,7 @@ fun parse_inline_table(a: *Allocator, src: str, i: *usize) Result[Value, str] {
         var ks: KeySegs = unwrap_ok[KeySegs, str](ksr);
 
         skip_ws(src, i);
-        if (src.data[@i] != '=') { ret err[Value, str]("expected '=' in inline table"); }
+        if (peek_at(src, @i) != '=') { ret err[Value, str]("expected '=' in inline table"); }
         @i = @i + 1;
 
         val vr: Result[Value, str] = parse_value(a, src, i);
@@ -1292,11 +1303,11 @@ fun parse_inline_table(a: *Allocator, src: str, i: *usize) Result[Value, str] {
         if (is_err[bool, str](sr)) { ret err[Value, str](unwrap_err[bool, str](sr)); }
 
         skip_ws(src, i);
-        if (src.data[@i] == ',') {
+        if (peek_at(src, @i) == ',') {
             @i = @i + 1;
             cnt;
         }
-        if (src.data[@i] == '}') {
+        if (peek_at(src, @i) == '}') {
             @i = @i + 1;
             brk;
         }
@@ -1387,16 +1398,15 @@ fun navigate_for_array_table(a: *Allocator, root: *Table, ks: *KeySegs) Result[*
 # supports TOML 1.0: basic and literal strings (single and multi-line),
 # integers (decimal, hex, octal, binary), floats, booleans, arrays,
 # tables, inline tables, array of tables, and dotted keys.
+#
+# bounded by src.len; the input does not need to be null-terminated.
 # ---
 # a:   allocator for all internal allocations
-# src: null-terminated TOML source string
+# src: TOML source string
 # ret: the root table, or an error message
 pub fun parse(a: *Allocator, src: str) Result[Table, str] {
     if (a == nil) {
         ret err[Table, str]("allocator is nil");
-    }
-    if (src.data == nil) {
-        ret err[Table, str]("source is nil");
     }
 
     var root: Table = table_make();
@@ -1405,10 +1415,10 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
 
     for {
         skip_ws_comments_newlines(src, ?i);
-        if (src.data[i] == 0) { brk; }
+        if (peek_at(src, i) == 0) { brk; }
 
         # array of tables: [[key]]
-        if (src.data[i] == '[' && src.data[i + 1] == '[') {
+        if (peek_at(src, i) == '[' && peek_at(src, i + 1) == '[') {
             i = i + 2;
             skip_ws(src, ?i);
 
@@ -1417,7 +1427,7 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
             var ks: KeySegs = unwrap_ok[KeySegs, str](ksr);
 
             skip_ws(src, ?i);
-            if (src.data[i] != ']' || src.data[i + 1] != ']') {
+            if (peek_at(src, i) != ']' || peek_at(src, i + 1) != ']') {
                 ret err[Table, str]("expected ']]'");
             }
             i = i + 2;
@@ -1431,7 +1441,7 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
         }
 
         # table header: [key]
-        if (src.data[i] == '[') {
+        if (peek_at(src, i) == '[') {
             i = i + 1;
             skip_ws(src, ?i);
 
@@ -1440,7 +1450,7 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
             var ks: KeySegs = unwrap_ok[KeySegs, str](ksr);
 
             skip_ws(src, ?i);
-            if (src.data[i] != ']') {
+            if (peek_at(src, i) != ']') {
                 ret err[Table, str]("expected ']'");
             }
             i = i + 1;
@@ -1465,7 +1475,7 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
         var ks: KeySegs = unwrap_ok[KeySegs, str](ksr);
 
         skip_ws(src, ?i);
-        if (src.data[i] != '=') {
+        if (peek_at(src, i) != '=') {
             ret err[Table, str]("expected '='");
         }
         i = i + 1;

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -63,7 +63,7 @@ val HEX_CHARS:         str   = "0123456789abcdef";
 # p:   file path
 # ret: the opened File, or an error message
 pub fun open(p: str) Result[File, str] {
-    val raw: i64 = os.open(os.AT_FDCWD, p, os.O_RDONLY, 0);
+    val raw: i64 = os.open(os.AT_FDCWD, p.data, os.O_RDONLY, 0);
     if (raw < 0) { ret err[File, str](os.message(raw)); }
     ret ok[File, str](File{fd: raw::i32});
 }
@@ -75,7 +75,7 @@ pub fun open(p: str) Result[File, str] {
 # mode:  permission bits for creation
 # ret:   the opened File, or an error message
 pub fun open_with(p: str, flags: i32, mode: i32) Result[File, str] {
-    val raw: i64 = os.open(os.AT_FDCWD, p, flags, mode);
+    val raw: i64 = os.open(os.AT_FDCWD, p.data, flags, mode);
     if (raw < 0) { ret err[File, str](os.message(raw)); }
     ret ok[File, str](File{fd: raw::i32});
 }
@@ -87,7 +87,7 @@ pub fun open_with(p: str, flags: i32, mode: i32) Result[File, str] {
 # ret:  the created File, or an error message
 pub fun create(p: str, mode: i32) Result[File, str] {
     val flags: i32 = os.O_CREAT | os.O_TRUNC | os.O_WRONLY;
-    val raw: i64 = os.open(os.AT_FDCWD, p, flags, mode);
+    val raw: i64 = os.open(os.AT_FDCWD, p.data, flags, mode);
     if (raw < 0) { ret err[File, str](os.message(raw)); }
     ret ok[File, str](File{fd: raw::i32});
 }
@@ -212,7 +212,10 @@ pub fun read_all(a: *allocator.Allocator, p: str) Result[str, str] {
     close(?f);
 
     buf[total] = 0;
-    ret ok[str, str](buf::str);
+    var s: str;
+    s.len  = total::u32;
+    s.data = buf;
+    ret ok[str, str](s);
 }
 
 # write_file: write data to a file at path, creating or truncating it.
@@ -262,9 +265,9 @@ pub fun info_is_symlink(fi: *FileInfo) bool {
 # p:   path to query
 # ret: file metadata, or an error message
 pub fun info_path(p: str) Result[FileInfo, str] {
-    if (p == nil) { ret err[FileInfo, str]("path is nil"); }
+    if (path.is_empty(p)) { ret err[FileInfo, str]("path is nil"); }
     var st: os.stat_t;
-    val raw: i64 = os.stat_path(os.AT_FDCWD, p, ?st, 0);
+    val raw: i64 = os.stat_path(os.AT_FDCWD, p.data, ?st, 0);
     if (raw < 0) { ret err[FileInfo, str](os.message(raw)); }
     ret ok[FileInfo, str](info_from_stat(?st));
 }
@@ -295,7 +298,7 @@ pub fun exists(p: str) bool {
 # p:   path to remove
 # ret: true on success, or an error message
 pub fun unlink(p: str) Result[bool, str] {
-    val raw: i64 = os.unlink(os.AT_FDCWD, p, 0);
+    val raw: i64 = os.unlink(os.AT_FDCWD, p.data, 0);
     if (raw < 0) { ret err[bool, str](os.message(raw)); }
     ret ok[bool, str](true);
 }
@@ -306,7 +309,7 @@ pub fun unlink(p: str) Result[bool, str] {
 # to:   destination path
 # ret:  true on success, or an error message
 pub fun rename(from: str, to: str) Result[bool, str] {
-    val raw: i64 = os.rename(os.AT_FDCWD, from, os.AT_FDCWD, to);
+    val raw: i64 = os.rename(os.AT_FDCWD, from.data, os.AT_FDCWD, to.data);
     if (raw < 0) { ret err[bool, str](os.message(raw)); }
     ret ok[bool, str](true);
 }
@@ -317,8 +320,8 @@ pub fun rename(from: str, to: str) Result[bool, str] {
 # mode: permission bits
 # ret:  true on success, or an error message
 pub fun create_dir(p: str, mode: i32) Result[bool, str] {
-    if (p == nil) { ret err[bool, str]("path is nil"); }
-    val raw: i64 = os.make_dir(os.AT_FDCWD, p, mode);
+    if (path.is_empty(p)) { ret err[bool, str]("path is nil"); }
+    val raw: i64 = os.make_dir(os.AT_FDCWD, p.data, mode);
     if (raw < 0) { ret err[bool, str](os.message(raw)); }
     ret ok[bool, str](true);
 }
@@ -330,7 +333,6 @@ pub fun create_dir(p: str, mode: i32) Result[bool, str] {
 # mode: permission bits
 # ret:  true on success, or an error message
 pub fun create_dir_all(a: *allocator.Allocator, p: str, mode: i32) Result[bool, str] {
-    if (p == nil)         { ret err[bool, str]("path is nil"); }
     if (path.is_empty(p)) { ret err[bool, str]("path is empty"); }
     if (path.is_root(p))  { ret ok[bool, str](true); }
     if (is_dir(p))        { ret ok[bool, str](true); }
@@ -346,8 +348,8 @@ pub fun create_dir_all(a: *allocator.Allocator, p: str, mode: i32) Result[bool, 
     val parent_path: path.Path = unwrap_ok[path.Path, str](parent_res);
     val parent_create: Result[bool, str] = create_dir_all(a, parent_path, mode);
 
-    val parent_len: usize = str_len(parent_path);
-    allocator.deallocate[u8](a, parent_path::ptr::*u8, parent_len + 1);
+    val parent_len: usize = parent_path.len::usize;
+    allocator.deallocate[u8](a, parent_path.data, parent_len + 1);
 
     if (is_err[bool, str](parent_create)) { ret parent_create; }
 
@@ -378,13 +380,13 @@ pub fun temp_create(a: *allocator.Allocator, prefix: str) Result[TempFile, str] 
         val p: path.Path = unwrap_ok[path.Path, str](name_res);
 
         val flags: i32 = os.O_CREAT | os.O_EXCL | os.O_RDWR;
-        val raw: i64 = os.open(os.AT_FDCWD, p, flags, 384);
+        val raw: i64 = os.open(os.AT_FDCWD, p.data, flags, 384);
         if (raw >= 0) {
             ret ok[TempFile, str](TempFile{file: File{fd: raw::i32}, path: p});
         }
 
-        val p_len: usize = str_len(p);
-        allocator.deallocate[u8](a, p::ptr::*u8, p_len + 1);
+        val p_len: usize = p.len::usize;
+        allocator.deallocate[u8](a, p.data, p_len + 1);
 
         if (raw != os.EEXIST) {
             ret err[TempFile, str](os.message(raw));
@@ -439,31 +441,28 @@ fun temp_build_path(a: *allocator.Allocator, prefix: str, rnd: *u8) Result[path.
     var buf: [256]u8;
     var off: usize = 0;
 
-    val dir_len: usize = str_len(TEMP_DIR);
-    var prefix_len: usize = 0;
-    if (prefix != nil) {
-        prefix_len = str_len(prefix);
-    }
-    val needed: usize = dir_len + 1 + prefix_len + 1 + 16 + 1;
+    val dir_len:    usize = TEMP_DIR.len::usize;
+    val prefix_len: usize = prefix.len::usize;
+    val needed:     usize = dir_len + 1 + prefix_len + 1 + 16 + 1;
     if (needed > 256) {
         ret err[path.Path, str]("temp path too long");
     }
 
-    mem.raw_copy(?buf[0], TEMP_DIR, dir_len);
+    mem.raw_copy(?buf[0], TEMP_DIR.data::ptr, dir_len);
     off = dir_len;
 
     buf[off] = 47;
     off = off + 1;
 
-    if (prefix != nil) {
-        mem.raw_copy(?buf[off], prefix, prefix_len);
+    if (prefix_len > 0) {
+        mem.raw_copy(?buf[off], prefix.data::ptr, prefix_len);
         off = off + prefix_len;
     }
 
     buf[off] = 95;
     off = off + 1;
 
-    val hex: *u8 = HEX_CHARS::*u8;
+    val hex: *u8 = HEX_CHARS.data;
     var i: usize = 0;
     for (i < 8) {
         buf[off] = hex[rnd[i]::usize >> 4];
@@ -481,7 +480,11 @@ fun temp_build_path(a: *allocator.Allocator, prefix: str, rnd: *u8) Result[path.
     val out: *u8 = unwrap_ok[*u8, str](r);
     mem.raw_copy(out::ptr, ?buf[0], off);
     out[off] = 0;
-    ret ok[path.Path, str](out::str);
+
+    var p: str;
+    p.len  = off::u32;
+    p.data = out;
+    ret ok[path.Path, str](p);
 }
 
 fun write_u64(off: usize, buf: *u8, cap: usize, n: u64) usize {
@@ -521,7 +524,7 @@ test "filesystem: temp_create creates file" {
     if (is_err[TempFile, str](r)) { ret 0; }
     var tf: TempFile = unwrap_ok[TempFile, str](r);
     if (tf.file.fd < 0) { ret 2; }
-    if (tf.path == nil) { ret 3; }
+    if (tf.path.data == nil) { ret 3; }
     val cr: Result[bool, str] = temp_close_and_remove(?tf);
     if (is_err[bool, str](cr)) { ret 4; }
     ret 1;
@@ -536,7 +539,7 @@ test "filesystem: temp file write and read" {
     var tf: TempFile = unwrap_ok[TempFile, str](r);
 
     val data: str = "hello temp file";
-    val wr: Result[usize, str] = write(?tf.file, data, str_len(data));
+    val wr: Result[usize, str] = write(?tf.file, data.data, str_len(data));
     if (is_err[usize, str](wr)) { ret 2; }
     if (unwrap_ok[usize, str](wr) != str_len(data)) { ret 3; }
 
@@ -548,7 +551,10 @@ test "filesystem: temp file write and read" {
     if (is_err[usize, str](rr)) { ret 5; }
     if (unwrap_ok[usize, str](rr) != str_len(data)) { ret 6; }
 
-    if (!str_starts_with(?buf[0], "hello temp file")) { ret 7; }
+    var view: str;
+    view.len  = str_len(data)::u32;
+    view.data = ?buf[0];
+    if (!str_starts_with(view, "hello temp file")) { ret 7; }
 
     temp_close_and_remove(?tf);
     ret 1;
@@ -563,7 +569,7 @@ test "filesystem: info returns valid metadata" {
     var tf: TempFile = unwrap_ok[TempFile, str](cr);
 
     val data: str = "some content";
-    write(?tf.file, data, str_len(data));
+    write(?tf.file, data.data, str_len(data));
 
     val ir: Result[FileInfo, str] = info(?tf.file);
     if (is_err[FileInfo, str](ir)) { ret 2; }
@@ -583,7 +589,7 @@ test "filesystem: create write close open read" {
     var tf: TempFile = unwrap_ok[TempFile, str](cr);
 
     val data: str = "test data 12345";
-    val wr: Result[usize, str] = write(?tf.file, data, str_len(data));
+    val wr: Result[usize, str] = write(?tf.file, data.data, str_len(data));
     if (is_err[usize, str](wr)) { ret 2; }
 
     val clr: Result[bool, str] = temp_close(?tf);

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -265,7 +265,7 @@ pub fun info_is_symlink(fi: *FileInfo) bool {
 # p:   path to query
 # ret: file metadata, or an error message
 pub fun info_path(p: str) Result[FileInfo, str] {
-    if (path.is_empty(p)) { ret err[FileInfo, str]("path is nil"); }
+    if (path.is_empty(p)) { ret err[FileInfo, str]("path is empty"); }
     var st: os.stat_t;
     val raw: i64 = os.stat_path(os.AT_FDCWD, p.data, ?st, 0);
     if (raw < 0) { ret err[FileInfo, str](os.message(raw)); }
@@ -320,7 +320,7 @@ pub fun rename(from: str, to: str) Result[bool, str] {
 # mode: permission bits
 # ret:  true on success, or an error message
 pub fun create_dir(p: str, mode: i32) Result[bool, str] {
-    if (path.is_empty(p)) { ret err[bool, str]("path is nil"); }
+    if (path.is_empty(p)) { ret err[bool, str]("path is empty"); }
     val raw: i64 = os.make_dir(os.AT_FDCWD, p.data, mode);
     if (raw < 0) { ret err[bool, str](os.message(raw)); }
     ret ok[bool, str](true);

--- a/src/format.mach
+++ b/src/format.mach
@@ -24,8 +24,8 @@ pub fun write_bytes(w: *writer.Writer, buf: *u8, len: usize) Result[usize, str] 
 # s:   string to write (nil treated as empty)
 # ret: bytes written, or an error message
 pub fun write_str(w: *writer.Writer, s: str) Result[usize, str] {
-    if (s == nil) { ret ok[usize, str](0); }
-    ret writer.write_all(w, s, str_len(s));
+    if (s.len == 0 || s.data == nil) { ret ok[usize, str](0); }
+    ret writer.write_all(w, s.data, str_len(s));
 }
 
 # write_byte: write a single byte to a writer.
@@ -167,10 +167,11 @@ pub fun vformat(w: *writer.Writer, format: str, ap: *va_list, ...) Result[usize,
 
     var total: usize = 0;
     var i: usize = 0;
+    val flen: usize = format.len::usize;
 
-    for (format[i] != 0) {
-        if (format[i] != '%') {
-            val r: Result[usize, str] = write_byte(w, format[i]);
+    for (i < flen) {
+        if (format.data[i] != '%') {
+            val r: Result[usize, str] = write_byte(w, format.data[i]);
             if (is_err[usize, str](r)) { ret r; }
             total = total + unwrap_ok[usize, str](r);
             i = i + 1;
@@ -178,10 +179,10 @@ pub fun vformat(w: *writer.Writer, format: str, ap: *va_list, ...) Result[usize,
         }
 
         i = i + 1;
-        val c: u8 = format[i];
-        if (c == 0) {
+        if (i >= flen) {
             ret err[usize, str](ERR_BAD_FORMAT);
         }
+        val c: u8 = format.data[i];
 
         var r: Result[usize, str];
 

--- a/src/log.mach
+++ b/src/log.mach
@@ -62,13 +62,13 @@ fun write_piece(buf: *u8, len: usize) {
 
 fun log_msg(level: Level, prefix: str, msg: str) {
     if (level::i64 < atomic.load(?level_val)) { ret; }
-    write_piece("[", 1);
-    write_piece(prefix, str_len(prefix));
-    write_piece("] ", 2);
-    if (msg != nil) {
-        write_piece(msg, str_len(msg));
+    write_piece(`[`, 1);
+    write_piece(prefix.data, str_len(prefix));
+    write_piece(`] `, 2);
+    if (msg.data != nil) {
+        write_piece(msg.data, str_len(msg));
     }
-    write_piece("\n", 1);
+    write_piece(`\n`, 1);
 }
 
 # log a message at DEBUG level.
@@ -119,12 +119,12 @@ test "set_level: DEBUG enables all" {
     ret 1;
 }
 
-test "log functions: nil message does not crash" {
+test "log functions: empty message does not crash" {
     set_level(DEBUG);
-    debug(nil);
-    info(nil);
-    warn(nil);
-    error(nil);
+    debug("");
+    info("");
+    warn("");
+    error("");
     set_level(INFO);
     ret 1;
 }

--- a/src/net/dns.mach
+++ b/src/net/dns.mach
@@ -71,7 +71,7 @@ pub fun lookup_hosts(hostname: str, addr: *ip.IPv4) bool {
             val name_len: usize = pos - name_start;
 
             val host_len: usize = str_len(hostname);
-            if (name_len == host_len && region_eq(?buf[name_start], hostname, host_len)) {
+            if (name_len == host_len && region_eq(?buf[name_start], hostname.data, host_len)) {
                 val parsed: bool = parse_ipv4(?buf[ip_start], ip_end - ip_start, addr);
                 if (parsed) { ret true; }
             }
@@ -189,13 +189,13 @@ fun build_query(hostname: str, buf: *u8, cap: usize, qid: u16) usize {
     var label_len: usize = 0;
     var i: usize = 0;
     for (i < host_len) {
-        if ((hostname::*u8)[i] == '.') {
+        if (hostname.data[i] == '.') {
             buf[label_start] = label_len::u8;
             label_start = pos;
             label_len = 0;
             pos = pos + 1;
         } or {
-            buf[pos] = (hostname::*u8)[i];
+            buf[pos] = hostname.data[i];
             pos = pos + 1;
             label_len = label_len + 1;
         }

--- a/src/net/ip.mach
+++ b/src/net/ip.mach
@@ -245,7 +245,10 @@ test "ip: ipv4_format" {
     var buf: [16]u8;
     val n: usize = ipv4_format(ip, ?buf[0], 16);
     if (n != 7) { ret 0; }
-    if (!str_starts_with(?buf[0], "127.0.0.1")) { ret 0; }
+    var view: str;
+    view.len  = n::u32;
+    view.data = ?buf[0];
+    if (!str_starts_with(view, "127.0.0.1")) { ret 0; }
     ret 1;
 }
 
@@ -254,7 +257,10 @@ test "ip: ipv4_format three digit octets" {
     var buf: [20]u8;
     val n: usize = ipv4_format(ip, ?buf[0], 20);
     if (n != 15) { ret 0; }
-    if (!str_starts_with(?buf[0], "255.255.255.255")) { ret 0; }
+    var view: str;
+    view.len  = n::u32;
+    view.data = ?buf[0];
+    if (!str_starts_with(view, "255.255.255.255")) { ret 0; }
     ret 1;
 }
 

--- a/src/process/env.mach
+++ b/src/process/env.mach
@@ -13,7 +13,7 @@ use os: std.system.os;
 # cap:  buffer capacity in bytes
 # ret:  length of value, or NOT_FOUND (-1)
 pub fun get(name: str, buf: *u8, cap: usize) i64 {
-    ret os.getenv(name, buf, cap);
+    ret os.getenv(name.data, buf, cap);
 }
 
 # cwd: read the current working directory into a buffer.

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -28,7 +28,7 @@ pub rec Child {
 # envp:     null-terminated environment array
 # ret:      exit status, or an error message
 pub fun run(pathname: str, argv: **u8, envp: **u8) Result[ExitStatus, str] {
-    val pid: i64 = os.spawn(pathname, argv, envp);
+    val pid: i64 = os.spawn(pathname.data, argv, envp);
     if (pid < 0) { ret err[ExitStatus, str]("spawn failed"); }
 
     var wstatus: i32 = 0;
@@ -45,7 +45,7 @@ pub fun run(pathname: str, argv: **u8, envp: **u8) Result[ExitStatus, str] {
 # envp:     null-terminated environment array
 # ret:      child handle, or an error message
 pub fun spawn(pathname: str, argv: **u8, envp: **u8) Result[Child, str] {
-    val pid: i64 = os.spawn(pathname, argv, envp);
+    val pid: i64 = os.spawn(pathname.data, argv, envp);
     if (pid < 0) { ret err[Child, str]("spawn failed"); }
     ret ok[Child, str](Child{pid: pid});
 }
@@ -102,7 +102,7 @@ pub fun exit(code: i64) {
 
 fun make_argv1(prog: str) [2]usize {
     var buf: [2]usize;
-    buf[0] = prog::usize;
+    buf[0] = prog.data::usize;
     buf[1] = 0;
     ret buf;
 }

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -771,7 +771,7 @@ pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i6
 
 # dns
 
-pub val DNS_HOSTS_PATH: str = "/etc/hosts";
+pub val DNS_HOSTS_PATH: zstr = `/etc/hosts`;
 
 # dns_nameserver: read the first nameserver from /etc/resolv.conf.
 # ---

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -897,11 +897,11 @@ pub fun getcwd(buf: *u8, size: usize) i64 {
 pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
     if (_envp == 0) { ret os_shared.NOT_FOUND; }
     val envp: **u8 = _envp::**u8;
-    val name_len: usize = str_len(name);
+    val name_len: usize = zstr_len(name);
     var i: usize = 0;
     for (envp[i]::usize != 0) {
         val entry: *u8 = envp[i];
-        if (str_starts_with(entry, name) && entry[name_len] == '='::u8) {
+        if (entry_starts_with(entry, name, name_len) && entry[name_len] == '='::u8) {
             if (cap == 0) { ret 0; }
             val val_start: usize = name_len + 1;
             var j: usize = 0;
@@ -917,6 +917,15 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
         i = i + 1;
     }
     ret os_shared.NOT_FOUND;
+}
+
+fun entry_starts_with(entry: *u8, name: *u8, name_len: usize) bool {
+    var i: usize = 0;
+    for (i < name_len) {
+        if (entry[i] != name[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 # threads
@@ -1111,14 +1120,14 @@ pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i6
 
 # dns
 
-pub val DNS_HOSTS_PATH: str = "/etc/hosts";
+pub val DNS_HOSTS_PATH: zstr = `/etc/hosts`;
 
 # dns_nameserver: read the first nameserver from /etc/resolv.conf.
 # ---
 # ns:  pointer to 4 bytes to fill with the IPv4 address
 # ret: 0 on success, or NOT_FOUND / negative errno
 pub fun dns_nameserver(ns: *u8) i64 {
-    val fd: i64 = open(AT_FDCWD, "/etc/resolv.conf", O_RDONLY, 0);
+    val fd: i64 = open(AT_FDCWD, `/etc/resolv.conf`, O_RDONLY, 0);
     if (fd < 0) { ret fd; }
 
     var buf: [2048]u8;
@@ -1133,7 +1142,7 @@ pub fun dns_nameserver(ns: *u8) i64 {
     for (pos < len) {
         for (pos < len && (buf[pos] == 32 || buf[pos] == 9)) { pos = pos + 1; }
 
-        if (pos + 10 < len && dns_prefix_match(?buf[pos], "nameserver", 10)) {
+        if (pos + 10 < len && dns_prefix_match(?buf[pos], `nameserver`, 10)) {
             pos = pos + 10;
             for (pos < len && (buf[pos] == 32 || buf[pos] == 9)) { pos = pos + 1; }
             var start: usize = pos;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -1545,7 +1545,7 @@ pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i6
 
 # dns
 
-pub val DNS_HOSTS_PATH: str = "C:/Windows/System32/drivers/etc/hosts";
+pub val DNS_HOSTS_PATH: zstr = `C:/Windows/System32/drivers/etc/hosts`;
 
 # dns_nameserver: get the primary DNS nameserver address.
 #

--- a/src/text/parse.mach
+++ b/src/text/parse.mach
@@ -29,7 +29,7 @@ pub fun parse_u64(s: str, base: u8) Result[u64, str] {
     var actual_base: u8 = base;
 
     # skip leading whitespace
-    for (i < len && char_is_space(s[i])) {
+    for (i < len && char_is_space(s.data[i])) {
         i = i + 1;
     }
 
@@ -39,8 +39,8 @@ pub fun parse_u64(s: str, base: u8) Result[u64, str] {
 
     # auto-detect base if base == 0
     if (actual_base == 0) {
-        if (s[i] == '0' && i + 1 < len) {
-            val next: u8 = s[i + 1];
+        if (s.data[i] == '0' && i + 1 < len) {
+            val next: u8 = s.data[i + 1];
             if (next == 'x' || next == 'X') {
                 actual_base = 16;
                 i = i + 2;
@@ -76,7 +76,7 @@ pub fun parse_u64(s: str, base: u8) Result[u64, str] {
     val base_u64: u64 = actual_base::u64;
 
     for (i < len) {
-        val c: u8 = s[i];
+        val c: u8 = s.data[i];
 
         # allow underscore separators
         if (c == '_') {
@@ -140,8 +140,8 @@ pub fun parse_u64_exact(s: str, base: u8) Result[u64, str] {
     var actual_base: u8 = base;
 
     if (actual_base == 0) {
-        if (s[i] == '0' && i + 1 < len) {
-            val next: u8 = s[i + 1];
+        if (s.data[i] == '0' && i + 1 < len) {
+            val next: u8 = s.data[i + 1];
             if (next == 'x' || next == 'X') {
                 actual_base = 16;
                 i = i + 2;
@@ -176,7 +176,7 @@ pub fun parse_u64_exact(s: str, base: u8) Result[u64, str] {
     val base_u64: u64 = actual_base::u64;
 
     for (i < len) {
-        val c: u8 = s[i];
+        val c: u8 = s.data[i];
 
         if (c == '_') {
             i = i + 1;
@@ -232,7 +232,7 @@ pub fun parse_i64(s: str, base: u8) Result[i64, str] {
     var i: usize = 0;
 
     # skip leading whitespace
-    for (i < len && char_is_space(s[i])) {
+    for (i < len && char_is_space(s.data[i])) {
         i = i + 1;
     }
 
@@ -242,11 +242,11 @@ pub fun parse_i64(s: str, base: u8) Result[i64, str] {
 
     # check for sign
     var negative: bool = false;
-    if (s[i] == '-') {
+    if (s.data[i] == '-') {
         negative = true;
         i = i + 1;
     }
-    or (s[i] == '+') {
+    or (s.data[i] == '+') {
         i = i + 1;
     }
 
@@ -254,8 +254,8 @@ pub fun parse_i64(s: str, base: u8) Result[i64, str] {
         ret err[i64, str]("no digits after sign");
     }
 
-    # parse remaining as unsigned using pointer arithmetic
-    val remaining: str = (?s[i])::str;
+    # parse the remaining tail as unsigned
+    val remaining: str = str_slice(s, i, len - i);
     val u_result: Result[u64, str] = parse_u64(remaining, base);
 
     if (is_err[u64, str](u_result)) {
@@ -302,11 +302,11 @@ pub fun parse_i64_exact(s: str, base: u8) Result[i64, str] {
     var i: usize = 0;
 
     var negative: bool = false;
-    if (s[i] == '-') {
+    if (s.data[i] == '-') {
         negative = true;
         i = i + 1;
     }
-    or (s[i] == '+') {
+    or (s.data[i] == '+') {
         i = i + 1;
     }
 
@@ -314,7 +314,7 @@ pub fun parse_i64_exact(s: str, base: u8) Result[i64, str] {
         ret err[i64, str]("no digits after sign");
     }
 
-    val remaining: str = (?s[i])::str;
+    val remaining: str = str_slice(s, i, len - i);
     val u_result: Result[u64, str] = parse_u64_exact(remaining, base);
 
     if (is_err[u64, str](u_result)) {
@@ -355,19 +355,19 @@ pub fun parse_f64(s: str) Result[f64, str] {
 
     var i: usize = 0;
 
-    for (i < len && char_is_space(s[i])) {
+    for (i < len && char_is_space(s.data[i])) {
         i = i + 1;
     }
     if (i >= len) { ret err[f64, str]("empty string after whitespace"); }
 
     var sign: f64 = 1.0;
-    if (s[i] == '-') { sign = 0.0 - 1.0; i = i + 1; }
-    or (s[i] == '+') { i = i + 1; }
+    if (s.data[i] == '-') { sign = 0.0 - 1.0; i = i + 1; }
+    or (s.data[i] == '+') { i = i + 1; }
 
     if (i >= len) { ret err[f64, str]("no digits after sign"); }
 
     # inf
-    if (i + 3 <= len && s[i] == 'i' && s[i + 1] == 'n' && s[i + 2] == 'f') {
+    if (i + 3 <= len && s.data[i] == 'i' && s.data[i + 1] == 'n' && s.data[i + 2] == 'f') {
         var bits: u64 = 0x7FF0000000000000;
         if (sign < 0.0) { bits = 0xFFF0000000000000; }
         var inf_val: f64;
@@ -376,7 +376,7 @@ pub fun parse_f64(s: str) Result[f64, str] {
     }
 
     # nan
-    if (i + 3 <= len && s[i] == 'n' && s[i + 1] == 'a' && s[i + 2] == 'n') {
+    if (i + 3 <= len && s.data[i] == 'n' && s.data[i + 1] == 'a' && s.data[i + 2] == 'n') {
         val bits: u64 = 0x7FF8000000000000;
         var nan_val: f64;
         mem.raw_copy(?nan_val, ?bits, 8);
@@ -387,7 +387,7 @@ pub fun parse_f64(s: str) Result[f64, str] {
     var int_part: f64 = 0.0;
     var has_digit: bool = false;
     for (i < len) {
-        val c: u8 = s[i];
+        val c: u8 = s.data[i];
         if (c == '_') { i = i + 1; cnt; }
         if (c < '0' || c > '9') { brk; }
         has_digit = true;
@@ -398,10 +398,10 @@ pub fun parse_f64(s: str) Result[f64, str] {
     # fractional part
     var frac: f64 = 0.0;
     var divisor: f64 = 1.0;
-    if (i < len && s[i] == '.') {
+    if (i < len && s.data[i] == '.') {
         i = i + 1;
         for (i < len) {
-            val c: u8 = s[i];
+            val c: u8 = s.data[i];
             if (c == '_') { i = i + 1; cnt; }
             if (c < '0' || c > '9') { brk; }
             has_digit = true;
@@ -416,16 +416,16 @@ pub fun parse_f64(s: str) Result[f64, str] {
     var result: f64 = (int_part + frac / divisor) * sign;
 
     # exponent
-    if (i < len && (s[i] == 'e' || s[i] == 'E')) {
+    if (i < len && (s.data[i] == 'e' || s.data[i] == 'E')) {
         i = i + 1;
         var exp_sign: i64 = 1;
-        if (i < len && s[i] == '+') { i = i + 1; }
-        or (i < len && s[i] == '-') { exp_sign = -1; i = i + 1; }
+        if (i < len && s.data[i] == '+') { i = i + 1; }
+        or (i < len && s.data[i] == '-') { exp_sign = -1; i = i + 1; }
 
         var exp: i64 = 0;
         var has_exp: bool = false;
         for (i < len) {
-            val c: u8 = s[i];
+            val c: u8 = s.data[i];
             if (c == '_') { i = i + 1; cnt; }
             if (c < '0' || c > '9') { brk; }
             has_exp = true;
@@ -462,13 +462,13 @@ pub fun parse_f64_exact(s: str) Result[f64, str] {
     var i: usize = 0;
 
     var sign: f64 = 1.0;
-    if (s[i] == '-') { sign = 0.0 - 1.0; i = i + 1; }
-    or (s[i] == '+') { i = i + 1; }
+    if (s.data[i] == '-') { sign = 0.0 - 1.0; i = i + 1; }
+    or (s.data[i] == '+') { i = i + 1; }
 
     if (i >= len) { ret err[f64, str]("no digits after sign"); }
 
     # inf
-    if (i + 3 <= len && s[i] == 'i' && s[i + 1] == 'n' && s[i + 2] == 'f') {
+    if (i + 3 <= len && s.data[i] == 'i' && s.data[i + 1] == 'n' && s.data[i + 2] == 'f') {
         if (i + 3 != len) { ret err[f64, str]("unexpected character"); }
         var bits: u64 = 0x7FF0000000000000;
         if (sign < 0.0) { bits = 0xFFF0000000000000; }
@@ -478,7 +478,7 @@ pub fun parse_f64_exact(s: str) Result[f64, str] {
     }
 
     # nan
-    if (i + 3 <= len && s[i] == 'n' && s[i + 1] == 'a' && s[i + 2] == 'n') {
+    if (i + 3 <= len && s.data[i] == 'n' && s.data[i + 1] == 'a' && s.data[i + 2] == 'n') {
         if (i + 3 != len) { ret err[f64, str]("unexpected character"); }
         val bits: u64 = 0x7FF8000000000000;
         var nan_val: f64;
@@ -490,7 +490,7 @@ pub fun parse_f64_exact(s: str) Result[f64, str] {
     var int_part: f64 = 0.0;
     var has_digit: bool = false;
     for (i < len) {
-        val c: u8 = s[i];
+        val c: u8 = s.data[i];
         if (c == '_') { i = i + 1; cnt; }
         if (c < '0' || c > '9') { brk; }
         has_digit = true;
@@ -501,10 +501,10 @@ pub fun parse_f64_exact(s: str) Result[f64, str] {
     # fractional part
     var frac: f64 = 0.0;
     var divisor: f64 = 1.0;
-    if (i < len && s[i] == '.') {
+    if (i < len && s.data[i] == '.') {
         i = i + 1;
         for (i < len) {
-            val c: u8 = s[i];
+            val c: u8 = s.data[i];
             if (c == '_') { i = i + 1; cnt; }
             if (c < '0' || c > '9') { brk; }
             has_digit = true;
@@ -519,16 +519,16 @@ pub fun parse_f64_exact(s: str) Result[f64, str] {
     var result: f64 = (int_part + frac / divisor) * sign;
 
     # exponent
-    if (i < len && (s[i] == 'e' || s[i] == 'E')) {
+    if (i < len && (s.data[i] == 'e' || s.data[i] == 'E')) {
         i = i + 1;
         var exp_sign: i64 = 1;
-        if (i < len && s[i] == '+') { i = i + 1; }
-        or (i < len && s[i] == '-') { exp_sign = -1; i = i + 1; }
+        if (i < len && s.data[i] == '+') { i = i + 1; }
+        or (i < len && s.data[i] == '-') { exp_sign = -1; i = i + 1; }
 
         var exp: i64 = 0;
         var has_exp: bool = false;
         for (i < len) {
-            val c: u8 = s[i];
+            val c: u8 = s.data[i];
             if (c == '_') { i = i + 1; cnt; }
             if (c < '0' || c > '9') { brk; }
             has_exp = true;

--- a/src/types/option.mach
+++ b/src/types/option.mach
@@ -49,7 +49,7 @@ pub fun is_none[T](opt: Option[T]) bool {
 # ret: the contained value
 pub fun unwrap[T](opt: Option[T]) T {
     if (!opt.has_value) {
-        panic("unwrap called on None\n");
+        panic(`unwrap called on None\n`);
     }
     ret opt.value;
 }

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -1,9 +1,9 @@
 # path manipulation helpers
 #
-# Path is a type alias for str. functions that return new paths allocate
-# through the caller-provided Allocator. functions that return views into
-# existing paths (filename, extension) return pointers into the input and
-# do not allocate.
+# Path is a type alias for str (the builtin fat string). functions that
+# return new paths allocate through the caller-provided Allocator. functions
+# that return views into existing paths (filename, extension) return a sub-
+# string referencing the original storage and do not allocate.
 
 use std.types.bool;
 use std.types.result;
@@ -22,28 +22,28 @@ pub fun separator() u8 {
     ret os.separator;
 }
 
-# is_empty: check whether a path is empty or nil.
+# is_empty: check whether a path is empty.
 pub fun is_empty(p: Path) bool {
-    ret p == nil || p[0] == 0;
+    ret p.len == 0 || p.data == nil;
 }
 
 # is_abs: check whether a path is absolute.
 pub fun is_abs(p: Path) bool {
-    if (p == nil) { ret false; }
+    if (is_empty(p)) { ret false; }
 
-    ret p[0] == separator();
+    ret p.data[0] == separator();
 }
 
 # is_root: check whether a path consists only of separators.
 pub fun is_root(p: Path) bool {
     if (is_empty(p)) { ret false; }
 
-    val len: usize = str_len(p);
+    val len: usize = p.len::usize;
     val sep: u8    = separator();
     var i:   usize = 0;
 
     for (i < len) {
-        if (p[i] != sep) { ret false; }
+        if (p.data[i] != sep) { ret false; }
         i = i + 1;
     }
 
@@ -52,21 +52,28 @@ pub fun is_root(p: Path) bool {
 
 # filename: return the final component of a path.
 #
-# returns a pointer into p (no allocation). returns nil for empty paths
-# and empty string for paths ending in a separator.
+# returns a sub-string referencing p.data (no allocation). returns an empty
+# str for empty paths and for paths ending in a separator.
 # ---
 # p:   path to extract filename from
-# ret: pointer into p at the filename, or nil
+# ret: sub-string into p at the filename, or empty
 pub fun filename(p: Path) str {
-    if (is_empty(p)) { ret nil; }
-    val len: usize = str_len(p);
+    var out: str;
+    out.len  = 0;
+    out.data = nil;
+
+    if (is_empty(p)) { ret out; }
+
+    val len: usize = p.len::usize;
     val sep: u8    = separator();
     var i:   usize = len;
 
     for (i > 0) {
         i = i - 1;
-        if (p[i] == sep) {
-            ret (p::usize + i + 1)::str;
+        if (p.data[i] == sep) {
+            out.len  = (len - i - 1)::u32;
+            out.data = (p.data::usize + i + 1)::*u8;
+            ret out;
         }
     }
 
@@ -75,33 +82,37 @@ pub fun filename(p: Path) str {
 
 # extension: return the file extension without the leading dot.
 #
-# returns a pointer into p (no allocation). returns nil if there is no
-# extension (no dot, or dot is first char of filename).
+# returns a sub-string referencing p.data (no allocation). returns an empty
+# str if there is no extension (no dot, or dot is first char of filename).
 # ---
 # p:   path to extract extension from
-# ret: pointer into p at the extension, or nil
+# ret: sub-string into p at the extension, or empty
 pub fun extension(p: Path) str {
+    var out: str;
+    out.len  = 0;
+    out.data = nil;
+
     val name: str = filename(p);
-    if (name == nil) { ret nil; }
+    if (name.len == 0) { ret out; }
 
-    val len: usize = str_len(name);
-    if (len == 0) { ret nil; }
-
+    val len: usize = name.len::usize;
     var i: usize = len;
     for (i > 0) {
         i = i - 1;
-        if (name[i] == '.') {
-            if (i == 0) { ret nil; }
-            ret (name::usize + i + 1)::str;
+        if (name.data[i] == '.') {
+            if (i == 0) { ret out; }
+            out.len  = (len - i - 1)::u32;
+            out.data = (name.data::usize + i + 1)::*u8;
+            ret out;
         }
     }
 
-    ret nil;
+    ret out;
 }
 
 # stem: return the filename without its extension.
 #
-# "foo/bar.txt" → "bar", "foo/.hidden" → ".hidden", "foo/bar" → "bar"
+# "foo/bar.txt" -> "bar", "foo/.hidden" -> ".hidden", "foo/bar" -> "bar"
 # ---
 # a:   allocator for the result
 # p:   path to extract stem from
@@ -110,16 +121,14 @@ pub fun stem(a: *allocator.Allocator, p: Path) Result[Path, str] {
     if (a == nil) { ret err[Path, str]("allocator is nil"); }
 
     val name: str = filename(p);
-    if (name == nil) { ret ok[Path, str](nil); }
-
-    val len: usize = str_len(name);
-    if (len == 0) { ret ok[Path, str](nil); }
+    if (name.len == 0) { ret ok[Path, str](empty_path()); }
 
     val file_ext: str = extension(p);
-    if (file_ext == nil) { ret clone(a, name); }
+    if (file_ext.len == 0) { ret clone(a, name); }
 
-    val ext_len:  usize = str_len(file_ext);
-    val stem_len: usize = len - ext_len - 1;
+    val ext_len:  usize = file_ext.len::usize;
+    val name_len: usize = name.len::usize;
+    val stem_len: usize = name_len - ext_len - 1;
 
     val r: Result[*u8, str] = allocator.allocate[u8](a, stem_len + 1);
     if (is_err[*u8, str](r)) {
@@ -127,32 +136,38 @@ pub fun stem(a: *allocator.Allocator, p: Path) Result[Path, str] {
     }
 
     val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, name::ptr, stem_len);
+    mem.raw_copy(buf::ptr, name.data::ptr, stem_len);
     buf[stem_len] = 0;
 
-    ret ok[Path, str](buf::*u8);
+    var out: str;
+    out.len  = stem_len::u32;
+    out.data = buf;
+    ret ok[Path, str](out);
 }
 
 # clone: duplicate a path using the provided allocator.
 # ---
 # a:   allocator for the new path
-# p:   path to clone (nil returns nil)
+# p:   path to clone (empty returns empty)
 # ret: the cloned path, or an error message
 pub fun clone(a: *allocator.Allocator, p: Path) Result[Path, str] {
-    if (a == nil) { ret err[Path, str]("allocator is nil"); }
-    if (p == nil) { ret ok[Path, str](nil); }
+    if (a == nil)    { ret err[Path, str]("allocator is nil"); }
+    if (is_empty(p)) { ret ok[Path, str](empty_path()); }
 
-    val n: usize            = str_len(p);
+    val n: usize            = p.len::usize;
     val r: Result[*u8, str] = allocator.allocate[u8](a, n + 1);
     if (is_err[*u8, str](r)) {
         ret err[Path, str](unwrap_err[*u8, str](r));
     }
 
     val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, p::ptr, n);
+    mem.raw_copy(buf::ptr, p.data::ptr, n);
     buf[n] = 0;
 
-    ret ok[Path, str](buf::*u8);
+    var out: str;
+    out.len  = n::u32;
+    out.data = buf;
+    ret ok[Path, str](out);
 }
 
 # join: join two path segments with the platform separator.
@@ -167,9 +182,9 @@ pub fun join(a: *allocator.Allocator, left: Path, right: Path) Result[Path, str]
     if (is_empty(right)) { ret clone(a, left); }
 
     val sep:       u8    = separator();
-    val left_len:  usize = str_len(left);
-    val right_len: usize = str_len(right);
-    val has_sep:   bool  = left[left_len - 1] == sep || right[0] == sep;
+    val left_len:  usize = left.len::usize;
+    val right_len: usize = right.len::usize;
+    val has_sep:   bool  = left.data[left_len - 1] == sep || right.data[0] == sep;
 
     var extra: usize = 0;
     if (!has_sep) { extra = 1; }
@@ -181,7 +196,7 @@ pub fun join(a: *allocator.Allocator, left: Path, right: Path) Result[Path, str]
     }
 
     val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, left::ptr, left_len);
+    mem.raw_copy(buf::ptr, left.data::ptr, left_len);
 
     var off: usize = left_len;
     if (!has_sep) {
@@ -189,10 +204,13 @@ pub fun join(a: *allocator.Allocator, left: Path, right: Path) Result[Path, str]
         off = off + 1;
     }
 
-    mem.raw_copy((buf::usize + off)::ptr, right::ptr, right_len);
+    mem.raw_copy((buf::usize + off)::ptr, right.data::ptr, right_len);
     buf[out_len] = 0;
 
-    ret ok[Path, str](buf::*u8);
+    var out: str;
+    out.len  = out_len::u32;
+    out.data = buf;
+    ret ok[Path, str](out);
 }
 
 # parent: return the parent directory of a path.
@@ -204,11 +222,11 @@ pub fun parent(a: *allocator.Allocator, p: Path) Result[Path, str] {
     if (a == nil)    { ret err[Path, str]("allocator is nil"); }
     if (is_empty(p)) { ret clone(a, "."); }
 
-    val len: usize = str_len(p);
+    val len: usize = p.len::usize;
     val sep: u8    = separator();
 
     var end: usize = len;
-    for (end > 0 && p[end - 1] == sep) {
+    for (end > 0 && p.data[end - 1] == sep) {
         end = end - 1;
     }
     if (end == 0) { ret clone_sep(a, sep); }
@@ -216,14 +234,14 @@ pub fun parent(a: *allocator.Allocator, p: Path) Result[Path, str] {
     var i: usize = end;
     for (i > 0) {
         i = i - 1;
-        if (p[i] == sep) { brk; }
+        if (p.data[i] == sep) { brk; }
     }
 
-    if (i == 0 && p[0] != sep) { ret clone(a, "."); }
-    if (i == 0)                { ret clone_sep(a, sep); }
+    if (i == 0 && p.data[0] != sep) { ret clone(a, "."); }
+    if (i == 0)                     { ret clone_sep(a, sep); }
 
     var parent_end: usize = i;
-    for (parent_end > 0 && p[parent_end - 1] == sep) {
+    for (parent_end > 0 && p.data[parent_end - 1] == sep) {
         parent_end = parent_end - 1;
     }
     if (parent_end == 0) { ret clone_sep(a, sep); }
@@ -234,10 +252,20 @@ pub fun parent(a: *allocator.Allocator, p: Path) Result[Path, str] {
     }
 
     val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, p::ptr, parent_end);
+    mem.raw_copy(buf::ptr, p.data::ptr, parent_end);
     buf[parent_end] = 0;
 
-    ret ok[Path, str](buf::*u8);
+    var out: str;
+    out.len  = parent_end::u32;
+    out.data = buf;
+    ret ok[Path, str](out);
+}
+
+fun empty_path() str {
+    var out: str;
+    out.len  = 0;
+    out.data = nil;
+    ret out;
 }
 
 fun clone_sep(a: *allocator.Allocator, sep: u8) Result[Path, str] {
@@ -250,7 +278,10 @@ fun clone_sep(a: *allocator.Allocator, sep: u8) Result[Path, str] {
     buf[0] = sep;
     buf[1] = 0;
 
-    ret ok[Path, str](buf::*u8);
+    var out: str;
+    out.len  = 1;
+    out.data = buf;
+    ret ok[Path, str](out);
 }
 
 test "path: is_abs with absolute path" {
@@ -263,8 +294,9 @@ test "path: is_abs with relative path" {
     ret 1;
 }
 
-test "path: is_abs with nil" {
-    if (is_abs(nil)) { ret 0; }
+test "path: is_abs with empty" {
+    val empty: str = "";
+    if (is_abs(empty)) { ret 0; }
     ret 1;
 }
 
@@ -280,9 +312,9 @@ test "path: filename no directory" {
     ret 1;
 }
 
-test "path: filename nil" {
-    val f: str = filename(nil);
-    if (f != nil) { ret 0; }
+test "path: filename empty" {
+    val f: str = filename("");
+    if (f.len != 0) { ret 0; }
     ret 1;
 }
 
@@ -294,13 +326,13 @@ test "path: extension basic" {
 
 test "path: extension none" {
     val e: str = extension("/foo/bar");
-    if (e != nil) { ret 0; }
+    if (e.len != 0) { ret 0; }
     ret 1;
 }
 
 test "path: extension hidden file" {
     val e: str = extension("/foo/.hidden");
-    if (e != nil) { ret 0; }
+    if (e.len != 0) { ret 0; }
     ret 1;
 }
 

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -1,9 +1,27 @@
 # path manipulation helpers
 #
-# Path is a type alias for str (the builtin fat string). functions that
-# return new paths allocate through the caller-provided Allocator. functions
-# that return views into existing paths (filename, extension) return a sub-
-# string referencing the original storage and do not allocate.
+# Path is a type alias for str (the builtin fat string). every value of
+# type Path upholds an additional invariant beyond str:
+#
+#     p.data[p.len] == 0
+#
+# i.e. one byte past the logical end of every valid Path is a null
+# terminator. this makes p.data unconditionally safe to pass across
+# C-FFI boundaries that expect a null-terminated *u8.
+#
+# the invariant is preserved by construction:
+#   * literal-derived Path values use rodata which is null-terminated by
+#     the compiler.
+#   * allocating constructors (clone, join, parent, stem, filename,
+#     extension, ...) write a trailing 0 into the buffer they allocate
+#     and report `len` excluding the terminator.
+#   * the canonical empty Path returned by `empty_path()` points at a
+#     static zero byte.
+#
+# corollary: do NOT construct a Path by hand-stitching `len` and `data`
+# fields unless you've ensured the byte at offset `len` is 0. functions
+# that conceptually slice a path (filename, extension) therefore allocate
+# a fresh null-terminated copy rather than returning a sub-view.
 
 use std.types.bool;
 use std.types.result;
@@ -17,14 +35,27 @@ use page:      std.allocator.page;
 
 pub def Path: str;
 
+# canonical empty Path. the backing storage is a single null byte so that
+# the null-termination invariant holds even for the empty case.
+val EMPTY_BYTE: zstr = ``;
+
 # separator: platform path separator character.
 pub fun separator() u8 {
     ret os.separator;
 }
 
+# empty_path: the canonical empty Path value. its data pointer is non-nil
+# and points at a static null byte, so `empty_path().data[0] == 0`.
+pub fun empty_path() Path {
+    var out: Path;
+    out.len  = 0;
+    out.data = EMPTY_BYTE;
+    ret out;
+}
+
 # is_empty: check whether a path is empty.
 pub fun is_empty(p: Path) bool {
-    ret p.len == 0 || p.data == nil;
+    ret p.len == 0;
 }
 
 # is_abs: check whether a path is absolute.
@@ -50,67 +81,71 @@ pub fun is_root(p: Path) bool {
     ret true;
 }
 
-# filename: return the final component of a path.
+# filename: return the final component of a path as a freshly allocated Path.
 #
-# returns a sub-string referencing p.data (no allocation). returns an empty
-# str for empty paths and for paths ending in a separator.
+# allocates a null-terminated copy via `a`. for an empty input or a path
+# that ends in a separator (no final component), returns the canonical
+# empty Path.
 # ---
+# a:   allocator for the result
 # p:   path to extract filename from
-# ret: sub-string into p at the filename, or empty
-pub fun filename(p: Path) str {
-    var out: str;
-    out.len  = 0;
-    out.data = nil;
-
-    if (is_empty(p)) { ret out; }
+# ret: the filename, or an error message
+pub fun filename(a: *allocator.Allocator, p: Path) Result[Path, str] {
+    if (a == nil) { ret err[Path, str]("allocator is nil"); }
+    if (is_empty(p)) { ret ok[Path, str](empty_path()); }
 
     val len: usize = p.len::usize;
     val sep: u8    = separator();
     var i:   usize = len;
 
+    var start:    usize = 0;
+    var name_len: usize = len;
+
     for (i > 0) {
         i = i - 1;
         if (p.data[i] == sep) {
-            out.len  = (len - i - 1)::u32;
-            out.data = (p.data::usize + i + 1)::*u8;
-            ret out;
+            start    = i + 1;
+            name_len = len - start;
+            ret clone_range(a, p, start, name_len);
         }
     }
 
-    ret p;
+    ret clone(a, p);
 }
 
-# extension: return the file extension without the leading dot.
+# extension: return the file extension (without leading dot) as a freshly
+# allocated Path.
 #
-# returns a sub-string referencing p.data (no allocation). returns an empty
-# str if there is no extension (no dot, or dot is first char of filename).
+# allocates a null-terminated copy via `a`. returns the canonical empty
+# Path if the filename has no extension (no dot, or dot is the first
+# character of the filename, like ".hidden").
 # ---
+# a:   allocator for the result
 # p:   path to extract extension from
-# ret: sub-string into p at the extension, or empty
-pub fun extension(p: Path) str {
-    var out: str;
-    out.len  = 0;
-    out.data = nil;
+# ret: the extension, or an error message
+pub fun extension(a: *allocator.Allocator, p: Path) Result[Path, str] {
+    if (a == nil) { ret err[Path, str]("allocator is nil"); }
 
-    val name: str = filename(p);
-    if (name.len == 0) { ret out; }
+    var name_start: usize = 0;
+    var name_len:   usize = 0;
+    filename_range(p, ?name_start, ?name_len);
+    if (name_len == 0) { ret ok[Path, str](empty_path()); }
 
-    val len: usize = name.len::usize;
-    var i: usize = len;
-    for (i > 0) {
-        i = i - 1;
-        if (name.data[i] == '.') {
-            if (i == 0) { ret out; }
-            out.len  = (len - i - 1)::u32;
-            out.data = (name.data::usize + i + 1)::*u8;
-            ret out;
+    var k: usize = name_len;
+    for (k > 0) {
+        k = k - 1;
+        if (p.data[name_start + k] == '.') {
+            if (k == 0) { ret ok[Path, str](empty_path()); }
+            val ext_start: usize = name_start + k + 1;
+            val ext_len:   usize = name_len - k - 1;
+            ret clone_range(a, p, ext_start, ext_len);
         }
     }
 
-    ret out;
+    ret ok[Path, str](empty_path());
 }
 
-# stem: return the filename without its extension.
+# stem: return the filename without its extension as a freshly allocated Path.
 #
 # "foo/bar.txt" -> "bar", "foo/.hidden" -> ".hidden", "foo/bar" -> "bar"
 # ---
@@ -120,29 +155,29 @@ pub fun extension(p: Path) str {
 pub fun stem(a: *allocator.Allocator, p: Path) Result[Path, str] {
     if (a == nil) { ret err[Path, str]("allocator is nil"); }
 
-    val name: str = filename(p);
-    if (name.len == 0) { ret ok[Path, str](empty_path()); }
+    var name_start: usize = 0;
+    var name_len:   usize = 0;
+    filename_range(p, ?name_start, ?name_len);
+    if (name_len == 0) { ret ok[Path, str](empty_path()); }
 
-    val file_ext: str = extension(p);
-    if (file_ext.len == 0) { ret clone(a, name); }
-
-    val ext_len:  usize = file_ext.len::usize;
-    val name_len: usize = name.len::usize;
-    val stem_len: usize = name_len - ext_len - 1;
-
-    val r: Result[*u8, str] = allocator.allocate[u8](a, stem_len + 1);
-    if (is_err[*u8, str](r)) {
-        ret err[Path, str](unwrap_err[*u8, str](r));
+    # find the last '.' that is not at position 0 of the filename
+    var dot_pos: usize = name_len;
+    var has_dot: bool  = false;
+    var k:       usize = name_len;
+    for (k > 0) {
+        k = k - 1;
+        if (p.data[name_start + k] == '.') {
+            if (k == 0) { brk; }
+            dot_pos = k;
+            has_dot = true;
+            brk;
+        }
     }
 
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, name.data::ptr, stem_len);
-    buf[stem_len] = 0;
-
-    var out: str;
-    out.len  = stem_len::u32;
-    out.data = buf;
-    ret ok[Path, str](out);
+    if (!has_dot) {
+        ret clone_range(a, p, name_start, name_len);
+    }
+    ret clone_range(a, p, name_start, dot_pos);
 }
 
 # clone: duplicate a path using the provided allocator.
@@ -154,20 +189,7 @@ pub fun clone(a: *allocator.Allocator, p: Path) Result[Path, str] {
     if (a == nil)    { ret err[Path, str]("allocator is nil"); }
     if (is_empty(p)) { ret ok[Path, str](empty_path()); }
 
-    val n: usize            = p.len::usize;
-    val r: Result[*u8, str] = allocator.allocate[u8](a, n + 1);
-    if (is_err[*u8, str](r)) {
-        ret err[Path, str](unwrap_err[*u8, str](r));
-    }
-
-    val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, p.data::ptr, n);
-    buf[n] = 0;
-
-    var out: str;
-    out.len  = n::u32;
-    out.data = buf;
-    ret ok[Path, str](out);
+    ret clone_range(a, p, 0, p.len::usize);
 }
 
 # join: join two path segments with the platform separator.
@@ -207,7 +229,7 @@ pub fun join(a: *allocator.Allocator, left: Path, right: Path) Result[Path, str]
     mem.raw_copy((buf::usize + off)::ptr, right.data::ptr, right_len);
     buf[out_len] = 0;
 
-    var out: str;
+    var out: Path;
     out.len  = out_len::u32;
     out.data = buf;
     ret ok[Path, str](out);
@@ -246,28 +268,57 @@ pub fun parent(a: *allocator.Allocator, p: Path) Result[Path, str] {
     }
     if (parent_end == 0) { ret clone_sep(a, sep); }
 
-    val r: Result[*u8, str] = allocator.allocate[u8](a, parent_end + 1);
+    ret clone_range(a, p, 0, parent_end);
+}
+
+# filename_range: compute the byte offset and length of the final
+# component of a path within p.data, without allocating.
+#
+# this is an internal helper. callers must use the result only to read
+# bytes within `p`; the byte after the range is NOT guaranteed to be 0.
+fun filename_range(p: Path, start: *usize, len: *usize) {
+    @start = 0;
+    @len   = 0;
+    if (is_empty(p)) { ret; }
+
+    val plen: usize = p.len::usize;
+    val sep:  u8    = separator();
+    var i:    usize = plen;
+
+    for (i > 0) {
+        i = i - 1;
+        if (p.data[i] == sep) {
+            @start = i + 1;
+            @len   = plen - @start;
+            ret;
+        }
+    }
+
+    @start = 0;
+    @len   = plen;
+}
+
+# clone_range: allocate a null-terminated Path containing
+# p.data[start..start+len].
+fun clone_range(a: *allocator.Allocator, p: Path, start: usize, len: usize) Result[Path, str] {
+    val r: Result[*u8, str] = allocator.allocate[u8](a, len + 1);
     if (is_err[*u8, str](r)) {
         ret err[Path, str](unwrap_err[*u8, str](r));
     }
 
     val buf: *u8 = unwrap_ok[*u8, str](r);
-    mem.raw_copy(buf::ptr, p.data::ptr, parent_end);
-    buf[parent_end] = 0;
+    if (len > 0) {
+        mem.raw_copy(buf::ptr, (p.data::usize + start)::ptr, len);
+    }
+    buf[len] = 0;
 
-    var out: str;
-    out.len  = parent_end::u32;
+    var out: Path;
+    out.len  = len::u32;
     out.data = buf;
     ret ok[Path, str](out);
 }
 
-fun empty_path() str {
-    var out: str;
-    out.len  = 0;
-    out.data = nil;
-    ret out;
-}
-
+# clone_sep: allocate a one-character Path consisting of just `sep`.
 fun clone_sep(a: *allocator.Allocator, sep: u8) Result[Path, str] {
     val r: Result[*u8, str] = allocator.allocate[u8](a, 2);
     if (is_err[*u8, str](r)) {
@@ -278,7 +329,7 @@ fun clone_sep(a: *allocator.Allocator, sep: u8) Result[Path, str] {
     buf[0] = sep;
     buf[1] = 0;
 
-    var out: str;
+    var out: Path;
     out.len  = 1;
     out.data = buf;
     ret ok[Path, str](out);
@@ -295,44 +346,81 @@ test "path: is_abs with relative path" {
 }
 
 test "path: is_abs with empty" {
-    val empty: str = "";
-    if (is_abs(empty)) { ret 0; }
+    if (is_abs(empty_path())) { ret 0; }
+    ret 1;
+}
+
+test "path: empty_path is null-terminated" {
+    val e: Path = empty_path();
+    if (e.len != 0)        { ret 0; }
+    if (e.data == nil)     { ret 0; }
+    if (e.data[0] != 0)    { ret 0; }
     ret 1;
 }
 
 test "path: filename basic" {
-    val f: str = filename("/foo/bar.txt");
+    var a: allocator.Allocator;
+    page.make(?a);
+    val r: Result[Path, str] = filename(?a, "/foo/bar.txt");
+    if (is_err[Path, str](r))      { ret 0; }
+    val f: Path = unwrap_ok[Path, str](r);
     if (!str_equals(f, "bar.txt")) { ret 0; }
+    if (f.data[f.len::usize] != 0) { ret 0; }
     ret 1;
 }
 
 test "path: filename no directory" {
-    val f: str = filename("bar.txt");
+    var a: allocator.Allocator;
+    page.make(?a);
+    val r: Result[Path, str] = filename(?a, "bar.txt");
+    if (is_err[Path, str](r))      { ret 0; }
+    val f: Path = unwrap_ok[Path, str](r);
     if (!str_equals(f, "bar.txt")) { ret 0; }
+    if (f.data[f.len::usize] != 0) { ret 0; }
     ret 1;
 }
 
-test "path: filename empty" {
-    val f: str = filename("");
-    if (f.len != 0) { ret 0; }
+test "path: filename empty input returns empty" {
+    var a: allocator.Allocator;
+    page.make(?a);
+    val r: Result[Path, str] = filename(?a, "");
+    if (is_err[Path, str](r)) { ret 0; }
+    val f: Path = unwrap_ok[Path, str](r);
+    if (f.len != 0)        { ret 0; }
+    if (f.data[0] != 0)    { ret 0; }
     ret 1;
 }
 
 test "path: extension basic" {
-    val e: str = extension("/foo/bar.txt");
-    if (!str_equals(e, "txt")) { ret 0; }
+    var a: allocator.Allocator;
+    page.make(?a);
+    val r: Result[Path, str] = extension(?a, "/foo/bar.txt");
+    if (is_err[Path, str](r))   { ret 0; }
+    val e: Path = unwrap_ok[Path, str](r);
+    if (!str_equals(e, "txt"))  { ret 0; }
+    if (e.data[e.len::usize] != 0) { ret 0; }
     ret 1;
 }
 
 test "path: extension none" {
-    val e: str = extension("/foo/bar");
-    if (e.len != 0) { ret 0; }
+    var a: allocator.Allocator;
+    page.make(?a);
+    val r: Result[Path, str] = extension(?a, "/foo/bar");
+    if (is_err[Path, str](r)) { ret 0; }
+    val e: Path = unwrap_ok[Path, str](r);
+    if (e.len != 0)           { ret 0; }
+    if (e.data[0] != 0)       { ret 0; }
     ret 1;
 }
 
 test "path: extension hidden file" {
-    val e: str = extension("/foo/.hidden");
-    if (e.len != 0) { ret 0; }
+    var a: allocator.Allocator;
+    page.make(?a);
+    val r: Result[Path, str] = extension(?a, "/foo/.hidden");
+    if (is_err[Path, str](r)) { ret 0; }
+    val e: Path = unwrap_ok[Path, str](r);
+    if (e.len != 0)           { ret 0; }
+    if (e.data[0] != 0)       { ret 0; }
     ret 1;
 }
 
@@ -340,9 +428,10 @@ test "path: stem basic" {
     var a: allocator.Allocator;
     page.make(?a);
     val r: Result[Path, str] = stem(?a, "/foo/bar.txt");
-    if (is_err[Path, str](r)) { ret 0; }
-    val s: str = unwrap_ok[Path, str](r);
-    if (!str_equals(s, "bar")) { ret 0; }
+    if (is_err[Path, str](r))     { ret 0; }
+    val s: Path = unwrap_ok[Path, str](r);
+    if (!str_equals(s, "bar"))    { ret 0; }
+    if (s.data[s.len::usize] != 0) { ret 0; }
     ret 1;
 }
 
@@ -350,9 +439,10 @@ test "path: stem no extension" {
     var a: allocator.Allocator;
     page.make(?a);
     val r: Result[Path, str] = stem(?a, "/foo/bar");
-    if (is_err[Path, str](r)) { ret 0; }
-    val s: str = unwrap_ok[Path, str](r);
-    if (!str_equals(s, "bar")) { ret 0; }
+    if (is_err[Path, str](r))     { ret 0; }
+    val s: Path = unwrap_ok[Path, str](r);
+    if (!str_equals(s, "bar"))    { ret 0; }
+    if (s.data[s.len::usize] != 0) { ret 0; }
     ret 1;
 }
 
@@ -360,9 +450,10 @@ test "path: parent basic" {
     var a: allocator.Allocator;
     page.make(?a);
     val r: Result[Path, str] = parent(?a, "/foo/bar");
-    if (is_err[Path, str](r)) { ret 0; }
-    val p: str = unwrap_ok[Path, str](r);
-    if (!str_equals(p, "/foo")) { ret 0; }
+    if (is_err[Path, str](r))    { ret 0; }
+    val p: Path = unwrap_ok[Path, str](r);
+    if (!str_equals(p, "/foo"))  { ret 0; }
+    if (p.data[p.len::usize] != 0) { ret 0; }
     ret 1;
 }
 
@@ -371,7 +462,30 @@ test "path: parent root" {
     page.make(?a);
     val r: Result[Path, str] = parent(?a, "/foo");
     if (is_err[Path, str](r)) { ret 0; }
-    val p: str = unwrap_ok[Path, str](r);
-    if (!str_equals(p, "/")) { ret 0; }
+    val p: Path = unwrap_ok[Path, str](r);
+    if (!str_equals(p, "/"))  { ret 0; }
+    if (p.data[p.len::usize] != 0) { ret 0; }
+    ret 1;
+}
+
+test "path: clone preserves null terminator" {
+    var a: allocator.Allocator;
+    page.make(?a);
+    val r: Result[Path, str] = clone(?a, "hello/world");
+    if (is_err[Path, str](r))      { ret 0; }
+    val c: Path = unwrap_ok[Path, str](r);
+    if (!str_equals(c, "hello/world")) { ret 0; }
+    if (c.data[c.len::usize] != 0) { ret 0; }
+    ret 1;
+}
+
+test "path: join produces null-terminated path" {
+    var a: allocator.Allocator;
+    page.make(?a);
+    val r: Result[Path, str] = join(?a, "/foo", "bar");
+    if (is_err[Path, str](r))      { ret 0; }
+    val j: Path = unwrap_ok[Path, str](r);
+    if (!str_equals(j, "/foo/bar")) { ret 0; }
+    if (j.data[j.len::usize] != 0) { ret 0; }
     ret 1;
 }

--- a/src/types/result.mach
+++ b/src/types/result.mach
@@ -54,7 +54,7 @@ pub fun is_err[T, E](res: Result[T, E]) bool {
 # ret: the contained ok value
 pub fun unwrap_ok[T, E](res: Result[T, E]) T {
     if (!res.tag) {
-        panic("unwrap_ok called on Err\n");
+        panic(`unwrap_ok called on Err\n`);
     }
     ret res.value.ok;
 }
@@ -66,7 +66,7 @@ pub fun unwrap_ok[T, E](res: Result[T, E]) T {
 # ret: the contained err value
 pub fun unwrap_err[T, E](res: Result[T, E]) E {
     if (res.tag) {
-        panic("unwrap_err called on Ok\n");
+        panic(`unwrap_err called on Ok\n`);
     }
     ret res.value.err;
 }

--- a/src/types/semver.mach
+++ b/src/types/semver.mach
@@ -31,11 +31,16 @@ pub rec Semver {
 # a:     allocator for prerelease/build substring copies
 # ret:   the parsed version, or an error message
 pub fun semver_parse(input: str, a: *allo.Allocator) Result[Semver, str] {
-    if (input == nil || str_len(input) == 0) {
+    if (str_len(input) == 0) {
         ret err[Semver, str]("empty version string");
     }
 
     var v:   Semver;
+    v.prerelease.len  = 0;
+    v.prerelease.data = nil;
+    v.build.len       = 0;
+    v.build.data      = nil;
+
     var pos: usize = 0;
 
     var major_result: Option[u64] = parse_number(input, ?pos);
@@ -44,7 +49,7 @@ pub fun semver_parse(input: str, a: *allo.Allocator) Result[Semver, str] {
     }
     v.major = unwrap[u64](major_result);
 
-    if (pos >= str_len(input) || input[pos] != '.') {
+    if (pos >= str_len(input) || input.data[pos] != '.') {
         ret err[Semver, str]("expected '.' after major");
     }
     pos = pos + 1;
@@ -55,7 +60,7 @@ pub fun semver_parse(input: str, a: *allo.Allocator) Result[Semver, str] {
     }
     v.minor = unwrap[u64](minor_result);
 
-    if (pos >= str_len(input) || input[pos] != '.') {
+    if (pos >= str_len(input) || input.data[pos] != '.') {
         ret err[Semver, str]("expected '.' after minor");
     }
     pos = pos + 1;
@@ -66,12 +71,12 @@ pub fun semver_parse(input: str, a: *allo.Allocator) Result[Semver, str] {
     }
     v.patch = unwrap[u64](patch_result);
 
-    if (pos < str_len(input) && input[pos] == '-') {
+    if (pos < str_len(input) && input.data[pos] == '-') {
         pos = pos + 1;
         val start: usize = pos;
 
         for (pos < str_len(input)) {
-            val c: u8 = input[pos];
+            val c: u8 = input.data[pos];
             if (c == '+') { brk; }
             if (!is_valid_prerelease_char(c)) {
                 ret err[Semver, str]("invalid prerelease character");
@@ -85,17 +90,18 @@ pub fun semver_parse(input: str, a: *allo.Allocator) Result[Semver, str] {
             ret err[Semver, str]("out of memory");
         }
         val buf: *u8 = unwrap_ok[ptr, str](alloc_result)::*u8;
-        mem.raw_copy(buf::ptr, (input + start)::ptr, pre_len);
+        mem.raw_copy(buf::ptr, (input.data::usize + start)::ptr, pre_len);
         buf[pre_len] = 0;
-        v.prerelease = buf::str;
+        v.prerelease.len  = pre_len::u32;
+        v.prerelease.data = buf;
     }
 
-    if (pos < str_len(input) && input[pos] == '+') {
+    if (pos < str_len(input) && input.data[pos] == '+') {
         pos = pos + 1;
         val start: usize = pos;
 
         for (pos < str_len(input)) {
-            val c: u8 = input[pos];
+            val c: u8 = input.data[pos];
             if (!is_valid_build_char(c)) {
                 ret err[Semver, str]("invalid build character");
             }
@@ -108,9 +114,10 @@ pub fun semver_parse(input: str, a: *allo.Allocator) Result[Semver, str] {
             ret err[Semver, str]("out of memory");
         }
         val buf: *u8 = unwrap_ok[ptr, str](alloc_result)::*u8;
-        mem.raw_copy(buf::ptr, (input + start)::ptr, bld_len);
+        mem.raw_copy(buf::ptr, (input.data::usize + start)::ptr, bld_len);
         buf[bld_len] = 0;
-        v.build = buf::str;
+        v.build.len  = bld_len::u32;
+        v.build.data = buf;
     }
 
     ret ok[Semver, str](v);
@@ -118,20 +125,20 @@ pub fun semver_parse(input: str, a: *allo.Allocator) Result[Semver, str] {
 
 # validate that a Semver is well-formed
 pub fun semver_is_valid(v: *Semver) bool {
-    if (!(v.prerelease == nil || str_len(v.prerelease) == 0)) {
+    if (v.prerelease.len > 0) {
         var i: usize = 0;
-        for (v.prerelease[i] != 0) {
-            if (!is_valid_prerelease_char(v.prerelease[i])) {
+        for (i < v.prerelease.len::usize) {
+            if (!is_valid_prerelease_char(v.prerelease.data[i])) {
                 ret false;
             }
             i = i + 1;
         }
     }
 
-    if (!(v.build == nil || str_len(v.build) == 0)) {
+    if (v.build.len > 0) {
         var i: usize = 0;
-        for (v.build[i] != 0) {
-            if (!is_valid_build_char(v.build[i])) {
+        for (i < v.build.len::usize) {
+            if (!is_valid_build_char(v.build.data[i])) {
                 ret false;
             }
             i = i + 1;
@@ -156,8 +163,8 @@ pub fun semver_compare(v: *Semver, other: *Semver) i64 {
     if (v.patch < other.patch) { ret -1; }
     if (v.patch > other.patch) { ret 1; }
 
-    val this_has_pre:  bool = !(v.prerelease == nil || str_len(v.prerelease) == 0);
-    val other_has_pre: bool = !(other.prerelease == nil || str_len(other.prerelease) == 0);
+    val this_has_pre:  bool = v.prerelease.len > 0;
+    val other_has_pre: bool = other.prerelease.len > 0;
 
     if (!this_has_pre && other_has_pre) { ret 1; }
     if (this_has_pre && !other_has_pre) { ret -1; }
@@ -186,17 +193,17 @@ pub fun semver_equals(v: *Semver, other: *Semver) bool {
 
 # check whether v is a stable release
 pub fun semver_is_stable(v: *Semver) bool {
-    ret v.prerelease == nil || str_len(v.prerelease) == 0;
+    ret v.prerelease.len == 0;
 }
 
 # check whether v is a prerelease
 pub fun semver_is_prerelease(v: *Semver) bool {
-    ret !(v.prerelease == nil || str_len(v.prerelease) == 0);
+    ret v.prerelease.len > 0;
 }
 
 # check whether v has build metadata
 pub fun semver_has_build(v: *Semver) bool {
-    ret !(v.build == nil || str_len(v.build) == 0);
+    ret v.build.len > 0;
 }
 
 # parse an unsigned number from input at pos
@@ -205,12 +212,11 @@ pub fun semver_has_build(v: *Semver) bool {
 # pos:   pointer to current position (advanced past the number on success)
 # ret:   some(value) or none on failure
 fun parse_number(input: str, pos: *usize) Option[u64] {
-    val start:       usize = @pos;
     var value:       u64   = 0;
     var found_digit: bool  = false;
 
     for (@pos < str_len(input)) {
-        val c: u8 = input[@pos];
+        val c: u8 = input.data[@pos];
         if (!char_is_digit(c)) { brk; }
 
         val digit: u64 = (c - '0')::u64;
@@ -246,27 +252,29 @@ fun compare_prerelease(a: str, b: str) i64 {
     var a_pos: usize = 0;
     var b_pos: usize = 0;
 
-    for {
-        val a_len: usize = str_len(a);
-        val b_len: usize = str_len(b);
+    val a_len: usize = str_len(a);
+    val b_len: usize = str_len(b);
 
+    for {
         if (a_pos >= a_len && b_pos >= b_len) { ret 0; }
         if (a_pos >= a_len) { ret -1; }
         if (b_pos >= b_len) { ret 1; }
 
         var a_start: usize = a_pos;
-        for (a_pos < a_len && a[a_pos] != '.') {
+        for (a_pos < a_len && a.data[a_pos] != '.') {
             a_pos = a_pos + 1;
         }
         val a_ident_len: usize = a_pos - a_start;
 
         var b_start: usize = b_pos;
-        for (b_pos < b_len && b[b_pos] != '.') {
+        for (b_pos < b_len && b.data[b_pos] != '.') {
             b_pos = b_pos + 1;
         }
         val b_ident_len: usize = b_pos - b_start;
 
-        val cmp: i64 = compare_identifier(a + a_start, a_ident_len, b + b_start, b_ident_len);
+        val cmp: i64 = compare_identifier_raw(
+            (a.data::usize + a_start)::*u8, a_ident_len,
+            (b.data::usize + b_start)::*u8, b_ident_len);
         if (cmp != 0) { ret cmp; }
 
         if (a_pos < a_len) { a_pos = a_pos + 1; }
@@ -276,37 +284,33 @@ fun compare_prerelease(a: str, b: str) i64 {
     ret 0;
 }
 
-# compare two identifiers per SemVer rules
+# compare two raw byte spans as semver identifiers
 # ---
-# a:     first identifier
+# a:     first identifier bytes
 # a_len: length of first identifier
-# b:     second identifier
+# b:     second identifier bytes
 # b_len: length of second identifier
 # ret:   <0 if a < b, 0 if equal, >0 if a > b
-fun compare_identifier(a: str, a_len: usize, b: str, b_len: usize) i64 {
-    val a_numeric: bool = is_numeric(a, a_len);
-    val b_numeric: bool = is_numeric(b, b_len);
+fun compare_identifier_raw(a: *u8, a_len: usize, b: *u8, b_len: usize) i64 {
+    val a_numeric: bool = is_numeric_raw(a, a_len);
+    val b_numeric: bool = is_numeric_raw(b, b_len);
 
     if (a_numeric && !b_numeric) { ret -1; }
     if (!a_numeric && b_numeric) { ret 1; }
 
     if (a_numeric && b_numeric) {
-        val a_val: u64 = parse_identifier_num(a, a_len);
-        val b_val: u64 = parse_identifier_num(b, b_len);
+        val a_val: u64 = parse_identifier_num_raw(a, a_len);
+        val b_val: u64 = parse_identifier_num_raw(b, b_len);
         if (a_val < b_val) { ret -1; }
         if (a_val > b_val) { ret 1; }
         ret 0;
     }
 
-    ret compare_bounded(a, a_len, b, b_len);
+    ret compare_bounded_raw(a, a_len, b, b_len);
 }
 
 # check whether the first len bytes of s are all digits
-# ---
-# s:   string to check
-# len: number of bytes to examine
-# ret: true if all bytes are digits and len > 0
-fun is_numeric(s: str, len: usize) bool {
+fun is_numeric_raw(s: *u8, len: usize) bool {
     if (len == 0) { ret false; }
 
     var i: usize = 0;
@@ -319,11 +323,7 @@ fun is_numeric(s: str, len: usize) bool {
 }
 
 # parse the first len bytes of s as a number
-# ---
-# s:   string containing digits
-# len: number of bytes to parse
-# ret: the parsed value
-fun parse_identifier_num(s: str, len: usize) u64 {
+fun parse_identifier_num_raw(s: *u8, len: usize) u64 {
     var value: u64   = 0;
     var i:     usize = 0;
 
@@ -338,14 +338,8 @@ fun parse_identifier_num(s: str, len: usize) u64 {
     ret value;
 }
 
-# lexicographic comparison of two bounded strings
-# ---
-# a:     first string
-# a_len: length of first string
-# b:     second string
-# b_len: length of second string
-# ret:   <0 if a < b, 0 if equal, >0 if a > b
-fun compare_bounded(a: str, a_len: usize, b: str, b_len: usize) i64 {
+# lexicographic comparison of two bounded raw byte spans
+fun compare_bounded_raw(a: *u8, a_len: usize, b: *u8, b_len: usize) i64 {
     var min_len: usize = a_len;
     if (b_len < min_len) { min_len = b_len; }
 
@@ -371,8 +365,8 @@ test "semver: parse basic version" {
     if (v.major != 1) { ret 0; }
     if (v.minor != 2) { ret 0; }
     if (v.patch != 3) { ret 0; }
-    if (v.prerelease != nil && str_len(v.prerelease) != 0) { ret 0; }
-    if (v.build != nil && str_len(v.build) != 0) { ret 0; }
+    if (v.prerelease.len != 0) { ret 0; }
+    if (v.build.len != 0) { ret 0; }
     ret 1;
 }
 
@@ -387,7 +381,7 @@ test "semver: parse prerelease with dots" {
     if (v.minor != 0) { ret 0; }
     if (v.patch != 0) { ret 0; }
     if (!str_equals(v.prerelease, "alpha.1")) { ret 0; }
-    if (v.build != nil && str_len(v.build) != 0) { ret 0; }
+    if (v.build.len != 0) { ret 0; }
     ret 1;
 }
 
@@ -399,7 +393,7 @@ test "semver: parse build metadata" {
     if (is_err[Semver, str](r)) { ret 0; }
     val v: Semver = unwrap_ok[Semver, str](r);
     if (v.major != 1) { ret 0; }
-    if (v.prerelease != nil && str_len(v.prerelease) != 0) { ret 0; }
+    if (v.prerelease.len != 0) { ret 0; }
     if (!str_equals(v.build, "build")) { ret 0; }
     ret 1;
 }

--- a/src/types/string.mach
+++ b/src/types/string.mach
@@ -1,4 +1,18 @@
-# null-terminated string primitives
+# fat-pointer string primitives
+#
+# `str` is a builtin compiler type with the layout:
+#
+#     rec { len: u32; data: *u8 }
+#
+# produced by double-quoted string literals ("..."). this module supplies
+# functions that operate on values of that type. the underlying bytes are
+# stored null-terminated in .rodata so that the data pointer can be passed
+# directly to C functions when needed, but `str` itself does not advertise
+# the terminator and `len` excludes it.
+#
+# `zstr` is the type of backtick literals (`...`). it is a bare `*u8`
+# pointing at null-terminated bytes; use it where you need C-style strings
+# at an FFI boundary.
 
 use std.types.bool;
 use std.types.size;
@@ -6,236 +20,220 @@ use std.types.option;
 use std.types.result;
 use std.types.char;
 
+# zstr: a pointer to a zero-terminated sequence of u8, suitable for C-style
+# interop. backtick literals (`...`) produce values of this type.
+pub def zstr: *u8;
 
-# str: a pointer to a null-terminated sequence of char.
-pub def str: *char;
-
-# zstr: a pointer to a zero-terminated sequence of char, suitable for C-style
-# interop. distinct alias for str today; will diverge once `str` becomes a
-# fat-pointer type. backtick literals (`...`) produce values of this type.
-pub def zstr: *char;
-
-# str_len: calculate the length of a null-terminated string.
+# str_len: return the length in bytes (excluding any trailing storage terminator).
 # ---
-# ret: length of the string (not including null terminator)
+# s:   the string
+# ret: number of bytes
 pub fun str_len(s: str) usize {
-    var len: usize = 0;
-    for (s[len] != 0) {
-        len = len + 1;
-    }
-    ret len;
+    ret s.len::usize;
 }
 
-# str_empty: check if the string is empty or nil.
+# str_empty: true if the string has zero length.
 # ---
-# ret: true if the string has zero length or is nil
+# s:   the string
+# ret: true if s.len == 0
 pub fun str_empty(s: str) bool {
-    if (s == nil) { ret true; }
-    ret s[0] == 0;
+    ret s.len == 0;
 }
 
-# str_equals: compare two null-terminated strings for equality.
+# str_equals: compare two strings for byte-wise equality.
 # ---
-# other: the other string to compare against
-# ret:   true if the strings are equal
+# s:     the first string
+# other: the second string
+# ret:   true if both strings have the same length and bytes
 pub fun str_equals(s: str, other: str) bool {
-    if (s == nil && other == nil) { ret true; }
-    if (s == nil || other == nil) { ret false; }
-    if (s == other) { ret true; }
+    if (s.len != other.len) { ret false; }
+    if (s.data == other.data) { ret true; }
     var i: usize = 0;
-    for (s[i] != 0 && other[i] != 0) {
-        if (s[i] != other[i]) {
-            ret false;
-        }
-        i = i + 1;
-    }
-    ret s[i] == other[i];
-}
-
-# str_compare: compare two null-terminated strings lexically.
-# ---
-# other: the other string to compare against
-# ret:   <0 if s < other, 0 if equal, >0 if s > other
-pub fun str_compare(s: str, other: str) i64 {
-    if (s == nil && other == nil) { ret 0; }
-    if (s == nil) { ret -1; }
-    if (other == nil) { ret 1; }
-    var i: usize = 0;
-    for {
-        val a: u8 = s[i];
-        val b: u8 = other[i];
-
-        if (a == 0 && b == 0) { ret 0; }
-        if (a == 0) { ret -1; }
-        if (b == 0) { ret 1; }
-
-        if (a < b) { ret -1; }
-        if (a > b) { ret 1; }
-
-        i = i + 1;
-    }
-    ret 0;
-}
-
-# str_starts_with: check if the string starts with the given prefix.
-# ---
-# prefix: the prefix to check
-# ret:    true if the string starts with prefix
-pub fun str_starts_with(s: str, prefix: str) bool {
-    var i: usize = 0;
-    for (prefix[i] != 0) {
-        if (s[i] == 0) { ret false; }
-        if (s[i] != prefix[i]) {
-            ret false;
-        }
+    for (i < s.len::usize) {
+        if (s.data[i] != other.data[i]) { ret false; }
         i = i + 1;
     }
     ret true;
 }
 
-# str_ends_with: check if the string ends with the given suffix.
+# str_compare: compare two strings lexically.
 # ---
-# suffix: the suffix to check
-# ret:    true if the string ends with suffix
-pub fun str_ends_with(s: str, suffix: str) bool {
-    val s_len:   usize = str_len(s);
-    val suffix_len: usize = str_len(suffix);
-
-    if (suffix_len > s_len) { ret false; }
-
-    var i: usize = 0;
-    for (i < suffix_len) {
-        if (s[s_len - suffix_len + i] != suffix[i]) {
-            ret false;
-        }
+# s:     the first string
+# other: the second string
+# ret:   <0 if s < other, 0 if equal, >0 if s > other
+pub fun str_compare(s: str, other: str) i64 {
+    var i:   usize = 0;
+    val lim: usize = if_min(s.len::usize, other.len::usize);
+    for (i < lim) {
+        val a: u8 = s.data[i];
+        val b: u8 = other.data[i];
+        if (a < b) { ret -1; }
+        if (a > b) { ret 1; }
         i = i + 1;
     }
+    if (s.len < other.len) { ret -1; }
+    if (s.len > other.len) { ret 1; }
+    ret 0;
+}
 
+# str_starts_with: true if s begins with prefix.
+# ---
+# s:      the string to test
+# prefix: the prefix to check for
+# ret:    true if s starts with prefix
+pub fun str_starts_with(s: str, prefix: str) bool {
+    if (prefix.len > s.len) { ret false; }
+    var i: usize = 0;
+    for (i < prefix.len::usize) {
+        if (s.data[i] != prefix.data[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# str_ends_with: true if s ends with suffix.
+# ---
+# s:      the string to test
+# suffix: the suffix to check for
+# ret:    true if s ends with suffix
+pub fun str_ends_with(s: str, suffix: str) bool {
+    if (suffix.len > s.len) { ret false; }
+    val offset: usize = (s.len - suffix.len)::usize;
+    var i:      usize = 0;
+    for (i < suffix.len::usize) {
+        if (s.data[offset + i] != suffix.data[i]) { ret false; }
+        i = i + 1;
+    }
     ret true;
 }
 
 # str_index_of: find the first index of a substring.
 # ---
+# s:   the string to search
 # sub: the substring to find
 # ret: the index of the first occurrence, or an error message
 pub fun str_index_of(s: str, sub: str) Result[usize, str] {
-    val s_len: usize = str_len(s);
-    val sub_len:  usize = str_len(sub);
-
-    if (sub_len == 0 || sub_len > s_len) {
+    if (sub.len == 0 || sub.len > s.len) {
         ret err[usize, str]("invalid substring length");
     }
-
-    var i: usize = 0;
+    val s_len:   usize = s.len::usize;
+    val sub_len: usize = sub.len::usize;
+    var i:       usize = 0;
     for (i <= s_len - sub_len) {
         var j:     usize = 0;
         var found: bool  = true;
-
         for (j < sub_len) {
-            if (s[i + j] != sub[j]) {
+            if (s.data[i + j] != sub.data[j]) {
                 found = false;
                 brk;
             }
             j = j + 1;
         }
-
         if (found) {
             ret ok[usize, str](i);
         }
-
         i = i + 1;
     }
-
     ret err[usize, str]("substring not found");
 }
 
 # str_last_index_of: find the last index of a substring.
 # ---
+# s:   the string to search
 # sub: the substring to find
 # ret: the index of the last occurrence, or an error message
 pub fun str_last_index_of(s: str, sub: str) Result[usize, str] {
-    val s_len: usize = str_len(s);
-    val sub_len:  usize = str_len(sub);
-
-    if (sub_len == 0 || sub_len > s_len) {
+    if (sub.len == 0 || sub.len > s.len) {
         ret err[usize, str]("invalid substring length");
     }
-
-    var i: usize = (s_len - sub_len) + 1;
+    val s_len:   usize = s.len::usize;
+    val sub_len: usize = sub.len::usize;
+    var i:       usize = (s_len - sub_len) + 1;
     for (i > 0) {
         i = i - 1;
         var j:     usize = 0;
         var found: bool  = true;
-
         for (j < sub_len) {
-            if (s[i + j] != sub[j]) {
+            if (s.data[i + j] != sub.data[j]) {
                 found = false;
                 brk;
             }
             j = j + 1;
         }
-
         if (found) {
             ret ok[usize, str](i);
         }
     }
-
     ret err[usize, str]("substring not found");
 }
 
-# str_contains: check if the string contains the given substring.
+# str_contains: true if s contains the given substring.
 # ---
-# sub: the substring to check
-# ret: true if the string contains sub
+# s:   the string to search
+# sub: the substring to check for
+# ret: true if s contains sub
 pub fun str_contains(s: str, sub: str) bool {
     val r: Result[usize, str] = str_index_of(s, sub);
     ret is_ok[usize, str](r);
 }
 
-# str_region_equals: compare a region of a string against a pattern.
+# str_region_equals: compare a region of s against a pattern.
 # ---
+# s:     source string
 # start: byte offset into s
 # len:   number of bytes to compare
-# other: null-terminated string to compare against
+# other: pattern to compare against
 # ret:   true if s[start..start+len] equals other exactly
 pub fun str_region_equals(s: str, start: usize, len: usize, other: str) bool {
-    if (s == nil || other == nil) { ret false; }
-
-    val other_len: usize = str_len(other);
-    if (other_len != len) { ret false; }
-
-    val s_len: usize = str_len(s);
-    if (start + len > s_len) { ret false; }
-
+    if (other.len::usize != len) { ret false; }
+    if (start + len > s.len::usize) { ret false; }
     var i: usize = 0;
     for (i < len) {
-        if (s[start + i] != other[i]) { ret false; }
+        if (s.data[start + i] != other.data[i]) { ret false; }
         i = i + 1;
     }
     ret true;
 }
 
-# str_trim_left: return a pointer past leading whitespace.
+# str_slice: return a sub-string spanning [start, start+len).
 # ---
-# ret: pointer to first non-whitespace character
+# s:     source string
+# start: byte offset into s
+# len:   length of the slice
+# ret:   sub-string sharing s.data; len == 0 and data == nil if out of range
+pub fun str_slice(s: str, start: usize, len: usize) str {
+    var out: str;
+    if (start + len > s.len::usize) {
+        out.len  = 0;
+        out.data = nil;
+        ret out;
+    }
+    out.len  = len::u32;
+    out.data = (s.data::usize + start)::*u8;
+    ret out;
+}
+
+# str_trim_left: skip leading whitespace and return a sub-string.
+# ---
+# s:   the string
+# ret: sub-string sharing s.data starting at the first non-whitespace byte
 pub fun str_trim_left(s: str) str {
-    if (s == nil) { ret nil; }
     var i: usize = 0;
-    for (char_is_space(s[i])) {
+    for (i < s.len::usize && char_is_space(s.data[i])) {
         i = i + 1;
     }
-    ret (s::usize + i)::str;
+    ret str_slice(s, i, (s.len::usize - i));
 }
 
 # str_index_char: find the first occurrence of a character in a string.
 # ---
+# s:   the string to search
 # c:   character to find
 # ret: the index of the first occurrence, or an error message
 pub fun str_index_char(s: str, c: char) Result[usize, str] {
-    if (s == nil) { ret err[usize, str]("nil string"); }
     var i: usize = 0;
-    for (s[i] != 0) {
-        if (s[i] == c) { ret ok[usize, str](i); }
+    for (i < s.len::usize) {
+        if (s.data[i] == c) { ret ok[usize, str](i); }
         i = i + 1;
     }
     ret err[usize, str]("character not found");
@@ -243,22 +241,22 @@ pub fun str_index_char(s: str, c: char) Result[usize, str] {
 
 # str_last_index_char: find the last occurrence of a character in a string.
 # ---
+# s:   the string to search
 # c:   character to find
 # ret: the index of the last occurrence, or an error message
 pub fun str_last_index_char(s: str, c: char) Result[usize, str] {
-    if (s == nil) { ret err[usize, str]("nil string"); }
-    val len: usize = str_len(s);
-    if (len == 0) { ret err[usize, str]("character not found"); }
-    var i: usize = len;
+    if (s.len == 0) { ret err[usize, str]("character not found"); }
+    var i: usize = s.len::usize;
     for (i > 0) {
         i = i - 1;
-        if (s[i] == c) { ret ok[usize, str](i); }
+        if (s.data[i] == c) { ret ok[usize, str](i); }
     }
     ret err[usize, str]("character not found");
 }
 
-# str_contains_char: check if a string contains a character.
+# str_contains_char: true if a string contains a character.
 # ---
+# s:   the string to search
 # c:   character to find
 # ret: true if c appears in s
 pub fun str_contains_char(s: str, c: char) bool {
@@ -266,262 +264,143 @@ pub fun str_contains_char(s: str, c: char) bool {
     ret is_ok[usize, str](r);
 }
 
-test "string: len of empty string" {
+# str_from_zstr: build a str whose bytes match the given null-terminated pointer.
+# the resulting str shares the input's storage; do not free it independently.
+# ---
+# z:   null-terminated byte pointer
+# ret: a str view over the same bytes (excluding the terminator)
+pub fun str_from_zstr(z: zstr) str {
+    var out: str;
+    if (z == nil) {
+        out.len  = 0;
+        out.data = nil;
+        ret out;
+    }
+    var n: usize = 0;
+    for (z[n] != 0) {
+        n = n + 1;
+    }
+    out.len  = n::u32;
+    out.data = z;
+    ret out;
+}
+
+# zstr_len: walk a null-terminated byte pointer to compute its length.
+# ---
+# z:   null-terminated byte pointer
+# ret: number of bytes before the null terminator (0 for nil)
+pub fun zstr_len(z: zstr) usize {
+    if (z == nil) { ret 0; }
+    var n: usize = 0;
+    for (z[n] != 0) {
+        n = n + 1;
+    }
+    ret n;
+}
+
+fun if_min(a: usize, b: usize) usize {
+    if (a < b) { ret a; }
+    ret b;
+}
+
+test "string: empty literal len" {
     val s: str = "";
     if (str_len(s) != 0) { ret 0; }
+    if (!str_empty(s))   { ret 0; }
     ret 1;
 }
 
-test "string: len of non-empty string" {
+test "string: literal len" {
     val s: str = "hello";
     if (str_len(s) != 5) { ret 0; }
+    if (str_empty(s))    { ret 0; }
     ret 1;
 }
 
-test "string: len of single char" {
-    val s: str = "x";
-    if (str_len(s) != 1) { ret 0; }
+test "string: equals same content" {
+    if (!str_equals("hello", "hello")) { ret 0; }
     ret 1;
 }
 
-test "string: empty returns true for empty string" {
-    val s: str = "";
-    if (!str_empty(s)) { ret 0; }
-    ret 1;
-}
-
-test "string: empty returns false for non-empty string" {
-    val s: str = "hello";
-    if (str_empty(s)) { ret 0; }
-    ret 1;
-}
-
-test "string: equals same strings" {
-    val a: str = "hello";
-    val b: str = "hello";
-    if (!str_equals(a, b)) { ret 0; }
-    ret 1;
-}
-
-test "string: equals different strings" {
-    val a: str = "hello";
-    val b: str = "world";
-    if (str_equals(a, b)) { ret 0; }
+test "string: equals different content" {
+    if (str_equals("hello", "world")) { ret 0; }
     ret 1;
 }
 
 test "string: equals different lengths" {
-    val a: str = "hello";
-    val b: str = "hello world";
-    if (str_equals(a, b)) { ret 0; }
+    if (str_equals("hello", "hello world")) { ret 0; }
     ret 1;
 }
 
-test "string: equals empty strings" {
-    val a: str = "";
-    val b: str = "";
-    if (!str_equals(a, b)) { ret 0; }
+test "string: compare lex order" {
+    if (str_compare("abc", "abd") >= 0) { ret 0; }
+    if (str_compare("abd", "abc") <= 0) { ret 0; }
+    if (str_compare("abc", "abc") != 0) { ret 0; }
     ret 1;
 }
 
-test "string: compare equal strings" {
-    val a: str = "abc";
-    val b: str = "abc";
-    if (str_compare(a, b) != 0) { ret 0; }
+test "string: starts_with" {
+    if (!str_starts_with("hello world", "hello")) { ret 0; }
+    if (str_starts_with("hello world", "world"))  { ret 0; }
+    if (!str_starts_with("hi", ""))                { ret 0; }
     ret 1;
 }
 
-test "string: compare less than" {
-    val a: str = "abc";
-    val b: str = "abd";
-    if (str_compare(a, b) >= 0) { ret 0; }
+test "string: ends_with" {
+    if (!str_ends_with("hello world", "world")) { ret 0; }
+    if (str_ends_with("hello world", "hello"))  { ret 0; }
+    if (!str_ends_with("hi", ""))                { ret 0; }
     ret 1;
 }
 
-test "string: compare greater than" {
-    val a: str = "abd";
-    val b: str = "abc";
-    if (str_compare(a, b) <= 0) { ret 0; }
+test "string: index_of" {
+    val r: Result[usize, str] = str_index_of("hello world", "wor");
+    if (is_err[usize, str](r))            { ret 0; }
+    if (unwrap_ok[usize, str](r) != 6)    { ret 0; }
     ret 1;
 }
 
-test "string: compare prefix is less" {
-    val a: str = "abc";
-    val b: str = "abcd";
-    if (str_compare(a, b) >= 0) { ret 0; }
+test "string: contains" {
+    if (!str_contains("hello world", "wor")) { ret 0; }
+    if (str_contains("hello world", "xyz"))  { ret 0; }
     ret 1;
 }
 
-test "string: starts_with matching prefix" {
-    val s: str = "hello world";
-    if (!str_starts_with(s, "hello")) { ret 0; }
-    ret 1;
-}
-
-test "string: starts_with non-matching prefix" {
-    val s: str = "hello world";
-    if (str_starts_with(s, "world")) { ret 0; }
-    ret 1;
-}
-
-test "string: starts_with empty prefix" {
-    val s: str = "hello";
-    if (!str_starts_with(s, "")) { ret 0; }
-    ret 1;
-}
-
-test "string: starts_with full string" {
-    val s: str = "hello";
-    if (!str_starts_with(s, "hello")) { ret 0; }
-    ret 1;
-}
-
-test "string: ends_with matching suffix" {
-    val s: str = "hello world";
-    if (!str_ends_with(s, "world")) { ret 0; }
-    ret 1;
-}
-
-test "string: ends_with non-matching suffix" {
-    val s: str = "hello world";
-    if (str_ends_with(s, "hello")) { ret 0; }
-    ret 1;
-}
-
-test "string: ends_with empty suffix" {
-    val s: str = "hello";
-    if (!str_ends_with(s, "")) { ret 0; }
-    ret 1;
-}
-
-test "string: ends_with full string" {
-    val s: str = "hello";
-    if (!str_ends_with(s, "hello")) { ret 0; }
-    ret 1;
-}
-
-test "string: index_of finds substring at start" {
-    val s: str = "hello world";
-    val r: Result[usize, str] = str_index_of(s, "hello");
-    if (is_err[usize, str](r)) { ret 0; }
-    if (unwrap_ok[usize, str](r) != 0) { ret 0; }
-    ret 1;
-}
-
-test "string: index_of finds substring in middle" {
-    val s: str = "hello world";
-    val r: Result[usize, str] = str_index_of(s, "wor");
-    if (is_err[usize, str](r)) { ret 0; }
-    if (unwrap_ok[usize, str](r) != 6) { ret 0; }
-    ret 1;
-}
-
-test "string: index_of not found" {
-    val s: str = "hello world";
-    val r: Result[usize, str] = str_index_of(s, "xyz");
-    if (is_ok[usize, str](r)) { ret 0; }
-    ret 1;
-}
-
-test "string: last_index_of finds last occurrence" {
-    val s: str = "abcabc";
-    val r: Result[usize, str] = str_last_index_of(s, "abc");
-    if (is_err[usize, str](r)) { ret 0; }
-    if (unwrap_ok[usize, str](r) != 3) { ret 0; }
-    ret 1;
-}
-
-test "string: last_index_of single occurrence" {
-    val s: str = "hello world";
-    val r: Result[usize, str] = str_last_index_of(s, "world");
-    if (is_err[usize, str](r)) { ret 0; }
-    if (unwrap_ok[usize, str](r) != 6) { ret 0; }
-    ret 1;
-}
-
-test "string: contains found" {
-    val s: str = "hello world";
-    if (!str_contains(s, "wor")) { ret 0; }
-    ret 1;
-}
-
-test "string: contains not found" {
-    val s: str = "hello world";
-    if (str_contains(s, "xyz")) { ret 0; }
-    ret 1;
-}
-
-test "string: contains empty substring" {
-    val s: str = "hello";
-    if (str_contains(s, "")) { ret 0; }
-    ret 1;
-}
-
-test "string: region_equals matching start" {
-    if (!str_region_equals("hello world", 0, 5, "hello")) { ret 0; }
-    ret 1;
-}
-
-test "string: region_equals matching middle" {
+test "string: region_equals" {
     if (!str_region_equals("hello world", 6, 5, "world")) { ret 0; }
+    if (str_region_equals("hello world", 0, 5, "world"))  { ret 0; }
     ret 1;
 }
 
-test "string: region_equals single char" {
-    if (!str_region_equals("abcdef", 3, 1, "d")) { ret 0; }
-    ret 1;
-}
-
-test "string: region_equals full string" {
-    if (!str_region_equals("hello", 0, 5, "hello")) { ret 0; }
-    ret 1;
-}
-
-test "string: region_equals wrong length" {
-    if (str_region_equals("hello world", 0, 5, "hell")) { ret 0; }
-    ret 1;
-}
-
-test "string: region_equals mismatch" {
-    if (str_region_equals("hello world", 0, 5, "world")) { ret 0; }
-    ret 1;
-}
-
-test "string: trim_left" {
-    if (!str_equals(str_trim_left("  hello"), "hello")) { ret 0; }
-    if (!str_equals(str_trim_left("hello"), "hello")) { ret 0; }
+test "string: slice" {
+    val s:   str = "hello world";
+    val sub: str = str_slice(s, 6, 5);
+    if (!str_equals(sub, "world")) { ret 0; }
     ret 1;
 }
 
 test "string: index_char" {
-    var r: Result[usize, str] = str_index_char("hello", 'l');
-    if (is_err[usize, str](r)) { ret 0; }
+    val r: Result[usize, str] = str_index_char("hello", 'l');
+    if (is_err[usize, str](r))         { ret 0; }
     if (unwrap_ok[usize, str](r) != 2) { ret 0; }
-    r = str_index_char("hello", 'h');
-    if (is_err[usize, str](r)) { ret 0; }
-    if (unwrap_ok[usize, str](r) != 0) { ret 0; }
-    r = str_index_char("hello", 'o');
-    if (is_err[usize, str](r)) { ret 0; }
-    if (unwrap_ok[usize, str](r) != 4) { ret 0; }
-    r = str_index_char("hello", 'x');
-    if (is_ok[usize, str](r)) { ret 0; }
-    ret 1;
-}
-
-test "string: last_index_char" {
-    var r: Result[usize, str] = str_last_index_char("hello", 'l');
-    if (is_err[usize, str](r)) { ret 0; }
-    if (unwrap_ok[usize, str](r) != 3) { ret 0; }
-    r = str_last_index_char("hello", 'h');
-    if (is_err[usize, str](r)) { ret 0; }
-    if (unwrap_ok[usize, str](r) != 0) { ret 0; }
-    r = str_last_index_char("hello", 'x');
-    if (is_ok[usize, str](r)) { ret 0; }
     ret 1;
 }
 
 test "string: contains_char" {
     if (!str_contains_char("hello", 'e')) { ret 0; }
-    if (str_contains_char("hello", 'x')) { ret 0; }
+    if (str_contains_char("hello", 'x'))  { ret 0; }
+    ret 1;
+}
+
+test "string: zstr_len" {
+    if (zstr_len(`abc`) != 3)    { ret 0; }
+    if (zstr_len(`hello`) != 5)  { ret 0; }
+    ret 1;
+}
+
+test "string: from_zstr round trip" {
+    val s: str = str_from_zstr(`hello`);
+    if (s.len != 5)                { ret 0; }
+    if (!str_equals(s, "hello"))   { ret 0; }
     ret 1;
 }

--- a/src/types/string.mach
+++ b/src/types/string.mach
@@ -10,6 +10,11 @@ use std.types.char;
 # str: a pointer to a null-terminated sequence of char.
 pub def str: *char;
 
+# zstr: a pointer to a zero-terminated sequence of char, suitable for C-style
+# interop. distinct alias for str today; will diverge once `str` becomes a
+# fat-pointer type. backtick literals (`...`) produce values of this type.
+pub def zstr: *char;
+
 # str_len: calculate the length of a null-terminated string.
 # ---
 # ret: length of the string (not including null terminator)


### PR DESCRIPTION
## Summary

Migrates mach-std to the new string model:

- `str` is no longer a `*char` alias — it's a fat-pointer record (`rec { len: u32; data: *u8 }`) provided by the compiler as a builtin (see octalide/mach-boot#59).
- `zstr` (new) is `*u8` — the type of backtick literals (`` `...` ``), used at C-FFI boundaries.

This PR depends on octalide/mach-boot#59 landing first.

## Why

Splits two concerns that the previous `str = *char` definition conflated:
- Length-aware mach-internal strings (`str_len` is now `s.len` — no walking-to-null).
- Null-terminated byte pointers for FFI (`zstr`, explicit at the call site).

Sliced sub-strings work without sentinel concerns. C-interop sites are visible from `\`...\`` literals at the call site.

## Commits

1. **`feat: add zstr type alias`** — placeholder during early scaffolding (preserved for history; superseded by later commits)
2. **`refactor: migrate to fat-str semantics`** — the bulk migration. 19 files, +618 / -654.
3. **`refactor(path): formalize null-termination invariant for Path`** — Path now guarantees `p.data[p.len] == 0` for every valid value. `filename` and `extension` are now allocating, error-returning APIs (breaking change to public surface; verified no downstream callers in mach-std).
4. **`refactor(data): bounds-safe TOML and JSON parsing`** — replaces null-byte EOF detection with `len`-bounded parsing. Introduces `peek_at(src, i) u8` in `toml.mach` (returns 0 for out-of-range), 78 call-sites converted. JSON gets one missing bounds guard in `parse_bool`.

## High-level changes by category

**`src/types/string.mach`** — new fat-str API: `str_len(s)` returns `s.len` (no scan); `str_equals` / `str_compare` / `str_starts_with` / `str_ends_with` / `str_index_of` / `str_last_index_of` / `str_contains` / `str_region_equals` rewritten to use `s.len` + `s.data`. New: `str_slice`, `str_trim_left`, `str_from_zstr`, `zstr_len`. `zstr` declared as `pub def zstr: *u8;`.

**`src/types/path.mach`** — `Path` is `pub def Path: str;`. Invariant `p.data[p.len] == 0` documented and enforced by every constructor. All allocating helpers route through a private `clone_range` for a single source of truth on the buffer contract. `filename` and `extension` allocate and return `Result[Path, str]` instead of borrowed sub-views. `empty_path()` backed by a static `\`\`` so its `data[0]` is the null byte (not `nil`). `is_empty` simplified to `p.len == 0`.

**`src/data/toml.mach`** — bounds-safe parsing. `peek_at(src, i)` is the single read primitive; reads past `src.len` return 0. The previous `src.data[i] != 0` checks become `peek_at(src, i) != 0` and behave identically for null-terminated input but are now correct for arbitrary input. Two-pass string parsers (`parse_basic_string`, `parse_ml_basic_string`) bound the second pass via the closing quote position the first pass found.

**`src/data/json.mach`** — already mostly bounds-safe; one missing guard added at `parse_bool` entry. Note: `json.mach` is documented as zero-copy, so its `str` outputs are views into the input buffer (bounded by `len`, not null-terminated unless input is). Inherent to the design.

**`src/types/result.mach`, `src/types/option.mach`** — `panic` calls switched from `"..."` (was `*u8`, now `str`) to `` `...` `` (zstr) since `panic` takes a `*u8`.

**`src/types/semver.mach`** — internal helpers that took `str` parameters and were called on offset views built via pointer arithmetic refactored into `_raw` variants taking `*u8` + length. Public API surface unchanged.

**`src/system/os/{linux,darwin,windows}/shared.mach`** — `DNS_HOSTS_PATH` switched from `str` to `zstr` (consumed by `os.open` which takes `*u8`). `getenv` prefix matching uses a small file-local helper for `*u8`-as-bytes comparison.

**`src/filesystem.mach`** — Path-is-empty error messages corrected from `"path is nil"` to `"path is empty"` (the actual check is `is_empty`, not nil).

**`src/process/{env,exec}.mach`, `src/log.mach`, `src/format.mach`, `src/net/{dns,ip}.mach`, `src/text/parse.mach`, `src/collections/map.mach`** — assorted indexing / nil-comparison / FFI-callsite updates.

## Audit findings (no code changes needed)

- **`* 8` patterns audited.** Every hit verified: bytes-to-bits in `crypto/hash`, argv stride in `runtime/{linux,darwin}` (genuinely 64-bit pointer width), str-sized arrays already covered by `STR_SIZE = $size_of(str)` in toml/json. Collections all go through `allocate[T]` which uses `$size_of(T)`. No lurking str-sized hardcodes.
- **`*nil*` test labels.** `memory.mach` tests with "nil" in their name (`raw_fill with nil pointer`, etc.) genuinely test nil-pointer noop behavior on `ptr` / `*T` arguments — those CAN be nil. Left alone.

## Test plan

- [x] `cmach build .` from mach-std root: exit 0 against the new cmach (PR octalide/mach-boot#59)
- [x] Old cmach (without backtick literals on PATH) is expected to fail — that's the hard dependency
- [ ] Test runner has unrelated pre-existing instability; not addressed here

## Diff

22 files changed across the four commits, +~700 / -~700 net (substantially the same line count despite the reshuffle and added bounds checks).