### PR TITLE
docs(readme): fix install examples to branch/dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ To use the standard library in your Mach project, you can include it as a depend
 [dep.std]
 type="remote"
 path="https://github.com/octalide/mach-std"
-version="branch/main"
+version="branch/dev"
 ```
 
 You can also use the Mach dependency manager to add it to your project:
 
 ```bash
-mach dep add https://github.com/octalide/mach-std --version branch/main
+mach dep add https://github.com/octalide/mach-std --version branch/dev
 ```
 
 ## Documentation


### PR DESCRIPTION
Fixes the stale branch reference in the README. Both install snippets pointed at `branch/main`, but all consumers pin `branch/dev` — updated both to `branch/dev`.

Scope note: the issue also mentions bumping the mach consumer's submodule pin. That is a separate action in octalide/mach (not this repo) and is intentionally out of scope here.

Closes #184