### PR TITLE
fix(semver): replace invalid str pointer arithmetic with offset casts

### DIFF
--- a/src/types/semver.mach
+++ b/src/types/semver.mach
@@ -99,7 +99,7 @@ pub fun semver_parse(input: str, a: *allo.Allocator) Result[Semver, str] {
             ret err[Semver, str]("out of memory");
         }
         val buf: *u8 = unwrap_ok[ptr, str](alloc_result)::*u8;
-        mem.raw_copy(buf::ptr, (input + start)::ptr, pre_len);
+        mem.raw_copy(buf::ptr, (input::usize + start)::ptr, pre_len);
         buf[pre_len] = 0;
         v.prerelease = buf::str;
     }
@@ -122,7 +122,7 @@ pub fun semver_parse(input: str, a: *allo.Allocator) Result[Semver, str] {
             ret err[Semver, str]("out of memory");
         }
         val buf: *u8 = unwrap_ok[ptr, str](alloc_result)::*u8;
-        mem.raw_copy(buf::ptr, (input + start)::ptr, bld_len);
+        mem.raw_copy(buf::ptr, (input::usize + start)::ptr, bld_len);
         buf[bld_len] = 0;
         v.build = buf::str;
     }
@@ -280,7 +280,7 @@ fun compare_prerelease(a: str, b: str) i64 {
         }
         val b_ident_len: usize = b_pos - b_start;
 
-        val cmp: i64 = compare_identifier(a + a_start, a_ident_len, b + b_start, b_ident_len);
+        val cmp: i64 = compare_identifier((a::usize + a_start)::str, a_ident_len, (b::usize + b_start)::str, b_ident_len);
         if (cmp != 0) { ret cmp; }
 
         if (a_pos < a_len) { a_pos = a_pos + 1; }


### PR DESCRIPTION
Closes #187

`src/types/semver.mach` performed `input + start` pointer arithmetic on a `str` (a `*char`) at the prerelease copy, build-metadata copy, and prerelease-identifier comparison. mach has no pointer-arithmetic operator (per `doc/language/operators.md`), so the compiler correctly rejected these with `type mismatch: incompatible operand types`.

This replaces the three sites with the std idiom for advancing a pointer by a byte offset — cast to `usize`, add, cast back — matching `str_trim_left` in `src/types/string.mach`:

- L102 `(input + start)::ptr` -> `(input::usize + start)::ptr`
- L125 `(input + start)::ptr` -> `(input::usize + start)::ptr`
- L283 `compare_identifier(a + a_start, ..., b + b_start, ...)` -> `compare_identifier((a::usize + a_start)::str, ..., (b::usize + b_start)::str, ...)`

## Verification

Built with a compiler containing the #1186 `fwd` re-export fix. `std.types.semver` now passes sema, lower, and codegen cleanly (previously rejected at all three sites). The full `mach build .` / `mach test .` still stops later at `codegen std.sync.atomic` with `encode: malformed inline-asm two-operand instruction` — an unrelated pre-existing backend bug, out of scope here.