### PR TITLE
fix(atomic): stage {ptr} in a scratch register before dereferencing

### DIFF
--- a/src/sync/atomic.mach
+++ b/src/sync/atomic.mach
@@ -23,15 +23,19 @@ pub fun load(ptr: *i64) i64 {
     var result: i64 = 0;
     $if ($mach.target.arch == $mach.arch.x86_64) {
         # aligned MOV is ordered under x86-TSO; gives seq-cst load semantics
+        # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
-            mov rax, [{ptr}]
+            mov rcx, {ptr}
+            mov rax, [rcx]
             mov {result}, rax
         }
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         # load-acquire pairs with STLR stores for seq-cst ordering
+        # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
-            ldar {result}, [{ptr}]
+            mov x12, {ptr}
+            ldar {result}, [x12]
         }
     }
     ret result;
@@ -44,15 +48,19 @@ pub fun load(ptr: *i64) i64 {
 pub fun store(ptr: *i64, v: i64) {
     $if ($mach.target.arch == $mach.arch.x86_64) {
         # XCHG to memory carries an implicit LOCK, giving a seq-cst store
+        # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
             mov rax, {v}
-            xchg [{ptr}], rax
+            mov rcx, {ptr}
+            xchg [rcx], rax
         }
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         # store-release pairs with LDAR loads for seq-cst ordering
+        # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
-            stlr {v}, [{ptr}]
+            mov x12, {ptr}
+            stlr {v}, [x12]
         }
     }
 }
@@ -70,22 +78,26 @@ pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
     val exp: i64 = @expected;
     $if ($mach.target.arch == $mach.arch.x86_64) {
         # LOCK CMPXCHG: RAX holds the comparand and receives the prior value
+        # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
             mov rax, {exp}
             mov rdx, {desired}
-            lock cmpxchg [{ptr}], rdx
+            mov rcx, {ptr}
+            lock cmpxchg [rcx], rdx
             mov {old}, rax
         }
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         # LDAXR/STLXR retry loop; trailing DMB ISH gives full seq-cst order
+        # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
             mov x9, {exp}
+            mov x12, {ptr}
         cas_retry:
-            ldaxr x10, [{ptr}]
+            ldaxr x10, [x12]
             cmp x10, x9
             b.ne cas_done
-            stlxr w11, {desired}, [{ptr}]
+            stlxr w11, {desired}, [x12]
             cbnz w11, cas_retry
         cas_done:
             mov {old}, x10
@@ -106,19 +118,23 @@ pub fun fetch_add(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
     $if ($mach.target.arch == $mach.arch.x86_64) {
         # LOCK XADD returns the prior value in the source register
+        # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
             mov rax, {v}
-            lock xadd [{ptr}], rax
+            mov rcx, {ptr}
+            lock xadd [rcx], rax
             mov {old}, rax
         }
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         # LDAXR/STLXR add loop; trailing DMB ISH gives full seq-cst order
+        # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
+            mov x12, {ptr}
         fadd_retry:
-            ldaxr x9, [{ptr}]
+            ldaxr x9, [x12]
             add x10, x9, {v}
-            stlxr w11, x10, [{ptr}]
+            stlxr w11, x10, [x12]
             cbnz w11, fadd_retry
             mov {old}, x9
             dmb ish
@@ -136,20 +152,24 @@ pub fun fetch_sub(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
     $if ($mach.target.arch == $mach.arch.x86_64) {
         # negate then LOCK XADD; returns the prior value
+        # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
             mov rax, {v}
             neg rax
-            lock xadd [{ptr}], rax
+            mov rcx, {ptr}
+            lock xadd [rcx], rax
             mov {old}, rax
         }
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         # LDAXR/STLXR sub loop; trailing DMB ISH gives full seq-cst order
+        # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
+            mov x12, {ptr}
         fsub_retry:
-            ldaxr x9, [{ptr}]
+            ldaxr x9, [x12]
             sub x10, x9, {v}
-            stlxr w11, x10, [{ptr}]
+            stlxr w11, x10, [x12]
             cbnz w11, fsub_retry
             mov {old}, x9
             dmb ish
@@ -167,18 +187,22 @@ pub fun exchange(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
     $if ($mach.target.arch == $mach.arch.x86_64) {
         # XCHG with memory carries an implicit LOCK (full barrier)
+        # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
             mov rax, {v}
-            xchg [{ptr}], rax
+            mov rcx, {ptr}
+            xchg [rcx], rax
             mov {old}, rax
         }
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         # LDAXR/STLXR swap loop; trailing DMB ISH gives full seq-cst order
+        # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
+            mov x12, {ptr}
         xchg_retry:
-            ldaxr x9, [{ptr}]
-            stlxr w11, {v}, [{ptr}]
+            ldaxr x9, [x12]
+            stlxr w11, {v}, [x12]
             cbnz w11, xchg_retry
             mov {old}, x9
             dmb ish


### PR DESCRIPTION
Closes #190

## Problem
`src/sync/atomic.mach` dereferenced a bound local as a memory base — `mov rax, [{ptr}]`, `xchg [{ptr}], rax`, `lock xadd [{ptr}], rax`, `lock cmpxchg [{ptr}], rdx`, etc. (16 sites across `load`/`store`/`cas`/`fetch_add`/`fetch_sub`/`exchange`, x86_64 and aarch64).

Mach's inline-asm model binds every `{name}` to the local's **stack slot**, substituting it textually as `[rbp+disp]`. So `[{ptr}]` expanded to `[[rbp+disp]]` — a nested memory operand, not a valid x86 addressing form. The encoder rejected it with `encode: malformed inline-asm two-operand instruction`, and `mach build .` stopped at `codegen std.sync.atomic`.

## Fix
Load the pointer **value** into a caller-saved scratch register first, then dereference that register. Inline-asm blocks are a caller-saved clobber barrier, so the scratch is safe.

- **x86_64:** `rcx` as the pointer scratch (every op uses only `rax`, except `cas` which also uses `rdx`; `rcx` is free in all).
- **aarch64:** `x12` as the pointer scratch (the blocks use `x9`/`x10`/`x11`/`w11`; `x12` is free). The aarch64 loops stage `{ptr}` once before the retry label so both `ldaxr`/`stlxr` reuse `[x12]`.

Atomic semantics (seq-cst load/store/cas/add/sub/exchange) are unchanged — only **how** the address is formed (via a register) changes, not the operations or their ordering. Existing explanatory comments are preserved, with a one-line note added to each block explaining the staging.

> **aarch64 note:** there is no aarch64 backend yet, so these blocks cannot be compiled/verified on this host. They are fixed for forward-correctness only. The x86_64 path is comptime-selected here and is what the build exercises.

## Build / test
Built with the dev compiler carrying the `fwd` re-export fix (mach#1186). After the fix, `mach build .` is fully green — every module including `std.sync.atomic` codegens cleanly. Test results in a follow-up comment.