### PR TITLE
fix(linux): make THREAD_CLONE_FLAGS a foldable global constant

### DIFF
--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -7,6 +7,17 @@ use std.types.size.usize;
 
 use shared: std.system.os.linux.shared;
 
+# imported unaliased so the clone-flag constants bind under their bare names
+# into this module's comptime context; `THREAD_CLONE_FLAGS` then folds at
+# compile time (a module-qualified `shared.CLONE_*` member path is not
+# comptime-evaluable, so the global would otherwise have no constant value).
+use std.system.os.linux.shared.CLONE_VM;
+use std.system.os.linux.shared.CLONE_FS;
+use std.system.os.linux.shared.CLONE_FILES;
+use std.system.os.linux.shared.CLONE_SIGHAND;
+use std.system.os.linux.shared.CLONE_THREAD;
+use std.system.os.linux.shared.CLONE_SYSVSEM;
+
 $if ($mach.target.os != $mach.os.linux) {
     $error("std.system.os.linux.x86_64: requires linux target");
 }
@@ -22,7 +33,7 @@ pub fun page_size() usize {
     ret 4096;
 }
 
-val THREAD_CLONE_FLAGS: usize = shared.CLONE_VM | shared.CLONE_FS | shared.CLONE_FILES | shared.CLONE_SIGHAND | shared.CLONE_THREAD | shared.CLONE_SYSVSEM;
+val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM;
 
 fun thread_trampoline() {
     var fn_addr: usize = 0;


### PR DESCRIPTION
## Problem

`THREAD_CLONE_FLAGS` was defined as a `|` chain over module-qualified `shared.CLONE_*` member paths:

```mach
val THREAD_CLONE_FLAGS: usize = shared.CLONE_VM | shared.CLONE_FS | ...;
```

A module-qualified member path (`alias.CONST`) is **not comptime-evaluable**, so this global initialiser had no constant value and silently lowered to **0**. `thread_spawn` then called `clone(2)` with **no flags** — the child shared no address space, file table, or signal handlers, breaking threading on Linux.

The released compiler masked this with a silent zero-placeholder fallback for non-foldable global initialisers. octalide/mach#1206 removes that fallback (a global initialiser must now be a constant expression or it is a hard error), which surfaced this latent bug.

## Fix

Import the six clone-flag constants **unaliased** so they bind under their bare names into this module's comptime context, where the `|` chain folds. `THREAD_CLONE_FLAGS` now folds to `0x50F00` (331520), verified against a fixed compiler.

The aliased `shared` import and its `fwd` re-exports are untouched.

## Coordination

Pairs with octalide/mach#1206 (the compiler fix). That PR's submodule bump to mach-std should land after this merges.