### PR TITLE
refactor(fs): drop gratuitous mode::i32 casts

### DIFF
--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -288,17 +288,17 @@ pub fun write_file(p: str, data: *u8, len: usize, mode: i32) Result[bool, str] {
 
 # info_is_dir: check whether FileInfo describes a directory.
 pub fun info_is_dir(fi: *FileInfo) bool {
-    ret (fi.mode::i32 & os.S_IFMT) == os.S_IFDIR;
+    ret (fi.mode & os.S_IFMT) == os.S_IFDIR;
 }
 
 # info_is_file: check whether FileInfo describes a regular file.
 pub fun info_is_file(fi: *FileInfo) bool {
-    ret (fi.mode::i32 & os.S_IFMT) == os.S_IFREG;
+    ret (fi.mode & os.S_IFMT) == os.S_IFREG;
 }
 
 # info_is_symlink: check whether FileInfo describes a symbolic link.
 pub fun info_is_symlink(fi: *FileInfo) bool {
-    ret (fi.mode::i32 & os.S_IFMT) == os.S_IFLNK;
+    ret (fi.mode & os.S_IFMT) == os.S_IFLNK;
 }
 
 # info_path: get metadata for a path.


### PR DESCRIPTION
Removes the three pointless `::i32` casts in `info_is_dir`/`info_is_file`/`info_is_symlink` — `fi.mode` and the `S_IF*` constants are all `u32`, so the casts only manufactured mixed-signedness comparisons. Requested by the maintainer alongside the mixed-numeric-comparison ruling (octalide/mach#1248).

Verified: the mach compiler (dev tip) builds against this tree and its full test suite passes.