### PR TITLE
chore(release): 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-06-10
+
+First tagged release carrying the 0.3.0 and 0.4.0 work (neither was tagged);
+`main` advances from 0.2.5 straight to 0.4.1.
+
+### Fixed
+- Corrected the expected length in the `ip: ipv4_format` test — a single-octet
+  address such as `127.0.0.1` formats to 9 bytes, not 7. The function was
+  correct; only the test assertion was wrong.
+
+### Known Issues
+These tests fail or hang under `mach test` and are tracked for follow-up. All
+three are gaps in modules added during the 0.4.x rework (after 0.2.5), not
+regressions:
+- `thread: spawn and join` / `thread: is_done after join` deadlock — the clone
+  parent/child discrimination is a shared-memory race ([#195](https://github.com/octalide/mach-std/issues/195)).
+- `json: value_find on object` never matches — object keys are stored as
+  non-null-terminated source slices but compared with `str_equals` ([#196](https://github.com/octalide/mach-std/issues/196)).
+- `env: get PATH returns positive length` — the std code is correct; `mach test`
+  execs the test binary with an empty environment ([#197](https://github.com/octalide/mach-std/issues/197)).
+
 ## [0.4.0] - 2026-03-10
 
 ### Added

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "std"
 name = "Mach Standard Library"
-version = "0.4.0"
+version = "0.4.1"
 dir_src = "src"
 dir_out = "out"
 dir_dep = "dep"

--- a/src/net/ip.mach
+++ b/src/net/ip.mach
@@ -244,7 +244,7 @@ test "ip: ipv4_format" {
     val ip: IPv4 = ipv4(127, 0, 0, 1);
     var buf: [16]u8;
     val n: usize = ipv4_format(ip, ?buf[0], 16);
-    if (n != 7) { ret 1; }
+    if (n != 9) { ret 1; }
     if (!str_starts_with(?buf[0], "127.0.0.1")) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Release-prep for v0.4.1 (the dev→main sync that unblocks octalide/mach#1239).

## Changes
- `fix(net)`: correct the `ip: ipv4_format` test assertion (a single-octet address formats to 9 bytes, not 7 — the function was already correct).
- `chore(release)`: bump the manifest `0.4.0 → 0.4.1` and add a CHANGELOG entry.

## Test triage
`mach test .` (run with the released compiler, v1.2.0) currently has three known-failing/hanging tests, all in modules added during the 0.4.x rework (after 0.2.5) — none are regressions:

| test | status | issue |
|------|--------|-------|
| `ip: ipv4_format` | **fixed here** | — |
| `thread: spawn and join` / `is_done after join` | hangs (clone discrimination race) | #195 |
| `json: value_find on object` | fails (keys not null-terminated) | #196 |
| `env: get PATH` | fails (harness execs with empty env; std code is correct) | #197 |

The thread deadlock hangs the suite, so CI here will not complete — it is documented and tracked in #195. Merging per maintainer authorization for the 0.4.1 cut.