### PR TITLE
fix(runtime): drop the 8-byte stack mis-align in x86_64 _start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- The x86_64 `_start` entrypoints (linux and darwin) mis-aligned the stack by 8
+  bytes at every CALL: after `and rsp, -16` an extra `sub rsp, 8` left RSP at
+  `rsp % 16 == 8` so callees were entered with `rsp % 16 == 0` instead of the
+  SysV-required 8. Harmless to pure-Mach programs but it SIGSEGV'd at the C
+  boundary whenever an external function used an aligned SSE access against a
+  16-aligned stack slot. Dropped the `sub rsp, 8`; `and rsp, -16` alone holds
+  the call-boundary invariant ([#200](https://github.com/octalide/mach-std/issues/200)).
+
 ## [0.4.1] - 2026-06-10
 
 First tagged release carrying the 0.3.0 and 0.4.0 work (neither was tagged);

--- a/src/runtime/darwin/x86_64.mach
+++ b/src/runtime/darwin/x86_64.mach
@@ -53,8 +53,7 @@ pub fun _start() {
         mov [_rt_argv], rsi
         mov [_rt_envp], rcx
 
-        and rsp, -16      # align stack to 16 bytes
-        sub rsp, 8        # adjust for CALL (pushes 8-byte return address)
+        and rsp, -16      # 16-align rsp for the SysV call boundary
         call _rt_init
 
         mov rdi, [_rt_argc]

--- a/src/runtime/linux/x86_64.mach
+++ b/src/runtime/linux/x86_64.mach
@@ -11,8 +11,9 @@
 #
 # this entrypoint:
 #   1. extracts argc, argv, and envp from the initial stack
-#   2. calls _rt_init to store envp into the OS layer
-#   3. aligns the stack to 16 bytes (required by SysV ABI before CALL)
+#   2. aligns the stack to 16 bytes (the SysV call-boundary invariant: RSP is
+#      16-aligned at the CALL site, so the callee is entered with RSP%16==8)
+#   3. calls _rt_init to store envp into the OS layer
 #   4. calls user-supplied `main(argc, argv)`
 #   5. exits via sys_exit with the return code from main
 #
@@ -50,8 +51,7 @@ pub fun _start() {
         mov [_rt_argv], rsi
         mov [_rt_envp], rcx
 
-        and rsp, -16      # align stack to 16 bytes
-        sub rsp, 8        # adjust for CALL (pushes 8-byte return address)
+        and rsp, -16      # 16-align rsp for the SysV call boundary
         call _rt_init
 
         mov rdi, [_rt_argc]


### PR DESCRIPTION
## Summary

The linux and darwin x86_64 `_start` entrypoints mis-aligned the stack by 8 bytes at every CALL. After `and rsp, -16` (the kernel already enters `_start` 16-aligned) the stack is exactly in the state the SysV call boundary wants — a CALL pushes the 8-byte return address and the callee is entered with `rsp % 16 == 8`. The extra `sub rsp, 8` over-corrected, leaving every callee (`_rt_init`, `main`, and transitively the whole program) entered with `rsp % 16 == 0`.

This is invisible to pure-Mach programs (Mach codegen never relies on RBP-relative aligned SSE operands under SysV), but it corrupts the boundary with external C: an aligned SSE access (`movaps`/`movapd`) against a 16-aligned stack slot `#GP`-faults (SIGSEGV). It is the root cause of the `cffi` SIGSEGV (exit 139) in the mach compiler's integration suite.

## Evidence
- A naked probe returning `rsp & 15` at entry: **0** before, **8** after (SysV requires 8).
- A deterministic `movaps`-to-stack C callee: **SIGSEGV (139)** before, **exit 0** after.
- The compiler's `cffi` suite (gcc-compiled by-value float structs): **PASS** after, including with `-O2` callees.

## Scope
- Linux and Darwin x86_64 entrypoints fixed. Win64 was already correct (`sub rsp, 32` shadow space is a multiple of 16).

Closes #200