### PR TITLE
chore(release): bump version to 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- The x86_64 `_start` entrypoints (linux and darwin) mis-aligned the stack by 8
-  bytes at every CALL: after `and rsp, -16` an extra `sub rsp, 8` left RSP at
-  `rsp % 16 == 8` so callees were entered with `rsp % 16 == 0` instead of the
-  SysV-required 8. Harmless to pure-Mach programs but it SIGSEGV'd at the C
-  boundary whenever an external function used an aligned SSE access against a
-  16-aligned stack slot. Dropped the `sub rsp, 8`; `and rsp, -16` alone holds
-  the call-boundary invariant ([#200](https://github.com/octalide/mach-std/issues/200)).
-
 ## [0.4.2] - 2026-06-10
 
 Patch release: SysV stack-alignment fix in the program entrypoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   16-aligned stack slot. Dropped the `sub rsp, 8`; `and rsp, -16` alone holds
   the call-boundary invariant ([#200](https://github.com/octalide/mach-std/issues/200)).
 
+## [0.4.2] - 2026-06-10
+
+Patch release: SysV stack-alignment fix in the program entrypoint.
+
+### Fixed
+
+- `_start` (linux and darwin x86_64) entered every callee with an 8-byte
+  misaligned stack, violating the SysV call invariant — invisible to pure-Mach
+  programs but a SIGSEGV for any C callee using aligned SSE accesses (#200).
+
 ## [0.4.1] - 2026-06-10
 
 First tagged release carrying the 0.3.0 and 0.4.0 work (neither was tagged);

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "std"
 name = "Mach Standard Library"
-version = "0.4.1"
+version = "0.4.2"
 dir_src = "src"
 dir_out = "out"
 dir_dep = "dep"


### PR DESCRIPTION
Version bump + changelog for the v0.4.2 patch release (the #200 `_start` stack-alignment fix).