### PR TITLE
release: v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- The x86_64 `_start` entrypoints (linux and darwin) mis-aligned the stack by 8
-  bytes at every CALL: after `and rsp, -16` an extra `sub rsp, 8` left RSP at
-  `rsp % 16 == 8` so callees were entered with `rsp % 16 == 0` instead of the
-  SysV-required 8. Harmless to pure-Mach programs but it SIGSEGV'd at the C
-  boundary whenever an external function used an aligned SSE access against a
-  16-aligned stack slot. Dropped the `sub rsp, 8`; `and rsp, -16` alone holds
-  the call-boundary invariant ([#200](https://github.com/octalide/mach-std/issues/200)).
-
 ## [0.4.2] - 2026-06-10
 
 Patch release: SysV stack-alignment fix in the program entrypoint.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   16-aligned stack slot. Dropped the `sub rsp, 8`; `and rsp, -16` alone holds
   the call-boundary invariant ([#200](https://github.com/octalide/mach-std/issues/200)).
 
+## [0.4.2] - 2026-06-10
+
+Patch release: SysV stack-alignment fix in the program entrypoint.
+
+### Fixed
+
+- `_start` (linux and darwin x86_64) entered every callee with an 8-byte
+  misaligned stack, violating the SysV call invariant — invisible to pure-Mach
+  programs but a SIGSEGV for any C callee using aligned SSE accesses (#200).
+
 ## [0.4.1] - 2026-06-10
 
 First tagged release carrying the 0.3.0 and 0.4.0 work (neither was tagged);

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- The x86_64 `_start` entrypoints (linux and darwin) mis-aligned the stack by 8
+  bytes at every CALL: after `and rsp, -16` an extra `sub rsp, 8` left RSP at
+  `rsp % 16 == 8` so callees were entered with `rsp % 16 == 0` instead of the
+  SysV-required 8. Harmless to pure-Mach programs but it SIGSEGV'd at the C
+  boundary whenever an external function used an aligned SSE access against a
+  16-aligned stack slot. Dropped the `sub rsp, 8`; `and rsp, -16` alone holds
+  the call-boundary invariant ([#200](https://github.com/octalide/mach-std/issues/200)).
+
 ## [0.4.1] - 2026-06-10
 
 First tagged release carrying the 0.3.0 and 0.4.0 work (neither was tagged);

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id = "std"
 name = "Mach Standard Library"
-version = "0.4.1"
+version = "0.4.2"
 dir_src = "src"
 dir_out = "out"
 dir_dep = "dep"

--- a/src/runtime/darwin/x86_64.mach
+++ b/src/runtime/darwin/x86_64.mach
@@ -53,8 +53,7 @@ pub fun _start() {
         mov [_rt_argv], rsi
         mov [_rt_envp], rcx
 
-        and rsp, -16      # align stack to 16 bytes
-        sub rsp, 8        # adjust for CALL (pushes 8-byte return address)
+        and rsp, -16      # 16-align rsp for the SysV call boundary
         call _rt_init
 
         mov rdi, [_rt_argc]

--- a/src/runtime/linux/x86_64.mach
+++ b/src/runtime/linux/x86_64.mach
@@ -11,8 +11,9 @@
 #
 # this entrypoint:
 #   1. extracts argc, argv, and envp from the initial stack
-#   2. calls _rt_init to store envp into the OS layer
-#   3. aligns the stack to 16 bytes (required by SysV ABI before CALL)
+#   2. aligns the stack to 16 bytes (the SysV call-boundary invariant: RSP is
+#      16-aligned at the CALL site, so the callee is entered with RSP%16==8)
+#   3. calls _rt_init to store envp into the OS layer
 #   4. calls user-supplied `main(argc, argv)`
 #   5. exits via sys_exit with the return code from main
 #
@@ -50,8 +51,7 @@ pub fun _start() {
         mov [_rt_argv], rsi
         mov [_rt_envp], rcx
 
-        and rsp, -16      # align stack to 16 bytes
-        sub rsp, 8        # adjust for CALL (pushes 8-byte return address)
+        and rsp, -16      # 16-align rsp for the SysV call boundary
         call _rt_init
 
         mov rdi, [_rt_argc]


### PR DESCRIPTION
Integration merge for the v0.4.2 patch release: the #200 `_start` SysV stack-alignment fix (linux + darwin x86_64).