### PR TITLE
fix(runtime): exit via SYS_exit_group so process exit kills all threads

### DIFF
--- a/src/runtime/linux/x86_64.mach
+++ b/src/runtime/linux/x86_64.mach
@@ -15,7 +15,9 @@
 #      16-aligned at the CALL site, so the callee is entered with RSP%16==8)
 #   3. calls _rt_init to store envp into the OS layer
 #   4. calls user-supplied `main(argc, argv)`
-#   5. exits via sys_exit with the return code from main
+#   5. exits via sys_exit_group with the return code from main, terminating
+#      all threads in the process (sys_exit would leave non-main threads
+#      alive, hanging the process after main returns)
 #
 # user code must define:
 #   $main.symbol = "main";
@@ -59,7 +61,7 @@ pub fun _start() {
         call main
 
         mov rdi, rax      # exit code from main -> rdi (1st syscall arg)
-        mov rax, 60       # SYS_exit
+        mov rax, 231      # SYS_exit_group
         syscall
     }
 }

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -37,6 +37,7 @@ $if ($mach.target.arch == $mach.arch.x86_64) {
     val SYS_VFORK:         usize = 58;
     val SYS_EXECVE:        usize = 59;
     val SYS_EXIT:          usize = 60;
+    val SYS_EXIT_GROUP:    usize = 231;
     val SYS_WAIT4:         usize = 61;
     val SYS_PIPE2:         usize = 293;
     val SYS_GETCWD:        usize = 79;
@@ -790,10 +791,13 @@ pub var _envp: usize = 0;
 # process
 
 # terminate: exit the process with the given code.
+#
+# uses exit_group so all threads in the process are terminated; plain
+# exit would only end the calling thread, leaving the process alive.
 # ---
 # code: exit code
 pub fun terminate(code: i64) {
-    syscall1(SYS_EXIT, code::usize);
+    syscall1(SYS_EXIT_GROUP, code::usize);
     asm x86_64 { hlt }
 }
 
@@ -888,7 +892,7 @@ pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
             }
         }
         exec(pathname, argv, envp);
-        syscall1(SYS_EXIT, 127);
+        syscall1(SYS_EXIT_GROUP, 127);
     }
     ret pid;
 }


### PR DESCRIPTION
## Summary

`_start` on linux x86_64 terminated the process with `SYS_exit` (60), which exits only the **calling thread**. Any program with a live non-main thread (detached/unjoined `std.sync.thread`, or service threads left by C libraries — found via GLFW's dbus/libdecor threads in octalide/mach-glfw) never terminated after `main` returned. Now exits via `SYS_exit_group` (231), which terminates all threads — matching what C runtimes do (glibc/musl `exit` → `exit_group`).

The same class of bug existed in two more linux process-exit paths in `src/system/os/linux/shared.mach`, both moved to `SYS_EXIT_GROUP`:
- `terminate()` (backs `process.exec.exit`, `abort`, and panic) — identical hang if called with threads alive.
- the `spawn()` child's exec-failure exit (127) — functionally equivalent today (a forked child is single-threaded) but exit_group is the correct process-exit semantic, matching libc `_exit`.

## Audit of other exit sites (unchanged, deliberately)

- `src/system/os/linux/x86_64.mach` thread trampoline (`mov rax, 60`) — a **thread** exit; must stay `SYS_exit` or every thread exit would kill the whole process.
- `src/runtime/darwin/{x86_64,aarch64}.mach` — BSD `exit` (class 2 syscall 1) terminates the entire XNU task (all threads); already correct.
- `src/system/os/darwin/shared.mach` `terminate()` — same BSD `exit`; already correct. Thread exit uses `bsdthread_terminate`, correctly thread-scoped.
- `src/runtime/windows/x86_64.mach` and `src/system/os/windows/shared.mach` — `ExitProcess`, which terminates all threads; already correct.

## Verification

- `mach test`: 495 PASS with the fix, byte-identical PASS set and exit behavior to the `dev` baseline (both runs end at the pre-existing #195 thread spawn/join crash; not a regression of this change).
- Regression proof — a program that spawns a thread looping forever (`for (1) { }`) then `ret 0` from `main`, run under `timeout 5`:
  - **before** (`SYS_exit`): hangs, killed by timeout — exit **124**
  - **after** (`SYS_exit_group`): exits immediately — exit **0**

Closes #205