### PR TITLE
chore: convert the manifest to the v1.4.0 format; declare windows libs via [os.windows]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-06-12
+
+Manifest migrated to the v1.4.0 format and windows link requirements declared
+once via the os overlay, plus the memory/string primitives added since 0.4.2.
 
 ### Added
 
 - `std.memory.raw_equal(a, b: ptr, n: usize) bool` — allocation-free byte-wise memory
   comparison with documented nil contract (n==0 vacuously true; equal pointers trivially
-  true; one-sided nil with n>0 is false).
-- `std.memory.equal[T](a, b: *T, n: usize) bool` — typed wrapper over `raw_equal`.
+  true; one-sided nil with n>0 is false) (#204).
+- `std.memory.equal[T](a, b: *T, n: usize) bool` — typed wrapper over `raw_equal` (#204).
 - `std.types.string.view_index_char(v: StrView, c: char) Result[usize, str]` — first
-  occurrence of a character within a view.
+  occurrence of a character within a view (#204).
 - `std.types.string.view_contains_char(v: StrView, c: char) bool` — membership test
-  delegating to `view_index_char`.
+  delegating to `view_index_char` (#204).
+- `[os.windows] libs = ["kernel32.dll"]` os overlay — std's windows runtime link
+  requirement, declared once and cascaded to every windows consumer build via the
+  v1.4.0 manifest os-component overlay.
 
 ### Changed
 
+- `mach.toml` converted to the v1.4.0 manifest schema: `dir_src`/`dir_out`/`dir_dep`
+  become `src`/`dep` plus explicit `out`/`obj`/`ir`/`asm`/`tests` path templates;
+  `[targets.linux]` becomes `[target.linux]`; the library `mode = "library"` /
+  `entrypoint = "lib.mach"` pair becomes `[lib.std] entry = "lib.mach" kind = "static"`.
+  v1.4.0 reads only this format.
 - `data/toml`: internal `str_eq_n` removed; call site migrated to `memory.raw_equal`
-  (behavioral match: both are byte-wise n-byte comparisons over `str = *char = *u8`).
+  (behavioral match: both are byte-wise n-byte comparisons over `str = *char = *u8`) (#204).
 
 ## [0.4.3] - 2026-06-11
 

--- a/README.md
+++ b/README.md
@@ -6,17 +6,16 @@ This repository contains the cannonical standard library for the Mach programmin
 
 To use the standard library in your Mach project, you can include it as a dependency in your project's configuration file:
 
-```mach
-[dep.std]
-type="remote"
-path="https://github.com/octalide/mach-std"
-version="branch/dev"
+```toml
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"
 ```
 
 You can also use the Mach dependency manager to add it to your project:
 
 ```bash
-mach dep add https://github.com/octalide/mach-std --version branch/dev
+mach dep add mach-std --git https://github.com/octalide/mach-std --ref branch/main
 ```
 
 ## Documentation

--- a/mach.toml
+++ b/mach.toml
@@ -1,18 +1,24 @@
 [project]
-id = "std"
-name = "Mach Standard Library"
-version = "0.4.3"
-dir_src = "src"
-dir_out = "out"
-dir_dep = "dep"
-target = "native"
+id      = "std"
+name    = "Mach Standard Library"
+version = "0.5.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+ir      = "out/{target}/{profile}/ir"
+asm     = "out/{target}/{profile}/asm"
+tests   = "out/{target}/{profile}/test/{name}"
 
-[targets.linux]
-os = "linux"
+[target.linux]
 isa = "x86_64"
+os  = "linux"
 abi = "sysv64"
-mode = "library"
-entrypoint = "lib.mach"
-artifacts = "linux"
-dir_tests = "tests"
-binary = "linux/bin/libmachstd.a"
+
+[os.windows]
+libs = ["kernel32.dll"]
+
+[lib.std]
+entry = "lib.mach"
+kind  = "static"


### PR DESCRIPTION
Converts `mach.toml` to the v1.4.0 manifest schema (the only format v1.4.0 reads) and declares std's windows link requirement once via an os overlay, then cuts 0.5.0.

## Manifest conversion

- `dir_src`/`dir_out`/`dir_dep` → `src`/`dep` + explicit `out`/`obj`/`ir`/`asm`/`tests` path templates
- `[targets.linux]` → `[target.linux]` (isa/os/abi preserved)
- library `mode = "library"` / `entrypoint = "lib.mach"` → `[lib.std] entry = "lib.mach" kind = "static"`
- `version` bumped 0.4.3 → 0.5.0

## OS overlay

- `[os.windows] libs = ["kernel32.dll"]` — std's windows runtime link requirement, declared once and cascaded to every windows consumer build via the v1.4.0 os-component overlay.

## Verification (all with the authoritative `mach` v1.4.0)

- `mach build .` clean in this repo
- `mach test .` (per-test engine): **529 passed, 4 failed, 533 total** — the 4 failures are the known issues #195 (×2, `FAIL(signal 11)` — crash isolation caught the SIGSEGV and continued), #196 (`json: value_find`, exit 1), #197 (`env: get PATH`, exit 1). No new failures.
- Consumer (`mach init`) vendoring this tree: native `build`/`run` print `Hello, World!`; windows cross-build links and produces `consumer.exe` whose PE import table includes `kernel32.dll` — sourced purely from std's overlay (the consumer's own `[target.windows]` declares no libs). Control: stripping the overlay breaks the link with `undefined symbol: GetCommandLineA`.

Also updates the README install snippet to the v1.4.0 `[deps.*]` `git`/`ref` form and the current `mach dep add` syntax.

Note: did **not** add a `[project] module` key (not mandated for std; std is imported by full path `std.*`) — flagged for maintainer ruling.

CI's Test step may hang/long-run on the #195 thread test per established convention; admin-merge.