### PR TITLE
release: v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-06-12
+
+Manifest migrated to the v1.4.0 format and windows link requirements declared
+once via the os overlay, plus the memory/string primitives added since 0.4.2.
 
 ### Added
 
 - `std.memory.raw_equal(a, b: ptr, n: usize) bool` — allocation-free byte-wise memory
   comparison with documented nil contract (n==0 vacuously true; equal pointers trivially
-  true; one-sided nil with n>0 is false).
-- `std.memory.equal[T](a, b: *T, n: usize) bool` — typed wrapper over `raw_equal`.
+  true; one-sided nil with n>0 is false) (#204).
+- `std.memory.equal[T](a, b: *T, n: usize) bool` — typed wrapper over `raw_equal` (#204).
 - `std.types.string.view_index_char(v: StrView, c: char) Result[usize, str]` — first
-  occurrence of a character within a view.
+  occurrence of a character within a view (#204).
 - `std.types.string.view_contains_char(v: StrView, c: char) bool` — membership test
-  delegating to `view_index_char`.
+  delegating to `view_index_char` (#204).
+- `[os.windows] libs = ["kernel32.dll"]` os overlay — std's windows runtime link
+  requirement, declared once and cascaded to every windows consumer build via the
+  v1.4.0 manifest os-component overlay.
 
 ### Changed
 
+- `mach.toml` converted to the v1.4.0 manifest schema: `dir_src`/`dir_out`/`dir_dep`
+  become `src`/`dep` plus explicit `out`/`obj`/`ir`/`asm`/`tests` path templates;
+  `[targets.linux]` becomes `[target.linux]`; the library `mode = "library"` /
+  `entrypoint = "lib.mach"` pair becomes `[lib.std] entry = "lib.mach" kind = "static"`.
+  v1.4.0 reads only this format.
 - `data/toml`: internal `str_eq_n` removed; call site migrated to `memory.raw_equal`
-  (behavioral match: both are byte-wise n-byte comparisons over `str = *char = *u8`).
+  (behavioral match: both are byte-wise n-byte comparisons over `str = *char = *u8`) (#204).
 
 ## [0.4.3] - 2026-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `std.memory.raw_equal(a, b: ptr, n: usize) bool` — allocation-free byte-wise memory
+  comparison with documented nil contract (n==0 vacuously true; equal pointers trivially
+  true; one-sided nil with n>0 is false).
+- `std.memory.equal[T](a, b: *T, n: usize) bool` — typed wrapper over `raw_equal`.
+- `std.types.string.view_index_char(v: StrView, c: char) Result[usize, str]` — first
+  occurrence of a character within a view.
+- `std.types.string.view_contains_char(v: StrView, c: char) bool` — membership test
+  delegating to `view_index_char`.
+
+### Changed
+
+- `data/toml`: internal `str_eq_n` removed; call site migrated to `memory.raw_equal`
+  (behavioral match: both are byte-wise n-byte comparisons over `str = *char = *u8`).
+
 ## [0.4.3] - 2026-06-11
 
 Patch release: process exit now terminates all threads on linux.

--- a/README.md
+++ b/README.md
@@ -6,17 +6,16 @@ This repository contains the cannonical standard library for the Mach programmin
 
 To use the standard library in your Mach project, you can include it as a dependency in your project's configuration file:
 
-```mach
-[dep.std]
-type="remote"
-path="https://github.com/octalide/mach-std"
-version="branch/dev"
+```toml
+[deps.mach-std]
+git = "https://github.com/octalide/mach-std"
+ref = "branch/main"
 ```
 
 You can also use the Mach dependency manager to add it to your project:
 
 ```bash
-mach dep add https://github.com/octalide/mach-std --version branch/dev
+mach dep add mach-std --git https://github.com/octalide/mach-std --ref branch/main
 ```
 
 ## Documentation

--- a/mach.toml
+++ b/mach.toml
@@ -1,18 +1,24 @@
 [project]
-id = "std"
-name = "Mach Standard Library"
-version = "0.4.3"
-dir_src = "src"
-dir_out = "out"
-dir_dep = "dep"
-target = "native"
+id      = "std"
+name    = "Mach Standard Library"
+version = "0.5.0"
+src     = "src"
+dep     = "dep"
+target  = "native"
+out     = "out/{target}/{profile}/bin/{name}{ext}"
+obj     = "out/{target}/{profile}/obj"
+ir      = "out/{target}/{profile}/ir"
+asm     = "out/{target}/{profile}/asm"
+tests   = "out/{target}/{profile}/test/{name}"
 
-[targets.linux]
-os = "linux"
+[target.linux]
 isa = "x86_64"
+os  = "linux"
 abi = "sysv64"
-mode = "library"
-entrypoint = "lib.mach"
-artifacts = "linux"
-dir_tests = "tests"
-binary = "linux/bin/libmachstd.a"
+
+[os.windows]
+libs = ["kernel32.dll"]
+
+[lib.std]
+entry = "lib.mach"
+kind  = "static"

--- a/src/data/toml.mach
+++ b/src/data/toml.mach
@@ -364,7 +364,7 @@ fun find_by_seg(t: *Table, seg: str, seg_len: usize) *Value {
     val vals: *Value = t.values::*Value;
     var i: usize = 0;
     for (i < t.len) {
-        if (str_len(keys[i]) == seg_len && str_eq_n(keys[i], seg, seg_len)) {
+        if (str_len(keys[i]) == seg_len && mem.raw_equal(keys[i]::ptr, seg::ptr, seg_len)) {
             ret ?vals[i];
         }
         i = i + 1;
@@ -372,15 +372,6 @@ fun find_by_seg(t: *Table, seg: str, seg_len: usize) *Value {
     ret nil;
 }
 
-# str_eq_n: compare two strings up to n bytes.
-fun str_eq_n(a: str, b: str, n: usize) bool {
-    var i: usize = 0;
-    for (i < n) {
-        if (a[i] != b[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
-}
 
 # get_str: look up a string value by dotted path.
 # ---

--- a/src/memory.mach
+++ b/src/memory.mach
@@ -1,3 +1,6 @@
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
 
 # low-level memory operations for raw and typed buffers.
@@ -135,6 +138,44 @@ pub fun zero[T](p: *T, count: usize) {
     if (p == nil || count == 0) { ret; }
     if (count > ~(0::usize) / $size_of(T)) { ret; }
     raw_zero(p::ptr, $size_of(T) * count);
+}
+
+# raw_equal: compare two blocks of raw memory byte-wise.
+#
+# nil contract: n==0 is vacuously true regardless of pointer values.
+# equal pointers (including nil==nil) are trivially true without dereference.
+# if exactly one pointer is nil and n>0, the result is false.
+# ---
+# a:   pointer to the first memory block
+# b:   pointer to the second memory block
+# n:   number of bytes to compare
+# ret: true if the first n bytes of a and b are identical
+pub fun raw_equal(a: ptr, b: ptr, n: usize) bool {
+    if (n == 0) { ret true; }
+    if (a == b)  { ret true; }
+    if (a == nil || b == nil) { ret false; }
+    val ab: *u8 = a::*u8;
+    val bb: *u8 = b::*u8;
+    var i: usize = 0;
+    for (i < n) {
+        if (ab[i] != bb[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# equal: compare n typed elements at a and b for byte-wise equality.
+#
+# delegates to raw_equal; see raw_equal for nil handling.
+# returns false if the byte count would overflow usize.
+# ---
+# a:   pointer to the first element
+# b:   pointer to the second element
+# n:   number of elements to compare
+# ret: true if the first n elements of a and b are byte-identical
+pub fun equal[T](a: *T, b: *T, n: usize) bool {
+    if (n > ~(0::usize) / $size_of(T)) { ret false; }
+    ret raw_equal(a::ptr, b::ptr, $size_of(T) * n);
 }
 
 test "memory: raw_fill with non-zero value" {
@@ -282,5 +323,73 @@ test "memory: zero with count zero is noop" {
     zero[i64](?arr[0], 0);
     if (arr[0] != 5) { ret 1; }
     if (arr[1] != 6) { ret 1; }
+    ret 0;
+}
+
+test "memory: raw_equal equal blocks" {
+    var a: [4]u8 = [4]u8{1, 2, 3, 4};
+    var b: [4]u8 = [4]u8{1, 2, 3, 4};
+    if (!raw_equal(?a[0], ?b[0], 4)) { ret 1; }
+    ret 0;
+}
+
+test "memory: raw_equal unequal blocks" {
+    var a: [4]u8 = [4]u8{1, 2, 3, 4};
+    var b: [4]u8 = [4]u8{1, 2, 3, 5};
+    if (raw_equal(?a[0], ?b[0], 4)) { ret 1; }
+    ret 0;
+}
+
+test "memory: raw_equal partial match" {
+    var a: [4]u8 = [4]u8{1, 2, 3, 4};
+    var b: [4]u8 = [4]u8{1, 2, 9, 9};
+    if (!raw_equal(?a[0], ?b[0], 2)) { ret 1; }
+    if (raw_equal(?a[0], ?b[0], 4)) { ret 1; }
+    ret 0;
+}
+
+test "memory: raw_equal zero length is true" {
+    var a: [2]u8 = [2]u8{1, 2};
+    var b: [2]u8 = [2]u8{9, 9};
+    if (!raw_equal(?a[0], ?b[0], 0)) { ret 1; }
+    ret 0;
+}
+
+test "memory: raw_equal nil nil zero length is true" {
+    if (!raw_equal(nil, nil, 0)) { ret 1; }
+    ret 0;
+}
+
+test "memory: raw_equal nil one side is false" {
+    var a: [2]u8 = [2]u8{1, 2};
+    if (raw_equal(nil, ?a[0], 2)) { ret 1; }
+    if (raw_equal(?a[0], nil, 2)) { ret 1; }
+    ret 0;
+}
+
+test "memory: equal equal typed arrays" {
+    var a: [3]i64 = [3]i64{1, 2, 3};
+    var b: [3]i64 = [3]i64{1, 2, 3};
+    if (!equal[i64](?a[0], ?b[0], 3)) { ret 1; }
+    ret 0;
+}
+
+test "memory: equal unequal typed arrays" {
+    var a: [3]i64 = [3]i64{1, 2, 3};
+    var b: [3]i64 = [3]i64{1, 2, 4};
+    if (equal[i64](?a[0], ?b[0], 3)) { ret 1; }
+    ret 0;
+}
+
+test "memory: equal zero length is true" {
+    var a: [2]i64 = [2]i64{1, 2};
+    var b: [2]i64 = [2]i64{9, 9};
+    if (!equal[i64](?a[0], ?b[0], 0)) { ret 1; }
+    ret 0;
+}
+
+test "memory: equal nil nil zero length is true" {
+    val p: *i64 = nil;
+    if (!equal[i64](p, p, 0)) { ret 1; }
     ret 0;
 }

--- a/src/types/string.mach
+++ b/src/types/string.mach
@@ -565,3 +565,62 @@ pub fun view_eq_str(v: StrView, s: str) bool {
     }
     ret s[v.len] == 0;
 }
+
+# view_index_char: find the first occurrence of a character within the view.
+# ---
+# v:   the view to search
+# c:   character to find
+# ret: index of the first occurrence, or an error message if not found
+pub fun view_index_char(v: StrView, c: char) Result[usize, str] {
+    var i: usize = 0;
+    for (i < v.len) {
+        if (v.data[i] == c) { ret ok[usize, str](i); }
+        i = i + 1;
+    }
+    ret err[usize, str]("character not found");
+}
+
+# view_contains_char: check if the view contains a character.
+# ---
+# v:   the view to search
+# c:   character to find
+# ret: true if c appears within v
+pub fun view_contains_char(v: StrView, c: char) bool {
+    val r: Result[usize, str] = view_index_char(v, c);
+    ret is_ok[usize, str](r);
+}
+
+test "string: view_index_char found" {
+    val s: str = "hello";
+    val v: StrView = view(s, 5);
+    var r: Result[usize, str] = view_index_char(v, 'l');
+    if (is_err[usize, str](r)) { ret 1; }
+    if (unwrap_ok[usize, str](r) != 2) { ret 1; }
+    r = view_index_char(v, 'h');
+    if (is_err[usize, str](r)) { ret 1; }
+    if (unwrap_ok[usize, str](r) != 0) { ret 1; }
+    ret 0;
+}
+
+test "string: view_index_char not found" {
+    val s: str = "hello";
+    val v: StrView = view(s, 5);
+    val r: Result[usize, str] = view_index_char(v, 'x');
+    if (is_ok[usize, str](r)) { ret 1; }
+    ret 0;
+}
+
+test "string: view_index_char empty view" {
+    val v: StrView = view(nil, 0);
+    val r: Result[usize, str] = view_index_char(v, 'a');
+    if (is_ok[usize, str](r)) { ret 1; }
+    ret 0;
+}
+
+test "string: view_contains_char found and not found" {
+    val s: str = "hello";
+    val v: StrView = view(s, 5);
+    if (!view_contains_char(v, 'e')) { ret 1; }
+    if (view_contains_char(v, 'x')) { ret 1; }
+    ret 0;
+}


### PR DESCRIPTION
Release sweep of the v1.4.0 manifest conversion + windows os overlay into `main`.

## Highlights since 0.4.3

- `mach.toml` converted to the v1.4.0 manifest schema (the only format v1.4.0 reads): `dir_src`/`dir_out`/`dir_dep` → `src`/`dep` + path templates; `[targets.linux]` → `[target.linux]`; `mode`/`entrypoint` → `[lib.std] entry="lib.mach" kind="static"`.
- `[os.windows] libs = ["kernel32.dll"]` overlay — std's windows link requirement declared once and cascaded to every windows consumer.
- Memory/string primitives (#204): `memory.raw_equal`, `memory.equal[T]`, `string.view_index_char`, `string.view_contains_char`.

## Known-failing tests (carried forward)

`mach test .` reports **529 passed, 4 failed**; the failures are tracked:
- #195 `thread: spawn and join` / `is_done after join` — `FAIL(signal 11)` (the new engine isolates the SIGSEGV and continues)
- #196 `json: value_find on object` — `FAIL(exit 1)`
- #197 `env: get PATH returns positive length` — `FAIL(exit 1)`

CI Test step fails on these by convention; admin-merge.