### PR TITLE
fix(thread): clone parent/child discrimination race and done-flag lifetime

### DIFF
--- a/src/sync/thread.mach
+++ b/src/sync/thread.mach
@@ -32,18 +32,21 @@ pub rec Thread {
 # handles clone and trampoline setup. the child sets the done flag and
 # wakes waiters on exit.
 #
+# the handle is caller-owned and initialized in place: the child writes
+# the completion flag through ?t.done, so the record must stay at a
+# stable address for the thread's lifetime (a by-value return would
+# hand the child the address of a dead frame — see issue #195).
 # ---
-# f:   function to execute in the new thread
-# ret: a Thread handle, or a Thread with tid < 0 on failure
-pub fun spawn(f: fun()) Thread {
-    var t: Thread;
+# f: function to execute in the new thread
+# t: caller-owned handle, initialized by this call; t.tid < 0 on failure
+pub fun spawn(f: fun(), t: *Thread) {
     t.tid = -1;
     t.stack = 0;
     t.done = 0;
 
     val stack_base: usize = sys.allocate(STACK_SIZE)::usize;
     if (stack_base == 0) {
-        ret t;
+        ret;
     }
 
     t.stack = stack_base;
@@ -55,11 +58,10 @@ pub fun spawn(f: fun()) Thread {
         sys.deallocate(stack_base::ptr, STACK_SIZE);
         t.stack = 0;
         t.tid = tid;
-        ret t;
+        ret;
     }
 
     t.tid = tid;
-    ret t;
 }
 
 # wait for a thread to finish.
@@ -103,7 +105,8 @@ test "thread: Thread record initializes" {
 
 test "thread: spawn and join" {
     atomic_mod.store(?test_flag, 0);
-    var t: Thread = spawn(test_worker);
+    var t: Thread;
+    spawn(test_worker, ?t);
     if (t.tid < 0) { ret 1; }
     join(?t);
     if (atomic_mod.load(?test_flag) != 1) { ret 1; }
@@ -112,7 +115,8 @@ test "thread: spawn and join" {
 
 test "thread: is_done after join" {
     atomic_mod.store(?test_flag, 0);
-    var t: Thread = spawn(test_worker);
+    var t: Thread;
+    spawn(test_worker, ?t);
     if (t.tid < 0) { ret 1; }
     join(?t);
     if (!is_done(?t)) { ret 1; }

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -35,6 +35,11 @@ pub fun page_size() usize {
 
 val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM;
 
+# entered by a direct jump from the child side of clone (see thread_spawn);
+# the symbol is pinned so the inline-asm branch can target it. at entry rsp
+# points at the argument block on the child stack, so after the prologue the
+# args sit at [rbp+8..rbp+32] exactly as if the trampoline had been called.
+$thread_trampoline.symbol = "_std_thread_trampoline";
 fun thread_trampoline() {
     var fn_addr: usize = 0;
     var done_addr: usize = 0;
@@ -81,19 +86,22 @@ fun thread_trampoline() {
 # stack_size: size of the stack in bytes
 # ret:        thread ID on success, or negative errno on failure
 pub fun thread_spawn(f: fun(), done_ptr: *i64, stack_base: usize, stack_size: usize) i64 {
-    val tramp: fun() = thread_trampoline;
     val stack_top: usize = stack_base + stack_size;
-    val child_sp: usize = stack_top - 48;
-    @(child_sp::*usize) = tramp::usize;
-    @((child_sp + 8)::*usize) = f::usize;
-    @((child_sp + 16)::*usize) = done_ptr::usize;
-    @((child_sp + 24)::*usize) = stack_base;
-    @((child_sp + 32)::*usize) = stack_size;
+    val child_sp: usize = stack_top - 40;
+    @(child_sp::*usize) = f::usize;
+    @((child_sp + 8)::*usize) = done_ptr::usize;
+    @((child_sp + 16)::*usize) = stack_base;
+    @((child_sp + 24)::*usize) = stack_size;
 
     var flags: usize = THREAD_CLONE_FLAGS;
     var stack_ptr: usize = child_sp;
     var result: i64 = 0;
 
+    # parent/child discrimination must stay in registers: under CLONE_VM the
+    # child's rbp still addresses the parent frame, so a shared stack local
+    # would race (both sides writing the same slot — see issue #195). the
+    # child jumps straight to the trampoline off its own stack; the parent
+    # falls through and stores the tid.
     asm x86_64 { mfence }
     asm x86_64 {
         mov rdi, {flags}
@@ -103,11 +111,9 @@ pub fun thread_spawn(f: fun(), done_ptr: *i64, stack_base: usize, stack_size: us
         xor r8, r8
         mov rax, 56           # SYS_clone
         syscall
-        mov {result}, rax
-    }
-
-    if (result == 0) {
-        asm x86_64 { ret }
+        test rax, rax
+        jz _std_thread_trampoline
+        mov {result}, rax     # parent: tid, or negative errno on failure
     }
 
     ret result;


### PR DESCRIPTION
Closes #195

## What

Two independent shared-memory bugs in the thread spawn path made `thread: spawn and join` and `thread: is_done after join` hang `mach test`:

1. **Clone discrimination race (the #195 analysis).** `thread_spawn` discriminated parent/child via a stack local `result`; under `CLONE_VM` the child's `rbp` still addresses the parent frame, so both sides raced on the same slot. Discrimination now happens entirely in registers inside the asm block: the child branches on `rax` straight to the trampoline (`jz _std_thread_trampoline` — the trampoline symbol is pinned via `$thread_trampoline.symbol` since inline-asm branches require symbol targets), and the parent falls through and stores the tid. The child stack layout drops the trampoline-pointer slot (jump entry instead of `ret` entry, offsets shift by 8 so the trampoline's `[rbp+N]` arg reads are unchanged, and entry alignment still matches call-convention entry).

2. **Done-flag lifetime bug (found while verifying; same spawn path).** `sync.thread.spawn` returned the `Thread` record **by value** while handing the child `?t.done` — the address of a local in spawn's frame. The record is returned via copy, so the child wrote the completion flag into a dead frame and `join` waited forever on the caller's copy. This was deterministic on this machine once bug 1 was fixed (it only passed under strace, where ptrace slows clone enough for the child to finish before the copy). `spawn` now initializes a **caller-owned** handle in place: `spawn(f: fun(), t: *Thread)`. This is a public API signature change; the only in-repo callers were the two tests.

## Darwin audit

The issue notes the darwin x86_64/aarch64 trampolines mirror the pattern — they do not: darwin `thread_spawn` uses `bsdthread_create` with a kernel-registered callback (`thread_start`), so there is no parent/child discrimination and no shared-local race. `fork()`-based paths don't share the address space. No darwin changes needed.

## Verification

- `mach build .` green
- `mach test .`: 531 passed, 2 failed — only the known-failing #196 (json value_find) and #197 (env PATH) remain; both thread tests pass
- 20x `mach test .` flake loop result will be posted as a PR comment