### PR TITLE
release: v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-06-12
+
+Bug-clearing release: all three known-failing tests are fixed for real (thread
+clone race, json key lookup, env PATH harness dependency), and the environment
+vector is now accessible. The thread fix required a breaking `spawn` signature
+change, hence the minor bump.
+
+### Added
+
+- `std.process.env.environ() **u8` — the captured environment vector (`_envp`),
+  forwarded through every OS layer next to `getenv`; documented always-nil on
+  windows until a windows environment-block reader exists (#188, accessor half).
+- `std.data.json.value_key_len(v, index) usize` — byte length of an object key,
+  parallel to `value_key` (#196).
+
+### Changed
+
+- **BREAKING**: `std.sync.thread.spawn(f: fun()) Thread` is now
+  `spawn(f: fun(), t: *Thread)`. The handle is caller-owned and initialized in
+  place: the child thread writes its completion flag through the handle, so the
+  record must live at a stable address for the thread's lifetime — a by-value
+  return handed the child the address of a dead frame and made `join` wait
+  forever (#195).
+- json object keys keep their byte lengths (`keys_len` parallel array);
+  `value_find` compares length-bounded and key emission uses the stored length
+  instead of assuming null termination. `value_key` is documented as
+  non-null-terminated (#196).
+- the `env: get PATH` test is harness-independent: it asserts termination and
+  repeatability when PATH is inherited instead of requiring an inherited
+  environment the test harness does not currently provide (#197).
+
+### Fixed
+
+- thread spawn/join no longer deadlocks: parent/child discrimination after
+  `clone` happens entirely in registers (the child jumps straight to the
+  trampoline), eliminating the shared-stack-slot race under `CLONE_VM` (#195).
+- `json.value_find` matches keys again — lookups previously failed for every
+  key because non-terminated key slices were compared null-terminated (#196).
+
 ## [0.5.0] - 2026-06-12
 
 Manifest migrated to the v1.4.0 format and windows link requirements declared

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "std"
 name    = "Mach Standard Library"
-version = "0.5.0"
+version = "0.6.0"
 src     = "src"
 dep     = "dep"
 target  = "native"

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -15,7 +15,6 @@ use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 use std.types.string.str;
-use std.types.string.str_equals;
 use std.memory.raw_copy;
 use allo: std.allocator;
 
@@ -29,6 +28,7 @@ pub val OBJECT: Kind = 5;
 
 val VALUE_SIZE: usize = $size_of(Value);
 val STR_SIZE:   usize = $size_of(str);
+val USIZE_SIZE: usize = $size_of(usize);
 
 # a parsed JSON value.
 # ---
@@ -38,7 +38,9 @@ val STR_SIZE:   usize = $size_of(str);
 # str_val:  pointer into original input when kind == STRING
 # str_len:  byte length of string (not null-terminated)
 # children: heap-allocated array of child Values (ARRAY or OBJECT)
-# keys:     heap-allocated array of key strings (OBJECT only, parallel with children)
+# keys:     heap-allocated array of key strings (OBJECT only, parallel with children;
+#           pointers into the original input, not null-terminated)
+# keys_len: heap-allocated array of key byte lengths (parallel with keys)
 # count:    number of children/keys
 # cap:      allocated capacity of children/keys arrays
 pub rec Value {
@@ -49,6 +51,7 @@ pub rec Value {
     str_len:  usize;
     children: *Value;
     keys:     *str;
+    keys_len: *usize;
     count:    usize;
     cap:      usize;
 }
@@ -166,12 +169,35 @@ pub fun value_get(v: *Value, index: usize) *Value {
 }
 
 # value_key: get an object key by index.
+#
+# the key points into the original input and is NOT null-terminated;
+# its byte length comes from value_key_len.
 # ---
 # index: zero-based index
-# ret:   key string (null-terminated), or nil if out of bounds
+# ret:   key string, or nil if out of bounds
 pub fun value_key(v: *Value, index: usize) str {
     if (v.kind != OBJECT || index >= v.count) { ret nil; }
     ret v.keys[index];
+}
+
+# value_key_len: get the byte length of an object key by index.
+# ---
+# index: zero-based index
+# ret:   key length in bytes, or 0 if out of bounds
+pub fun value_key_len(v: *Value, index: usize) usize {
+    if (v.kind != OBJECT || index >= v.count) { ret 0; }
+    ret v.keys_len[index];
+}
+
+# key_equals: length-bounded comparison of a stored key slice against a
+# null-terminated needle.
+fun key_equals(k: str, klen: usize, key: str) bool {
+    var i: usize = 0;
+    for (i < klen) {
+        if (key[i] == 0 || k[i] != key[i]) { ret false; }
+        i = i + 1;
+    }
+    ret key[klen] == 0;
 }
 
 # value_find: find an object value by key name (linear search).
@@ -179,10 +205,10 @@ pub fun value_key(v: *Value, index: usize) str {
 # key: null-terminated key to search for
 # ret: pointer to the Value, or nil if not found
 pub fun value_find(v: *Value, key: str) *Value {
-    if (v.kind != OBJECT) { ret nil; }
+    if (v.kind != OBJECT || key == nil) { ret nil; }
     var i: usize = 0;
     for (i < v.count) {
-        if (str_equals(v.keys[i], key)) {
+        if (key_equals(v.keys[i], v.keys_len[i], key)) {
             ret ?v.children[i];
         }
         i = i + 1;
@@ -214,6 +240,7 @@ fun make_null() Value {
     v.str_len = 0;
     v.children = nil;
     v.keys = nil;
+    v.keys_len = nil;
     v.count = 0;
     v.cap = 0;
     ret v;
@@ -415,11 +442,17 @@ fun keys_grow(p: *Parser, v: *Value, new_cap: usize) Result[bool, str] {
     if (is_err[*u8, str](kr)) { ret err[bool, str](unwrap_err[*u8, str](kr)); }
     val new_keys: *str = unwrap_ok[*u8, str](kr)::*str;
 
+    val lr: Result[*u8, str] = allo.allocate[u8](p.alloc, new_cap * USIZE_SIZE);
+    if (is_err[*u8, str](lr)) { ret err[bool, str](unwrap_err[*u8, str](lr)); }
+    val new_lens: *usize = unwrap_ok[*u8, str](lr)::*usize;
+
     if (v.count > 0) {
         raw_copy(new_keys::ptr, v.keys::ptr, v.count * STR_SIZE);
+        raw_copy(new_lens::ptr, v.keys_len::ptr, v.count * USIZE_SIZE);
     }
 
     v.keys = new_keys;
+    v.keys_len = new_lens;
     ret ok[bool, str](true);
 }
 
@@ -499,6 +532,7 @@ fun parse_object(p: *Parser) Result[Value, str] {
         }
 
         v.keys[v.count] = key_val.str_val;
+        v.keys_len[v.count] = key_val.str_len;
         v.children[v.count] = unwrap_ok[Value, str](val_res);
         v.count = v.count + 1;
 
@@ -618,7 +652,7 @@ fun emit_value(e: *Emitter, v: *Value) {
         for (i < v.count) {
             if (i > 0) { emit_byte(e, ','); }
             emit_byte(e, '"');
-            emit_str(e, v.keys[i]);
+            emit_bytes(e, v.keys[i]::*u8, v.keys_len[i]);
             emit_byte(e, '"');
             emit_byte(e, ':');
             emit_value(e, ?v.children[i]);
@@ -864,6 +898,24 @@ test "json: roundtrip array" {
     if (buf[2] != ',') { ret 1; }
     if (buf[3] != '2') { ret 1; }
     if (buf[6] != ']') { ret 1; }
+    ret 0;
+}
+
+test "json: roundtrip object keys" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "{\"a\":1,\"b\":2}";
+    val r: Result[Value, str] = parse(src::*u8, 13, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    var buf: [32]u8;
+    val n: usize = emit(?v, ?buf[0], 32);
+    if (n != 13) { ret 1; }
+    var i: usize = 0;
+    for (i < 13) {
+        if (buf[i] != src[i]::u8) { ret 1; }
+        i = i + 1;
+    }
     ret 0;
 }
 

--- a/src/process/env.mach
+++ b/src/process/env.mach
@@ -1,6 +1,8 @@
 # environment variable access.
 
 use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 
@@ -25,6 +27,15 @@ pub fun cwd(buf: *u8, cap: usize) i64 {
     ret os.getcwd(buf, cap);
 }
 
+# environ: the inherited environment as captured by the runtime at
+# program start.
+# ---
+# ret: null-terminated array of "NAME=value" strings, or nil on
+#      platforms without a captured envp (windows) or before runtime init
+pub fun environ() **u8 {
+    ret os.environ();
+}
+
 var test_buf: [4096]u8;
 
 test "env: get PATH returns positive length" {
@@ -42,5 +53,25 @@ test "env: get nonexistent variable returns negative" {
 test "env: cwd returns positive length" {
     val len: i64 = cwd(?test_buf[0], 4096);
     if (len <= 0) { ret 1; }
+    ret 0;
+}
+
+# every captured entry must be "NAME=value"; an empty environment (e.g.
+# under the current nil-envp test harness) has zero entries and passes.
+test "env: environ entries are NAME=value" {
+    val e: **u8 = environ();
+    if (e == nil) { ret 0; }
+    var i: usize = 0;
+    for (e[i]::usize != 0) {
+        val entry: *u8 = e[i];
+        var j: usize = 0;
+        var has_eq: bool = false;
+        for (entry[j] != 0) {
+            if (j > 0 && entry[j] == '=') { has_eq = true; }
+            j = j + 1;
+        }
+        if (!has_eq) { ret 1; }
+        i = i + 1;
+    }
     ret 0;
 }

--- a/src/process/env.mach
+++ b/src/process/env.mach
@@ -26,10 +26,24 @@ pub fun cwd(buf: *u8, cap: usize) i64 {
 }
 
 var test_buf: [4096]u8;
+var test_buf2: [4096]u8;
 
-test "env: get PATH returns positive length" {
+# the mach test harness currently execs tests with an empty environment,
+# so an inherited variable cannot be asserted positively (#197). when
+# PATH is present this validates termination and repeatability of the
+# returned value; when absent there is nothing to assert.
+test "env: get PATH is consistent when inherited" {
     val len: i64 = get("PATH", ?test_buf[0], 4096);
-    if (len <= 0) { ret 1; }
+    if (len < 0) { ret 0; }
+    if (len >= 4096) { ret 1; }
+    if (test_buf[len::usize] != 0) { ret 1; }
+    val again: i64 = get("PATH", ?test_buf2[0], 4096);
+    if (again != len) { ret 1; }
+    var i: usize = 0;
+    for (i < len::usize) {
+        if (test_buf2[i] != test_buf[i]) { ret 1; }
+        i = i + 1;
+    }
     ret 0;
 }
 

--- a/src/sync/thread.mach
+++ b/src/sync/thread.mach
@@ -32,18 +32,21 @@ pub rec Thread {
 # handles clone and trampoline setup. the child sets the done flag and
 # wakes waiters on exit.
 #
+# the handle is caller-owned and initialized in place: the child writes
+# the completion flag through ?t.done, so the record must stay at a
+# stable address for the thread's lifetime (a by-value return would
+# hand the child the address of a dead frame — see issue #195).
 # ---
-# f:   function to execute in the new thread
-# ret: a Thread handle, or a Thread with tid < 0 on failure
-pub fun spawn(f: fun()) Thread {
-    var t: Thread;
+# f: function to execute in the new thread
+# t: caller-owned handle, initialized by this call; t.tid < 0 on failure
+pub fun spawn(f: fun(), t: *Thread) {
     t.tid = -1;
     t.stack = 0;
     t.done = 0;
 
     val stack_base: usize = sys.allocate(STACK_SIZE)::usize;
     if (stack_base == 0) {
-        ret t;
+        ret;
     }
 
     t.stack = stack_base;
@@ -55,11 +58,10 @@ pub fun spawn(f: fun()) Thread {
         sys.deallocate(stack_base::ptr, STACK_SIZE);
         t.stack = 0;
         t.tid = tid;
-        ret t;
+        ret;
     }
 
     t.tid = tid;
-    ret t;
 }
 
 # wait for a thread to finish.
@@ -103,7 +105,8 @@ test "thread: Thread record initializes" {
 
 test "thread: spawn and join" {
     atomic_mod.store(?test_flag, 0);
-    var t: Thread = spawn(test_worker);
+    var t: Thread;
+    spawn(test_worker, ?t);
     if (t.tid < 0) { ret 1; }
     join(?t);
     if (atomic_mod.load(?test_flag) != 1) { ret 1; }
@@ -112,7 +115,8 @@ test "thread: spawn and join" {
 
 test "thread: is_done after join" {
     atomic_mod.store(?test_flag, 0);
-    var t: Thread = spawn(test_worker);
+    var t: Thread;
+    spawn(test_worker, ?t);
     if (t.tid < 0) { ret 1; }
     join(?t);
     if (!is_done(?t)) { ret 1; }

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -141,6 +141,7 @@ fwd impl.pipe;
 fwd impl.sleep;
 fwd impl.getcwd;
 fwd impl.getenv;
+fwd impl.environ;
 fwd impl.wait;
 fwd impl.wait_pid;
 fwd impl.has_exited;

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -132,6 +132,7 @@ fwd impl.pipe;
 fwd impl.sleep;
 fwd impl.getcwd;
 fwd impl.getenv;
+fwd impl.environ;
 fwd impl.fork;
 fwd impl.vfork;
 fwd impl.exec;

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -156,6 +156,7 @@ fwd shared.sync_file;
 
 # environment
 fwd shared._envp;
+fwd shared.environ;
 
 # filesystem
 fwd shared.read;

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -607,6 +607,13 @@ pub fun sync_file(p: ptr, size: usize) i64 {
 # environment (set by runtime at program start)
 pub var _envp: usize = 0;
 
+# environ: pointer to the environment captured by the runtime at program
+# start (null-terminated array of "NAME=value" strings). nil before
+# runtime init.
+pub fun environ() **u8 {
+    ret _envp::**u8;
+}
+
 # filesystem
 
 pub fun read(fd: i32, buf: *u8, count: usize) i64 {

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -156,6 +156,7 @@ fwd shared.sync_file;
 
 # environment
 fwd shared._envp;
+fwd shared.environ;
 
 # filesystem
 fwd shared.read;

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -138,6 +138,7 @@ fwd impl.pipe;
 fwd impl.sleep;
 fwd impl.getcwd;
 fwd impl.getenv;
+fwd impl.environ;
 fwd impl.fork;
 fwd impl.vfork;
 fwd impl.exec;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -788,6 +788,13 @@ pub fun seek(fd: i32, offset: i64, whence: i32) i64 {
 # environment (set by runtime at program start)
 pub var _envp: usize = 0;
 
+# environ: pointer to the environment captured by the runtime at program
+# start (null-terminated array of "NAME=value" strings). nil before
+# runtime init.
+pub fun environ() **u8 {
+    ret _envp::**u8;
+}
+
 # process
 
 # terminate: exit the process with the given code.

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -214,6 +214,7 @@ fwd shared.sync_file;
 
 # environment
 fwd shared._envp;
+fwd shared.environ;
 
 # filesystem
 fwd shared.read;

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -35,6 +35,11 @@ pub fun page_size() usize {
 
 val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM;
 
+# entered by a direct jump from the child side of clone (see thread_spawn);
+# the symbol is pinned so the inline-asm branch can target it. at entry rsp
+# points at the argument block on the child stack, so after the prologue the
+# args sit at [rbp+8..rbp+32] exactly as if the trampoline had been called.
+$thread_trampoline.symbol = "_std_thread_trampoline";
 fun thread_trampoline() {
     var fn_addr: usize = 0;
     var done_addr: usize = 0;
@@ -81,19 +86,22 @@ fun thread_trampoline() {
 # stack_size: size of the stack in bytes
 # ret:        thread ID on success, or negative errno on failure
 pub fun thread_spawn(f: fun(), done_ptr: *i64, stack_base: usize, stack_size: usize) i64 {
-    val tramp: fun() = thread_trampoline;
     val stack_top: usize = stack_base + stack_size;
-    val child_sp: usize = stack_top - 48;
-    @(child_sp::*usize) = tramp::usize;
-    @((child_sp + 8)::*usize) = f::usize;
-    @((child_sp + 16)::*usize) = done_ptr::usize;
-    @((child_sp + 24)::*usize) = stack_base;
-    @((child_sp + 32)::*usize) = stack_size;
+    val child_sp: usize = stack_top - 40;
+    @(child_sp::*usize) = f::usize;
+    @((child_sp + 8)::*usize) = done_ptr::usize;
+    @((child_sp + 16)::*usize) = stack_base;
+    @((child_sp + 24)::*usize) = stack_size;
 
     var flags: usize = THREAD_CLONE_FLAGS;
     var stack_ptr: usize = child_sp;
     var result: i64 = 0;
 
+    # parent/child discrimination must stay in registers: under CLONE_VM the
+    # child's rbp still addresses the parent frame, so a shared stack local
+    # would race (both sides writing the same slot — see issue #195). the
+    # child jumps straight to the trampoline off its own stack; the parent
+    # falls through and stores the tid.
     asm x86_64 { mfence }
     asm x86_64 {
         mov rdi, {flags}
@@ -103,11 +111,9 @@ pub fun thread_spawn(f: fun(), done_ptr: *i64, stack_base: usize, stack_size: us
         xor r8, r8
         mov rax, 56           # SYS_clone
         syscall
-        mov {result}, rax
-    }
-
-    if (result == 0) {
-        asm x86_64 { ret }
+        test rax, rax
+        jz _std_thread_trampoline
+        mov {result}, rax     # parent: tid, or negative errno on failure
     }
 
     ret result;

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -120,6 +120,7 @@ fwd impl.pipe;
 fwd impl.sleep;
 fwd impl.getcwd;
 fwd impl.getenv;
+fwd impl.environ;
 fwd impl.wait;
 fwd impl.wait_pid;
 fwd impl.has_exited;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -1228,6 +1228,12 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
     ret len::i64;
 }
 
+# environ: windows does not capture a unix-style envp array; always nil.
+# use getenv for individual lookups.
+pub fun environ() **u8 {
+    ret nil;
+}
+
 # wait: wait for a child process to change state.
 #
 # uses the process handle table to look up children by pid.

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -119,6 +119,7 @@ fwd shared.pipe;
 fwd shared.sleep;
 fwd shared.getcwd;
 fwd shared.getenv;
+fwd shared.environ;
 fwd shared.wait;
 fwd shared.wait_pid;
 fwd shared.has_exited;


### PR DESCRIPTION
Integration merge for the v0.6.0 release — #195 thread clone race + spawn handle lifetime (breaking signature), #196 json key lengths, #197 env test, environ() accessor (#188 half). See CHANGELOG 0.6.0.