### PR TITLE
fix(env): unify getenv truncation contract on full value length

### DIFF
--- a/src/process/env.mach
+++ b/src/process/env.mach
@@ -9,11 +9,15 @@ use std.types.string.str;
 use os: std.system.os;
 
 # get: read an environment variable into a buffer.
+#
+# when the value fits (ret < cap) it is copied and null-terminated.
+# always returns the full value length, so ret >= cap signals truncation
+# (buffer contents unspecified) and ret + 1 is the capacity to retry with.
 # ---
 # name: variable name
 # buf:  destination buffer
 # cap:  buffer capacity in bytes
-# ret:  length of value, or NOT_FOUND (-1)
+# ret:  full length of value, or negative on error (NOT_FOUND is -1)
 pub fun get(name: str, buf: *u8, cap: usize) i64 {
     ret os.getenv(name, buf, cap);
 }
@@ -46,7 +50,9 @@ var test_buf2: [4096]u8;
 test "env: get PATH is consistent when inherited" {
     val len: i64 = get("PATH", ?test_buf[0], 4096);
     if (len < 0) { ret 0; }
-    if (len >= 4096) { ret 1; }
+    # ret >= cap is truncation under the unified contract (#217); a
+    # truncated value cannot be validated here
+    if (len >= 4096) { ret 0; }
     if (test_buf[len::usize] != 0) { ret 1; }
     val again: i64 = get("PATH", ?test_buf2[0], 4096);
     if (again != len) { ret 1; }
@@ -55,6 +61,19 @@ test "env: get PATH is consistent when inherited" {
         if (test_buf2[i] != test_buf[i]) { ret 1; }
         i = i + 1;
     }
+    ret 0;
+}
+
+var test_small: [4]u8;
+
+# a too-small buffer must still report the full value length so callers
+# can detect truncation (ret >= cap) and size a retry buffer (#217).
+# vacuous when PATH is absent or shorter than the small buffer.
+test "env: get reports full length on truncation" {
+    val len: i64 = get("PATH", ?test_buf[0], 4096);
+    if (len < 4) { ret 0; }
+    val t: i64 = get("PATH", ?test_small[0], 4);
+    if (t != len) { ret 1; }
     ret 0;
 }
 

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -806,8 +806,7 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
         val entry: *u8 = envp[i];
         if (str_starts_with(entry, name) && entry[name_len] == '='::u8) {
             val val_start: usize = name_len + 1;
-            var len: usize = 0;
-            for (entry[val_start + len] != 0) { len = len + 1; }
+            val len: usize = str_len(?entry[val_start]);
             var j: usize = 0;
             for (j < len && j + 1 < cap) {
                 buf[j] = entry[val_start + j];

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -788,11 +788,15 @@ pub fun getcwd(buf: *u8, size: usize) i64 {
 }
 
 # getenv: look up an environment variable by name.
+#
+# when the value fits (ret < cap) it is copied and null-terminated.
+# always returns the full value length, so ret >= cap signals truncation
+# (buffer contents unspecified) and ret + 1 is the capacity to retry with.
 # ---
 # name: null-terminated variable name
 # buf:  destination buffer for the value
 # cap:  buffer capacity in bytes
-# ret:  length of value on success, or NOT_FOUND
+# ret:  full length of the value, or NOT_FOUND
 pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
     if (_envp == 0) { ret os_shared.NOT_FOUND; }
     val envp: **u8 = _envp::**u8;
@@ -801,17 +805,16 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
     for (envp[i]::usize != 0) {
         val entry: *u8 = envp[i];
         if (str_starts_with(entry, name) && entry[name_len] == '='::u8) {
-            if (cap == 0) { ret 0; }
             val val_start: usize = name_len + 1;
+            var len: usize = 0;
+            for (entry[val_start + len] != 0) { len = len + 1; }
             var j: usize = 0;
-            for (entry[val_start + j] != 0 && j < cap - 1) {
+            for (j < len && j + 1 < cap) {
                 buf[j] = entry[val_start + j];
                 j = j + 1;
             }
-            if (j < cap) {
-                buf[j] = 0;
-            }
-            ret j::i64;
+            if (j < cap) { buf[j] = 0; }
+            ret len::i64;
         }
         i = i + 1;
     }

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -940,11 +940,15 @@ pub fun getcwd(buf: *u8, size: usize) i64 {
 }
 
 # getenv: look up an environment variable by name.
+#
+# when the value fits (ret < cap) it is copied and null-terminated.
+# always returns the full value length, so ret >= cap signals truncation
+# (buffer contents unspecified) and ret + 1 is the capacity to retry with.
 # ---
 # name: null-terminated variable name
 # buf:  destination buffer for the value
 # cap:  buffer capacity in bytes
-# ret:  length of value on success, or NOT_FOUND
+# ret:  full length of the value, or NOT_FOUND
 pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
     if (_envp == 0) { ret os_shared.NOT_FOUND; }
     val envp: **u8 = _envp::**u8;
@@ -953,17 +957,16 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
     for (envp[i]::usize != 0) {
         val entry: *u8 = envp[i];
         if (str_starts_with(entry, name) && entry[name_len] == '='::u8) {
-            if (cap == 0) { ret 0; }
             val val_start: usize = name_len + 1;
+            var len: usize = 0;
+            for (entry[val_start + len] != 0) { len = len + 1; }
             var j: usize = 0;
-            for (entry[val_start + j] != 0 && j < cap - 1) {
+            for (j < len && j + 1 < cap) {
                 buf[j] = entry[val_start + j];
                 j = j + 1;
             }
-            if (j < cap) {
-                buf[j] = 0;
-            }
-            ret j::i64;
+            if (j < cap) { buf[j] = 0; }
+            ret len::i64;
         }
         i = i + 1;
     }

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -958,8 +958,7 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
         val entry: *u8 = envp[i];
         if (str_starts_with(entry, name) && entry[name_len] == '='::u8) {
             val val_start: usize = name_len + 1;
-            var len: usize = 0;
-            for (entry[val_start + len] != 0) { len = len + 1; }
+            val len: usize = str_len(?entry[val_start]);
             var j: usize = 0;
             for (j < len && j + 1 < cap) {
                 buf[j] = entry[val_start + j];

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -1211,11 +1211,15 @@ pub fun getcwd(buf: *u8, size: usize) i64 {
 }
 
 # getenv: look up an environment variable by name.
+#
+# when the value fits (ret < cap) it is copied and null-terminated.
+# always returns the full value length, so ret >= cap signals truncation
+# (buffer contents unspecified) and ret + 1 is the capacity to retry with.
 # ---
 # name: null-terminated variable name
 # buf:  destination buffer for the value
 # cap:  buffer capacity in bytes
-# ret:  length of value on success, or NOT_FOUND
+# ret:  full length of the value, NOT_FOUND, or EIO
 pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
     val len: u32 = GetEnvironmentVariableA(name, buf, cap::u32);
     if (len == 0) {
@@ -1224,6 +1228,11 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
             ret os_shared.NOT_FOUND;
         }
         ret EIO;
+    }
+    # on truncation the api reports the required size including the
+    # null terminator; normalize to the value length
+    if (len::usize >= cap) {
+        ret len::i64 - 1;
     }
     ret len::i64;
 }


### PR DESCRIPTION
Closes #217

## What

When the destination buffer was too small, linux/darwin `getenv` returned the COPIED length while windows returned the REQUIRED size (including the null terminator), so callers could not portably detect truncation or size a retry buffer.

All three platforms now share one documented contract:

- `getenv` / `env.get` **always return the full value length** (excluding the null terminator)
- when the value fits (`ret < cap`) it is copied and null-terminated
- `ret >= cap` signals truncation; buffer contents are then unspecified, and `ret + 1` is the capacity to retry with

The contents-unspecified clause exists because `GetEnvironmentVariableA` writes nothing on truncation; linux/darwin still copy what fits, but the portable contract does not promise it.

## Changes

- `src/system/os/linux/shared.mach`, `src/system/os/darwin/shared.mach`: compute the full value length first, copy what fits, null-terminate when `cap > 0`, return the full length; `cap == 0` now returns the required length instead of 0
- `src/system/os/windows/shared.mach`: normalize the API's truncation return (required size including nul) to the value length
- `src/process/env.mach`: document the contract on `get`; add the truncation test deliberately omitted from #214; the PATH consistency test now treats `ret >= cap` as vacuous truncation rather than failure

## Verification

- `mach build .` green
- `mach test .`: 536 passed, 0 failed, 536 total
- env test binaries also run directly with an inherited environment (PATH length 276): the truncation test genuinely exercises the new path (`get` with `cap = 4` returns 276; the old behavior would return 3)
- windows and darwin paths verified by reading only — no execution environment here. The darwin change is byte-identical logic to linux; the windows change relies on documented `GetEnvironmentVariableA` semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)