### PR TITLE
fix(darwin): restructure pipe asm to avoid numeric local labels

### DIFF
--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -19,28 +19,30 @@ pub fun page_size() usize {
 
 # pipe: create a unidirectional pipe.
 #
-# darwin pipe() syscall returns two fds in x0/x1. the syscall DSL only
-# captures x0, so this uses raw asm with a global to capture both.
+# darwin pipe() returns two fds in x0/x1 and signals failure via the
+# carry flag, neither of which the syscall DSL captures, so this uses raw
+# asm. inline-asm branches must target symbols (issue #216), so the carry
+# flag is materialized into a register (`cset`) and the branching happens
+# in mach code instead of the asm block.
 # ---
 # fds: pointer to two i32s; fds[0] = read end, fds[1] = write end
 # ret: 0 on success, or negative errno
 pub fun pipe(fds: *i32) i64 {
-    var result: i64 = 0;
+    var fd0: i64 = 0;
+    var fd1: i64 = 0;
+    var fail: i64 = 0;
     asm aarch64 {
-        mov x9, x0
         mov x16, 42
         svc 0x80
-        b.cs 1f
-        str w0, [x9]
-        str w1, [x9, 4]
-        mov x0, 0
-        b 2f
-    1:
-        neg x0, x0
-    2:
-        str x0, {result}
+        cset x9, cs
+        str x9, {fail}
+        str x0, {fd0}
+        str x1, {fd1}
     }
-    ret result;
+    if (fail != 0) { ret -fd0; }
+    fds[0] = fd0::i32;
+    fds[1] = fd1::i32;
+    ret 0;
 }
 
 # kernel ABI types

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -34,7 +34,7 @@ pub fun pipe(fds: *i32) i64 {
     asm aarch64 {
         mov x16, 42
         svc 0x80
-        cset x9, cs
+        csetm x9, cs             # x9 = -1 when carry set (error), else 0
         str x9, {fail}
         str x0, {fd0}
         str x1, {fd1}

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -19,28 +19,31 @@ pub fun page_size() usize {
 
 # pipe: create a unidirectional pipe.
 #
-# darwin pipe() syscall returns two fds in eax/edx. the syscall DSL only
-# captures eax, so this uses raw asm with a global to capture both.
+# darwin pipe() returns two fds in rax/rdx and signals failure via the
+# carry flag, neither of which the syscall DSL captures, so this uses raw
+# asm. the inline-asm encoder only branches to symbols (issue #216) and
+# has no CF-reading mnemonic, so the carry flag is materialized into a
+# register (`sbb rcx, rcx` via `.byte`) and the branching happens in mach
+# code instead of the asm block.
 # ---
 # fds: pointer to two i32s; fds[0] = read end, fds[1] = write end
 # ret: 0 on success, or negative errno
 pub fun pipe(fds: *i32) i64 {
-    var result: i64 = 0;
+    var fd0: i64 = 0;
+    var fd1: i64 = 0;
+    var fail: i64 = 0;
     asm x86_64 {
-        mov r8, rdi
         mov eax, 0x200002A
         syscall
-        jc 1f
-        mov [r8], eax
-        mov [r8+4], edx
-        xor eax, eax
-        jmp 2f
-    1:
-        neg rax
-    2:
-        mov {result}, rax
+        .byte 0x48, 0x19, 0xC9   # sbb rcx, rcx: rcx = -1 when carry set (error), else 0
+        mov {fail}, rcx
+        mov {fd0}, rax
+        mov {fd1}, rdx
     }
-    ret result;
+    if (fail != 0) { ret -fd0; }
+    fds[0] = fd0::i32;
+    fds[1] = fd1::i32;
+    ret 0;
 }
 
 # kernel ABI types


### PR DESCRIPTION
Closes #216

## What

Rewrites `pipe` in `src/system/os/darwin/x86_64.mach` and `src/system/os/darwin/aarch64.mach` so the inline asm contains no intra-block branches or numeric local labels (`1:`, `jc 1f`, `jmp 2f`, `b.cs 1f`, ...).

The x64 inline-asm encoder turns out to be stricter than the issue states: `jc`/`jnc` are not recognized mnemonics at all (the old code dies with `unknown x86_64 inline-asm instruction 'jc 1f'` before even reaching the symbol-target check), and the supported set (`je`/`jz`/`jne`/`jnz`/`jmp`/`call`, all symbol-target) has no way to read the carry flag — so the pinned-symbol pattern from #212 cannot express a carry-conditional branch either. Instead the asm now materializes CF into a register and all branching happens in mach code:

- **x86_64**: `sbb rcx, rcx` after `syscall` (rcx = -1 on error, 0 on success). The encoder has no `sbb`/`setc` mnemonic, so it is emitted via the `.byte 0x48, 0x19, 0xC9` escape hatch with a comment giving the instruction. Adding `sbb` (or `jc`/`jnc`) to the encoder in octalide/mach would let this be written as a plain mnemonic later.
- **aarch64**: `cset x9, cs`. No raw-byte hatch needed — but note the arm64 backend currently has no inline-asm support at all (`emit_asm = nil` in `target/isa/arm64.mach`), so this file remains aspirational regardless of syntax.

The fd stores moved out of the asm block into mach code (`fds[0]`/`fds[1]`), which also removes the old code's fragile assumption that the `fds` argument was still sitting in `rdi`/`x0` at asm entry.

## Verification

No darwin CI exists yet (octalide/mach#1178), so darwin behavior at runtime cannot be verified. What was verified:

- `mach build .` and `mach test .` on linux: **535 passed, 0 failed** (darwin modules are $if-gated out of the linux build, so this only guards against collateral damage).
- **Encode-stage proof** via a scratch project targeting darwin/x86_64 (Mach-O serialization is a stub, but it runs *after* the object image — including inline-asm encoding — is built):
  - old pipe body: fails encode with `unknown x86_64 inline-asm instruction 'jc 1f'`
  - new pipe body (verbatim from this branch): passes parse, typecheck, isel, and encode; only the `macho not implemented` writer stub fails
- Same function built for the **linux** target and disassembled: `objdump` shows exactly `syscall; sbb %rcx,%rcx; mov %rcx,-0x30(%rbp); mov %rax,...; mov %rdx,...` and correct `fds[0]`/`fds[1]` 32-bit stores — confirming the `.byte` bytes and operand forms.
- Grep confirms no numeric labels remain in either file.

## Out of scope (found while fixing)

- `src/system/os/darwin/shared.mach` has the **same numeric-label pattern in all 7 syscall wrappers × both arches** (`jnc 1f` / `b.cc 1f`, 14 sites) — equally dead-on-arrival at encode.
- A darwin-target typecheck of the std tree fails on three pre-existing errors before ever reaching encode: `unresolved type name usize` (darwin/x86_64.mach:16) and two cast errors in darwin/shared.mach (lines 676, 778).

I'll file follow-up issues for both unless they're already tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)