### PR TITLE
fix(darwin): clear pre-existing typecheck errors in darwin os tree

### DIFF
--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -3,6 +3,8 @@
 # provides page_size and pipe which require arch-specific assembly.
 # everything else is in shared.mach.
 
+use std.types.size.usize;
+
 use shared: std.system.os.darwin.shared;
 
 $if ($mach.target.os != $mach.os.darwin) {

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -673,7 +673,7 @@ pub fun make_dir(dirfd: i32, path: *u8, mode: i32) i64 {
 # darwin uses getdirentries64 instead of getdents64.
 pub fun read_dir(fd: i32, dirp: *dirent64, count: usize) i64 {
     var basep: i64 = 0;
-    ret syscall4(SYS_GETDIRENTRIES64, fd::isize::usize, dirp::usize, count, ?basep::usize);
+    ret syscall4(SYS_GETDIRENTRIES64, fd::isize::usize, dirp::usize, count, (?basep)::usize);
 }
 
 pub fun access(dirfd: i32, path: *u8, mode: i32, flags: i32) i64 {
@@ -775,7 +775,7 @@ pub fun sleep(nsec: i64) {
     var tv: timeval;
     tv.tv_sec = sec;
     tv.tv_usec = usec::i32;
-    syscall5(SYS_SELECT, 0, 0, 0, 0, ?tv::usize);
+    syscall5(SYS_SELECT, 0, 0, 0, 0, (?tv)::usize);
 }
 
 # getcwd: get the current working directory.

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -3,6 +3,8 @@
 # provides page_size and pipe which require arch-specific assembly.
 # everything else is in shared.mach.
 
+use std.types.size.usize;
+
 use shared: std.system.os.darwin.shared;
 
 $if ($mach.target.os != $mach.os.darwin) {


### PR DESCRIPTION
Closes #224

## What

Fixes the three pre-existing typecheck errors that blocked any darwin-target
build of the std tree before codegen (bit-rot found while verifying #216 / PR #222).

- **`usize` unimported** — `darwin/x86_64.mach` and `darwin/aarch64.mach`
  declare `page_size() usize` but never imported `std.types.size.usize`,
  so a darwin typecheck failed with `unresolved type name usize`. Added the
  import to both, matching `linux/x86_64.mach`.
- **`?basep::usize` (shared.mach:676)** — `?x::usize` parses as `?(x::usize)`
  (cast binds tighter than address-of), yielding `*u64` where `syscall4`
  expects `usize`. Wrapped as `(?basep)::usize`.
- **`?tv::usize` (shared.mach:778)** — same precedence trap; the inner cast
  tried to convert a `timeval` struct (`cast: conversion is invalid`). Wrapped
  as `(?tv)::usize`. Both now match the already-correct `(?rl[0])::usize` site.

No change beyond what typecheck requires.

## How far the darwin build now gets

Reproduced with a scratch project targeting `darwin` (`isa x86_64, os darwin,
abi sysv64`) with a `path` dep on this tree, `use std.system.os`, `mach build`:

- **before:** dies in **sema** with the three errors above (never reaches codegen).
- **after:** **typecheck → lower/isel → encode** all proceed; the build now dies
  in the inline-asm **encode** stage on the `darwin/shared.mach` syscall wrappers'
  numeric local labels (`jnc 1f`), which is the separate, already-tracked **#223**
  — *not* the Mach-O writer stub (that is further still). #224's typecheck scope
  is fully cleared.

`darwin/aarch64` cannot be built end-to-end by the current toolchain
(`mach 1.4.1` returns `no abi implementation registered` at target setup, before
sema), so its typecheck couldn't be independently confirmed via a build — but its
fix is the identical `usize` import plus the shared `shared.mach` casts.

## Verification

- Linux collateral guard: `mach build .` clean, `mach test .` **536 passed, 0 failed**.
- darwin/x86_64 scratch build: confirmed reaching encode (#223), past all of #224.

Runtime verification of darwin behavior waits on darwin CI (octalide/mach#1178).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
