### PR TITLE
feat(process): child stdout capture primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `std.process.exec.capture(pathname, argv, envp, buf, cap) Result[Capture, str]`
+  — run a child and collect its stdout into `buf`, draining the pipe to EOF so a
+  child outproducing the buffer never blocks; reports the full output length so
+  truncation (`len > cap`) is detectable, mirroring the `env.get` contract.
+  Backed by a new `std.system.os.spawn_captured` fd-redirection primitive
+  (fork + dup2 + exec, sharing `spawn`'s inherited-fd close path) on linux and
+  darwin; windows returns `ENOTSUP` until #221 (#188, capture half).
+
 ## [0.6.0] - 2026-06-12
 
 Bug-clearing release: all three known-failing tests are fixed for real (thread

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `std.process.exec.capture(pathname, argv, envp, buf, cap) Result[Capture, str]`
   — run a child and collect its stdout into `buf`, draining the pipe to EOF so a
-  child outproducing the buffer never blocks; reports the full output length so
-  truncation (`len > cap`) is detectable, mirroring the `env.get` contract.
-  Backed by a new `std.system.os.spawn_captured` fd-redirection primitive
-  (fork + dup2 + exec, sharing `spawn`'s inherited-fd close path) on linux and
-  darwin; windows returns `ENOTSUP` until #221 (#188, capture half).
+  child outproducing the buffer never blocks; always reports the full output
+  length, so `len > cap` signals truncation (raw bytes, no terminator slot — a
+  `len == cap` capture is complete, unlike `env.get` whose boundary is
+  `ret >= cap`). Backed by a new `std.system.os.spawn_redirected(pathname,
+  argv, envp, stdin_fd, stdout_fd, stderr_fd)` stdio-redirection primitive
+  (fork + per-stream dup2 + exec, -1 inheriting the parent's stream; child
+  exits 126 on redirect failure, 127 on exec failure) on linux and darwin,
+  onto which `spawn` now collapses; windows returns `ENOTSUP` until #221
+  (#188, capture half).
 
 ## [0.6.0] - 2026-06-12
 

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -1,6 +1,7 @@
 # process spawning and management.
 
 use std.types.bool.bool;
+use std.types.bool.true;
 use std.types.size.usize;
 use std.types.result.Result;
 use std.types.result.ok;
@@ -25,6 +26,16 @@ pub rec Child {
     pid: i64;
 }
 
+# Capture: result of running a child process and collecting its stdout.
+# ---
+# status: exit status of the child process
+# len:    total bytes the child wrote to stdout; a len greater than the
+#         destination capacity signals the captured output was truncated
+pub rec Capture {
+    status: ExitStatus;
+    len:    usize;
+}
+
 # run: spawn a process and wait for it to exit.
 # ---
 # pathname: path to executable
@@ -40,6 +51,63 @@ pub fun run(pathname: str, argv: **u8, envp: **u8) Result[ExitStatus, str] {
     if (r < 0) { ret err[ExitStatus, str]("wait failed"); }
 
     ret ok[ExitStatus, str](ExitStatus{raw: wstatus});
+}
+
+# capture: run a process and collect its standard output into a buffer.
+#
+# spawns the child with its stdout connected to a pipe, drains the pipe
+# to end-of-file (so a child producing more than buf holds never blocks),
+# waits for exit, and reports the full output length. at most cap bytes
+# are stored in buf; a returned len greater than cap signals truncation
+# and the capacity to retry with. buf holds raw bytes and is not
+# null-terminated.
+# ---
+# pathname: path to executable
+# argv:     null-terminated argument array
+# envp:     null-terminated environment array
+# buf:      destination buffer for captured stdout
+# cap:      buffer capacity in bytes
+# ret:      capture result (exit status and full output length), or an error
+pub fun capture(pathname: str, argv: **u8, envp: **u8, buf: *u8, cap: usize) Result[Capture, str] {
+    var fds: [2]i32;
+    if (os.pipe(?fds[0]) < 0) { ret err[Capture, str]("pipe failed"); }
+
+    val pid: i64 = os.spawn_captured(pathname, argv, envp, fds[1]);
+    if (pid < 0) {
+        os.close(fds[0]);
+        os.close(fds[1]);
+        ret err[Capture, str]("spawn failed");
+    }
+
+    # the parent never writes; closing its write end lets read see EOF
+    # once the child's stdout closes
+    os.close(fds[1]);
+
+    var wstatus: i32 = 0;
+    var total: usize = 0;
+    var scratch: [4096]u8;
+    for (true) {
+        var dst: *u8 = ?scratch[0];
+        var want: usize = 4096;
+        if (total < cap) {
+            dst = (buf::usize + total)::*u8;
+            want = cap - total;
+        }
+        val n: i64 = os.read(fds[0], dst, want);
+        if (n < 0) {
+            os.close(fds[0]);
+            os.wait_pid(pid, ?wstatus, 0);
+            ret err[Capture, str]("read failed");
+        }
+        if (n == 0) { brk; }
+        total = total + n::usize;
+    }
+    os.close(fds[0]);
+
+    val r: i64 = os.wait_pid(pid, ?wstatus, 0);
+    if (r < 0) { ret err[Capture, str]("wait failed"); }
+
+    ret ok[Capture, str](Capture{status: ExitStatus{raw: wstatus}, len: total});
 }
 
 # spawn: start a process without waiting.
@@ -111,6 +179,14 @@ fun make_argv1(prog: str) [2]usize {
     ret buf;
 }
 
+fun make_argv2(prog: str, a1: str) [3]usize {
+    var buf: [3]usize;
+    buf[0] = prog::usize;
+    buf[1] = a1::usize;
+    buf[2] = 0;
+    ret buf;
+}
+
 test "exec: run /bin/true exits 0" {
     var argv: [2]usize = make_argv1("/bin/true");
     val r: Result[ExitStatus, str] = run("/bin/true", (?argv[0])::**u8, nil);
@@ -141,5 +217,41 @@ test "exec: spawn and wait matches run" {
     val s: ExitStatus = unwrap_ok[ExitStatus, str](wr);
     if (!exited(s)) { ret 1; }
     if (code(s) != 0) { ret 1; }
+    ret 0;
+}
+
+var cap_buf: [64]u8;
+
+test "exec: capture /bin/echo stdout" {
+    var argv: [3]usize = make_argv2("/bin/echo", "hello");
+    val r: Result[Capture, str] = capture("/bin/echo", (?argv[0])::**u8, nil, ?cap_buf[0], 64);
+    if (is_err[Capture, str](r)) { ret 1; }
+    val c: Capture = unwrap_ok[Capture, str](r);
+    if (!exited(c.status)) { ret 1; }
+    if (code(c.status) != 0) { ret 1; }
+    if (c.len != 6) { ret 1; }
+    if (cap_buf[0] != 'h') { ret 1; }
+    if (cap_buf[1] != 'e') { ret 1; }
+    if (cap_buf[2] != 'l') { ret 1; }
+    if (cap_buf[3] != 'l') { ret 1; }
+    if (cap_buf[4] != 'o') { ret 1; }
+    if (cap_buf[5] != '\n') { ret 1; }
+    ret 0;
+}
+
+var cap_small: [2]u8;
+
+# a buffer too small must still report the full output length so callers
+# can detect truncation (len > cap) and size a retry buffer; the pipe is
+# drained past the buffer so the child never blocks.
+test "exec: capture reports full length on truncation" {
+    var argv: [3]usize = make_argv2("/bin/echo", "hello");
+    val r: Result[Capture, str] = capture("/bin/echo", (?argv[0])::**u8, nil, ?cap_small[0], 2);
+    if (is_err[Capture, str](r)) { ret 1; }
+    val c: Capture = unwrap_ok[Capture, str](r);
+    if (code(c.status) != 0) { ret 1; }
+    if (c.len != 6) { ret 1; }
+    if (cap_small[0] != 'h') { ret 1; }
+    if (cap_small[1] != 'e') { ret 1; }
     ret 0;
 }

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -58,9 +58,11 @@ pub fun run(pathname: str, argv: **u8, envp: **u8) Result[ExitStatus, str] {
 # spawns the child with its stdout connected to a pipe, drains the pipe
 # to end-of-file (so a child producing more than buf holds never blocks),
 # waits for exit, and reports the full output length. at most cap bytes
-# are stored in buf; a returned len greater than cap signals truncation
-# and the capacity to retry with. buf holds raw bytes and is not
-# null-terminated.
+# are stored in buf; len <= cap means the whole output was stored, while
+# len > cap means exactly cap bytes were stored and len is the capacity
+# to retry with. buf holds raw bytes and is not null-terminated (unlike
+# env.get, no byte is reserved for a terminator, so a len == cap capture
+# is complete).
 # ---
 # pathname: path to executable
 # argv:     null-terminated argument array
@@ -72,7 +74,7 @@ pub fun capture(pathname: str, argv: **u8, envp: **u8, buf: *u8, cap: usize) Res
     var fds: [2]i32;
     if (os.pipe(?fds[0]) < 0) { ret err[Capture, str]("pipe failed"); }
 
-    val pid: i64 = os.spawn_captured(pathname, argv, envp, fds[1]);
+    val pid: i64 = os.spawn_redirected(pathname, argv, envp, -1, fds[1], -1);
     if (pid < 0) {
         os.close(fds[0]);
         os.close(fds[1]);

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -136,7 +136,7 @@ fwd impl.seek;
 fwd impl.terminate;
 fwd impl.abort;
 fwd impl.spawn;
-fwd impl.spawn_captured;
+fwd impl.spawn_redirected;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -136,6 +136,7 @@ fwd impl.seek;
 fwd impl.terminate;
 fwd impl.abort;
 fwd impl.spawn;
+fwd impl.spawn_captured;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -127,6 +127,7 @@ fwd impl.seek;
 fwd impl.terminate;
 fwd impl.abort;
 fwd impl.spawn;
+fwd impl.spawn_captured;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -127,7 +127,7 @@ fwd impl.seek;
 fwd impl.terminate;
 fwd impl.abort;
 fwd impl.spawn;
-fwd impl.spawn_captured;
+fwd impl.spawn_redirected;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -128,6 +128,7 @@ fwd shared.syscall6;
 fwd shared.terminate;
 fwd shared.abort;
 fwd shared.spawn;
+fwd shared.spawn_captured;
 fwd shared.getpid;
 fwd shared.sleep;
 fwd shared.getcwd;

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -128,7 +128,7 @@ fwd shared.syscall6;
 fwd shared.terminate;
 fwd shared.abort;
 fwd shared.spawn;
-fwd shared.spawn_captured;
+fwd shared.spawn_redirected;
 fwd shared.getpid;
 fwd shared.sleep;
 fwd shared.getcwd;

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -738,12 +738,18 @@ fwd os_shared.was_continued;
 #
 # used by the child between fork and exec to avoid leaking parent FDs
 # (pipes, sockets, etc.); darwin has no close_range, so it walks up to
-# the open-file limit.
+# the open-file limit. limits beyond i32 range (e.g. RLIM_INFINITY)
+# fall back to OPEN_MAX (10240) instead of wrapping negative.
 fun close_inherited_fds() {
     var rl: [2]u64;
     var max_fd: i32 = 1024;
     if (syscall2(SYS_GETRLIMIT, RLIMIT_NOFILE, (?rl[0])::usize) == 0 && rl[0] > 0) {
-        max_fd = rl[0]::i32;
+        if (rl[0] <= 2147483647) {
+            max_fd = rl[0]::i32;
+        }
+        or {
+            max_fd = 10240;
+        }
     }
     var fd: i32 = 3;
     for (fd < max_fd) {
@@ -762,37 +768,41 @@ fun close_inherited_fds() {
 # envp:     null-terminated environment array
 # ret:      child PID on success, or negative errno
 pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
-    val pid: i64 = fork();
-    if (pid < 0) {
-        ret pid;
-    }
-    if (pid == 0) {
-        close_inherited_fds();
-        exec(pathname, argv, envp);
-        syscall1(SYS_EXIT, 127);
-    }
-    ret pid;
+    ret spawn_redirected(pathname, argv, envp, -1, -1, -1);
 }
 
-# spawn_captured: spawn a child with its standard output bound to a descriptor.
+# spawn_redirected: spawn a child with its standard streams bound to
+# caller-supplied descriptors.
 #
-# forks, duplicates stdout_fd onto the child's stdout, closes inherited
+# forks, duplicates each non-negative descriptor onto the matching
+# standard stream (-1 inherits the parent's stream), closes inherited
 # descriptors >= 3 (including both ends of a capture pipe), and execs.
-# the parent keeps ownership of stdout_fd; pairing it with a pipe write
-# end lets the parent read the child's output from the matching read end.
+# the parent keeps ownership of the passed descriptors; pairing one with
+# a pipe end lets the parent stream the child's stdio. the child exits
+# 126 when a redirect fails and 127 when exec fails.
 # ---
 # pathname:  path to executable
 # argv:      null-terminated argument array
 # envp:      null-terminated environment array
-# stdout_fd: descriptor to install as the child's stdout
+# stdin_fd:  descriptor to install as the child's stdin, or -1 to inherit
+# stdout_fd: descriptor to install as the child's stdout, or -1 to inherit
+# stderr_fd: descriptor to install as the child's stderr, or -1 to inherit
 # ret:       child PID on success, or negative errno
-pub fun spawn_captured(pathname: *u8, argv: **u8, envp: **u8, stdout_fd: i32) i64 {
+pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, stdout_fd: i32, stderr_fd: i32) i64 {
     val pid: i64 = fork();
     if (pid < 0) {
         ret pid;
     }
     if (pid == 0) {
-        syscall2(SYS_DUP2, stdout_fd::isize::usize, STDOUT_FD::isize::usize);
+        if (stdin_fd != -1 && syscall2(SYS_DUP2, stdin_fd::isize::usize, STDIN_FD::isize::usize) < 0) {
+            syscall1(SYS_EXIT, 126);
+        }
+        if (stdout_fd != -1 && syscall2(SYS_DUP2, stdout_fd::isize::usize, STDOUT_FD::isize::usize) < 0) {
+            syscall1(SYS_EXIT, 126);
+        }
+        if (stderr_fd != -1 && syscall2(SYS_DUP2, stderr_fd::isize::usize, STDERR_FD::isize::usize) < 0) {
+            syscall1(SYS_EXIT, 126);
+        }
         close_inherited_fds();
         exec(pathname, argv, envp);
         syscall1(SYS_EXIT, 127);

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -64,6 +64,7 @@ val SYS_LISTEN:           usize = 106;
 val SYS_SETSOCKOPT:       usize = 105;
 val SYS_GETRLIMIT:        usize = 194;
 val RLIMIT_NOFILE:        usize = 8;
+val SYS_DUP2:             usize = 90;
 
 val SIGABRT: i32 = 6;
 
@@ -733,6 +734,24 @@ fwd os_shared.was_stopped;
 fwd os_shared.stop_signal;
 fwd os_shared.was_continued;
 
+# close_inherited_fds: close every file descriptor >= 3 in the caller.
+#
+# used by the child between fork and exec to avoid leaking parent FDs
+# (pipes, sockets, etc.); darwin has no close_range, so it walks up to
+# the open-file limit.
+fun close_inherited_fds() {
+    var rl: [2]u64;
+    var max_fd: i32 = 1024;
+    if (syscall2(SYS_GETRLIMIT, RLIMIT_NOFILE, (?rl[0])::usize) == 0 && rl[0] > 0) {
+        max_fd = rl[0]::i32;
+    }
+    var fd: i32 = 3;
+    for (fd < max_fd) {
+        syscall1(SYS_CLOSE, fd::isize::usize);
+        fd = fd + 1;
+    }
+}
+
 # spawn: create a child process running the given program.
 #
 # closes inherited file descriptors >= 3 in the child before exec to
@@ -748,16 +767,33 @@ pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
         ret pid;
     }
     if (pid == 0) {
-        var rl: [2]u64;
-        var max_fd: i32 = 1024;
-        if (syscall2(SYS_GETRLIMIT, RLIMIT_NOFILE, (?rl[0])::usize) == 0 && rl[0] > 0) {
-            max_fd = rl[0]::i32;
-        }
-        var fd: i32 = 3;
-        for (fd < max_fd) {
-            syscall1(SYS_CLOSE, fd::isize::usize);
-            fd = fd + 1;
-        }
+        close_inherited_fds();
+        exec(pathname, argv, envp);
+        syscall1(SYS_EXIT, 127);
+    }
+    ret pid;
+}
+
+# spawn_captured: spawn a child with its standard output bound to a descriptor.
+#
+# forks, duplicates stdout_fd onto the child's stdout, closes inherited
+# descriptors >= 3 (including both ends of a capture pipe), and execs.
+# the parent keeps ownership of stdout_fd; pairing it with a pipe write
+# end lets the parent read the child's output from the matching read end.
+# ---
+# pathname:  path to executable
+# argv:      null-terminated argument array
+# envp:      null-terminated environment array
+# stdout_fd: descriptor to install as the child's stdout
+# ret:       child PID on success, or negative errno
+pub fun spawn_captured(pathname: *u8, argv: **u8, envp: **u8, stdout_fd: i32) i64 {
+    val pid: i64 = fork();
+    if (pid < 0) {
+        ret pid;
+    }
+    if (pid == 0) {
+        syscall2(SYS_DUP2, stdout_fd::isize::usize, STDOUT_FD::isize::usize);
+        close_inherited_fds();
         exec(pathname, argv, envp);
         syscall1(SYS_EXIT, 127);
     }

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -129,7 +129,7 @@ fwd shared.syscall6;
 fwd shared.terminate;
 fwd shared.abort;
 fwd shared.spawn;
-fwd shared.spawn_captured;
+fwd shared.spawn_redirected;
 fwd shared.getpid;
 fwd shared.sleep;
 fwd shared.getcwd;

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -129,6 +129,7 @@ fwd shared.syscall6;
 fwd shared.terminate;
 fwd shared.abort;
 fwd shared.spawn;
+fwd shared.spawn_captured;
 fwd shared.getpid;
 fwd shared.sleep;
 fwd shared.getcwd;

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -133,7 +133,7 @@ fwd impl.seek;
 fwd impl.terminate;
 fwd impl.abort;
 fwd impl.spawn;
-fwd impl.spawn_captured;
+fwd impl.spawn_redirected;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -133,6 +133,7 @@ fwd impl.seek;
 fwd impl.terminate;
 fwd impl.abort;
 fwd impl.spawn;
+fwd impl.spawn_captured;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -66,6 +66,7 @@ $if ($mach.target.arch == $mach.arch.x86_64) {
     val SYS_GETRANDOM:     usize = 318;
     val SYS_GETCPU:        usize = 309;
     val SYS_CLOSE_RANGE:   usize = 436;
+    val SYS_DUP2:          usize = 33;
 
     pub val FUTEX_WAIT: usize = 0;
     pub val FUTEX_WAKE: usize = 1;
@@ -875,6 +876,22 @@ fwd os_shared.was_stopped;
 fwd os_shared.stop_signal;
 fwd os_shared.was_continued;
 
+# close_inherited_fds: close every file descriptor >= 3 in the caller.
+#
+# used by the child between fork and exec to avoid leaking parent FDs
+# (pipes, sockets, etc.); falls back to a bounded loop when close_range
+# is unavailable.
+fun close_inherited_fds() {
+    val r: i64 = syscall3(SYS_CLOSE_RANGE, 3, ~(0::usize), 0);
+    if (r < 0) {
+        var fd: i32 = 3;
+        for (fd < 1024) {
+            syscall1(SYS_CLOSE, fd::isize::usize);
+            fd = fd + 1;
+        }
+    }
+}
+
 # spawn: create a child process running the given program.
 #
 # closes inherited file descriptors >= 3 in the child before exec to
@@ -890,14 +907,33 @@ pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
         ret pid;
     }
     if (pid == 0) {
-        val r: i64 = syscall3(SYS_CLOSE_RANGE, 3, ~(0::usize), 0);
-        if (r < 0) {
-            var fd: i32 = 3;
-            for (fd < 1024) {
-                syscall1(SYS_CLOSE, fd::isize::usize);
-                fd = fd + 1;
-            }
-        }
+        close_inherited_fds();
+        exec(pathname, argv, envp);
+        syscall1(SYS_EXIT_GROUP, 127);
+    }
+    ret pid;
+}
+
+# spawn_captured: spawn a child with its standard output bound to a descriptor.
+#
+# forks, duplicates stdout_fd onto the child's stdout, closes inherited
+# descriptors >= 3 (including both ends of a capture pipe), and execs.
+# the parent keeps ownership of stdout_fd; pairing it with a pipe write
+# end lets the parent read the child's output from the matching read end.
+# ---
+# pathname:  path to executable
+# argv:      null-terminated argument array
+# envp:      null-terminated environment array
+# stdout_fd: descriptor to install as the child's stdout
+# ret:       child PID on success, or negative errno
+pub fun spawn_captured(pathname: *u8, argv: **u8, envp: **u8, stdout_fd: i32) i64 {
+    val pid: i64 = fork();
+    if (pid < 0) {
+        ret pid;
+    }
+    if (pid == 0) {
+        syscall2(SYS_DUP2, stdout_fd::isize::usize, STDOUT_FD::isize::usize);
+        close_inherited_fds();
         exec(pathname, argv, envp);
         syscall1(SYS_EXIT_GROUP, 127);
     }

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -902,37 +902,41 @@ fun close_inherited_fds() {
 # envp:     null-terminated environment array
 # ret:      child PID on success, or negative errno
 pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
-    val pid: i64 = fork();
-    if (pid < 0) {
-        ret pid;
-    }
-    if (pid == 0) {
-        close_inherited_fds();
-        exec(pathname, argv, envp);
-        syscall1(SYS_EXIT_GROUP, 127);
-    }
-    ret pid;
+    ret spawn_redirected(pathname, argv, envp, -1, -1, -1);
 }
 
-# spawn_captured: spawn a child with its standard output bound to a descriptor.
+# spawn_redirected: spawn a child with its standard streams bound to
+# caller-supplied descriptors.
 #
-# forks, duplicates stdout_fd onto the child's stdout, closes inherited
+# forks, duplicates each non-negative descriptor onto the matching
+# standard stream (-1 inherits the parent's stream), closes inherited
 # descriptors >= 3 (including both ends of a capture pipe), and execs.
-# the parent keeps ownership of stdout_fd; pairing it with a pipe write
-# end lets the parent read the child's output from the matching read end.
+# the parent keeps ownership of the passed descriptors; pairing one with
+# a pipe end lets the parent stream the child's stdio. the child exits
+# 126 when a redirect fails and 127 when exec fails.
 # ---
 # pathname:  path to executable
 # argv:      null-terminated argument array
 # envp:      null-terminated environment array
-# stdout_fd: descriptor to install as the child's stdout
+# stdin_fd:  descriptor to install as the child's stdin, or -1 to inherit
+# stdout_fd: descriptor to install as the child's stdout, or -1 to inherit
+# stderr_fd: descriptor to install as the child's stderr, or -1 to inherit
 # ret:       child PID on success, or negative errno
-pub fun spawn_captured(pathname: *u8, argv: **u8, envp: **u8, stdout_fd: i32) i64 {
+pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, stdout_fd: i32, stderr_fd: i32) i64 {
     val pid: i64 = fork();
     if (pid < 0) {
         ret pid;
     }
     if (pid == 0) {
-        syscall2(SYS_DUP2, stdout_fd::isize::usize, STDOUT_FD::isize::usize);
+        if (stdin_fd != -1 && syscall2(SYS_DUP2, stdin_fd::isize::usize, STDIN_FD::isize::usize) < 0) {
+            syscall1(SYS_EXIT_GROUP, 126);
+        }
+        if (stdout_fd != -1 && syscall2(SYS_DUP2, stdout_fd::isize::usize, STDOUT_FD::isize::usize) < 0) {
+            syscall1(SYS_EXIT_GROUP, 126);
+        }
+        if (stderr_fd != -1 && syscall2(SYS_DUP2, stderr_fd::isize::usize, STDERR_FD::isize::usize) < 0) {
+            syscall1(SYS_EXIT_GROUP, 126);
+        }
         close_inherited_fds();
         exec(pathname, argv, envp);
         syscall1(SYS_EXIT_GROUP, 127);

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -240,7 +240,7 @@ fwd shared.seek;
 fwd shared.terminate;
 fwd shared.abort;
 fwd shared.spawn;
-fwd shared.spawn_captured;
+fwd shared.spawn_redirected;
 fwd shared.getpid;
 fwd shared.pipe;
 fwd shared.sleep;

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -240,6 +240,7 @@ fwd shared.seek;
 fwd shared.terminate;
 fwd shared.abort;
 fwd shared.spawn;
+fwd shared.spawn_captured;
 fwd shared.getpid;
 fwd shared.pipe;
 fwd shared.sleep;

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -115,7 +115,7 @@ fwd impl.seek;
 fwd impl.terminate;
 fwd impl.abort;
 fwd impl.spawn;
-fwd impl.spawn_captured;
+fwd impl.spawn_redirected;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -115,6 +115,7 @@ fwd impl.seek;
 fwd impl.terminate;
 fwd impl.abort;
 fwd impl.spawn;
+fwd impl.spawn_captured;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -1155,17 +1155,21 @@ pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
     ret pi.dwProcessId::i64;
 }
 
-# spawn_captured: spawn a child with its standard output bound to a descriptor.
+# spawn_redirected: spawn a child with its standard streams bound to
+# caller-supplied descriptors (-1 inherits the parent's stream).
 #
 # unimplemented on windows, which needs STARTUPINFO handle inheritance
+# (STARTF_USESTDHANDLES with all three of hStdInput/hStdOutput/hStdError)
 # rather than the posix fork/dup2/exec path; tracked by issue #221.
 # ---
 # pathname:  path to executable
 # argv:      null-terminated argument array
 # envp:      null-terminated environment array
-# stdout_fd: descriptor to install as the child's stdout
+# stdin_fd:  descriptor to install as the child's stdin, or -1 to inherit
+# stdout_fd: descriptor to install as the child's stdout, or -1 to inherit
+# stderr_fd: descriptor to install as the child's stderr, or -1 to inherit
 # ret:       ENOTSUP until windows support lands
-pub fun spawn_captured(pathname: *u8, argv: **u8, envp: **u8, stdout_fd: i32) i64 {
+pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, stdout_fd: i32, stderr_fd: i32) i64 {
     ret ENOTSUP;
 }
 

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -1155,6 +1155,20 @@ pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
     ret pi.dwProcessId::i64;
 }
 
+# spawn_captured: spawn a child with its standard output bound to a descriptor.
+#
+# unimplemented on windows, which needs STARTUPINFO handle inheritance
+# rather than the posix fork/dup2/exec path; tracked by issue #221.
+# ---
+# pathname:  path to executable
+# argv:      null-terminated argument array
+# envp:      null-terminated environment array
+# stdout_fd: descriptor to install as the child's stdout
+# ret:       ENOTSUP until windows support lands
+pub fun spawn_captured(pathname: *u8, argv: **u8, envp: **u8, stdout_fd: i32) i64 {
+    ret ENOTSUP;
+}
+
 # getpid: return the current process ID.
 # ---
 # ret: process ID

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -114,6 +114,7 @@ fwd shared.seek;
 fwd shared.terminate;
 fwd shared.abort;
 fwd shared.spawn;
+fwd shared.spawn_captured;
 fwd shared.getpid;
 fwd shared.pipe;
 fwd shared.sleep;

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -114,7 +114,7 @@ fwd shared.seek;
 fwd shared.terminate;
 fwd shared.abort;
 fwd shared.spawn;
-fwd shared.spawn_captured;
+fwd shared.spawn_redirected;
 fwd shared.getpid;
 fwd shared.pipe;
 fwd shared.sleep;


### PR DESCRIPTION
Implements the remaining half of #188: the child stdout capture / fd-redirection primitive for `std.process.exec`. The `environ()` half landed in #215.

## API

- `std.process.exec.capture(pathname, argv, envp, buf, cap) Result[Capture, str]` — run a child and collect its stdout. Connects the child's stdout to a pipe, drains it to EOF (so a child outproducing `buf` never deadlocks on a full pipe), waits for exit, and reports the full output length. At most `cap` bytes land in `buf`; `len > cap` signals truncation and the capacity to retry with. `buf` holds raw bytes with no terminator slot, so a `len == cap` capture is complete (capture's own boundary — distinct from `env.get`, which reserves a NUL and truncates at `ret >= cap`).
- `std.process.exec.Capture { status: ExitStatus; len: usize; }` — exit status plus total stdout length.
- `std.system.os.spawn_redirected(pathname, argv, envp, stdin_fd, stdout_fd, stderr_fd) i64` — the underlying OS primitive: fork + per-stream dup2 + close inherited fds + exec. Each descriptor independently redirects its standard stream; `-1` inherits the parent's stream. The child exits 126 when a redirect fails (so a failed dup2 never execs with inherited stdio) and 127 when exec fails. `spawn` collapses onto `spawn_redirected(..., -1, -1, -1)`, eliminating the duplicated fork/close/exec skeleton on linux and darwin. Windows returns `ENOTSUP` until #221, whose `STARTF_USESTDHANDLES` backend maps 1:1 onto the triple signature.

The inherited-fd close path lives in a private `close_inherited_fds` helper on each POSIX backend; the darwin variant guards the `RLIMIT_NOFILE` conversion so limits beyond i32 range (e.g. `RLIM_INFINITY`) fall back to `OPEN_MAX` (10240) instead of wrapping negative and skipping the close loop.

## Tests

`src/process/exec.mach`:
- `exec: capture /bin/echo stdout` — asserts exit 0, `len == 6`, bytes are `hello\n`.
- `exec: capture reports full length on truncation` — 2-byte buffer still reports `len == 6` and stores `he`, exercising the drain-past-buffer path.

## Verification

`mach build` clean; `mach test` 538 passed / 0 failed (+2 new). Darwin and windows backends typecheck clean via `mach check` under their targets (full darwin codegen is blocked on a pre-existing `setc cl` inline-asm issue unrelated to this change; native-darwin `fork()` child-indicator handling is tracked separately as #232).

Windows is out of scope (#221).

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)