### PR TITLE
fix(darwin): read XNU child-indicator register in fork()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- darwin `fork()` now reads the XNU child-indicator register (rdx on
+  x86_64, x1 on aarch64) and returns 0 in the child instead of the child
+  PID, so `spawn`/`spawn_captured` take the exec path in the child rather
+  than duplicating the parent program (#232).
+
 ## [0.6.0] - 2026-06-12
 
 Bug-clearing release: all three known-failing tests are fixed for real (thread

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -698,8 +698,47 @@ pub fun seek(fd: i32, offset: i64, whence: i32) i64 {
 
 # process
 
+# fork: create a child process by duplicating the caller.
+#
+# the XNU fork trap returns the child PID in the primary register
+# (rax/x0) for BOTH processes and flags the child via the second return
+# register (rdx == 1 on x86_64, x1 == 1 on aarch64). a plain syscall0
+# would leave the child seeing pid != 0, so this wrapper reads the child
+# indicator and returns 0 in the child, mirroring libc's fork stub. the
+# carry flag is materialized into `fail` (`setc`/`cset`) and the branch
+# happens in mach code, matching the syscall wrappers and pipe.
+# ---
+# ret: child PID in the parent, 0 in the child, or negative errno
 pub fun fork() i64 {
-    ret syscall0(SYS_FORK);
+    var n: usize = SYS_FORK;
+    var out: i64 = 0;
+    var fail: i64 = 0;
+    var child: i64 = 0;
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, 0x2000000
+            or rax, {n}
+            syscall
+            mov rcx, 0
+            setc cl
+            mov {fail}, rcx
+            mov {out}, rax
+            mov {child}, rdx
+        }
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            mov x16, {n}
+            svc 0x80
+            cset x9, cs
+            str x9, {fail}
+            str x0, {out}
+            str x1, {child}
+        }
+    }
+    if (fail != 0) { ret -out; }
+    if (child != 0) { ret 0; }
+    ret out;
 }
 
 pub fun vfork() i64 {


### PR DESCRIPTION
## Summary

Darwin `fork()` in `src/system/os/darwin/shared.mach` was a plain `syscall0(SYS_FORK)`. On XNU the fork trap returns the child PID in the primary return register (`rax`/`x0`) for **both** parent and child, and flags the child via the second return register (`rdx == 1` on x86_64, `x1 == 1` on aarch64). Because `syscall0` reads only the primary register, the child saw `pid != 0`, so the `if (pid == 0)` branch in `spawn`/`spawn_captured` never ran — the child resumed running the parent program as a duplicate instead of exec'ing.

## Fix

`fork()` is now a per-arch inline-asm wrapper (same shape as the syscall wrappers and `pipe()`): it reads the child-indicator register and returns `0` in the child. Error behaviour is unchanged — a set carry flag still yields the negative errno.

- **x86_64**: `mov rax,0x2000000 / or rax,{n}` (SYS_FORK), `syscall`, `setc cl` into `fail`, `mov {out}, rax`, `mov {child}, rdx`.
- **aarch64**: `mov x16,{n}`, `svc 0x80`, `cset x9, cs` into `fail`, `str x0,{out}`, `str x1,{child}`.

Then in mach code: `fail != 0` → `ret -out` (error); `child != 0` → `ret 0` (child); else `ret out` (parent PID). Carry handling follows the recent `setc`/`cset` sentinel convention.

Scoped strictly to the `fork()` wrapper; `spawn`/`spawn_captured` are untouched to minimise conflict with #231.

## Verification

Darwin codegen is unavailable on the current toolchain (mach 1.4.1), so darwin was validated through the parse/typecheck boundary only:

- `mach build --target darwin_x86` reaches codegen and fails **only** at the pre-existing `error: unknown x86_64 inline-asm instruction 'setc cl'` (the known `setc` codegen gap shared with `pipe()` and the syscall wrappers) — i.e. the whole module, including the new `fork()`, parses and typechecks cleanly.
- `mach build --target darwin_arm` fails at `error: no abi implementation registered` (no aarch64 darwin ABI in the toolchain), before codegen.
- `mach check` is target-agnostic in this toolchain (does not evaluate `$if`/target macros); exits 0 on the edited file.

Temporary darwin targets used for the above were applied to `mach.toml` only during verification and reverted — `mach.toml` is **not** part of this PR.

Linux (no regression — change is darwin-only):

- `mach build` → exit 0
- `mach test` → **536 passed, 0 failed, 536 total**

**Runtime verification on real darwin hardware is pending** (cannot run darwin binaries until darwin codegen/ABI is restored).

Closes #232