### PR TITLE
feat(process): native windows exec backend (CreateProcess)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   argv, envp, stdin_fd, stdout_fd, stderr_fd)` stdio-redirection primitive
   (fork + per-stream dup2 + exec, -1 inheriting the parent's stream; child
   exits 126 on redirect failure, 127 on exec failure) on linux and darwin,
-  onto which `spawn` now collapses; windows returns `ENOTSUP` until #221
-  (#188, capture half).
+  onto which `spawn` now collapses (#188, capture half).
+- Native windows exec backend: `spawn`/`spawn_redirected`/`run`/`capture`
+  over `CreateProcessA` + `WaitForSingleObject` + `GetExitCodeProcess`, with
+  argv joined per the windows command-line quoting rules, `envp` mapped to a
+  CreateProcess environment block (nil inherits), and stdio redirection via
+  `STARTF_USESTDHANDLES` over inheritable handles; the read path now treats a
+  broken anonymous pipe as EOF so `capture` drains cleanly. `environ()` is
+  now populated from `GetEnvironmentStrings` rather than always nil (#221,
+  #188 windows half).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,12 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   onto which `spawn` now collapses (#188, capture half).
 - Native windows exec backend: `spawn`/`spawn_redirected`/`run`/`capture`
   over `CreateProcessA` + `WaitForSingleObject` + `GetExitCodeProcess`, with
-  argv joined per the windows command-line quoting rules, `envp` mapped to a
-  CreateProcess environment block (nil inherits), and stdio redirection via
-  `STARTF_USESTDHANDLES` over inheritable handles; the read path now treats a
-  broken anonymous pipe as EOF so `capture` drains cleanly. `environ()` is
-  now populated from `GetEnvironmentStrings` rather than always nil (#221,
-  #188 windows half).
+  argv joined per the windows command-line quoting rules (a joined line over
+  the 32 KiB limit fails with `E2BIG` instead of truncating), `envp` mapped
+  to a CreateProcess environment block (nil inherits), and stdio redirection
+  via `STARTF_USESTDHANDLES` with inheritance scoped to exactly the child's
+  std handles through `PROC_THREAD_ATTRIBUTE_HANDLE_LIST` (inherit flags are
+  restored after the spawn, so concurrent spawns cannot leak pipe ends into
+  unrelated children; a spawn with no redirection inherits the parent's
+  streams natively). The read path treats a broken anonymous pipe as EOF so
+  `capture` drains cleanly. `environ()` is now populated from
+  `GetEnvironmentStrings` (hidden `=X:` drive-cwd entries excluded) rather
+  than always nil (#221, #188 windows half). `os.WNOHANG` is now forwarded
+  portably alongside `wait`/`wait_pid`.
 
 ### Fixed
 

--- a/src/process/env.mach
+++ b/src/process/env.mach
@@ -34,8 +34,8 @@ pub fun cwd(buf: *u8, cap: usize) i64 {
 # environ: the inherited environment as captured by the runtime at
 # program start.
 # ---
-# ret: null-terminated array of "NAME=value" strings, or nil on
-#      platforms without a captured envp (windows) or before runtime init
+# ret: null-terminated array of "NAME=value" strings, or nil if the
+#      environment is unavailable (e.g. before runtime init)
 pub fun environ() **u8 {
     ret os.environ();
 }

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -174,86 +174,174 @@ pub fun exit(code: i64) {
     os.terminate(code);
 }
 
-fun make_argv1(prog: str) [2]usize {
-    var buf: [2]usize;
-    buf[0] = prog::usize;
-    buf[1] = 0;
-    ret buf;
+# the exec contract is platform-neutral, but the test programs are not:
+# posix targets drive /bin utilities, windows drives cmd.exe builtins
+# (whose echo emits a trailing CRLF, so captured lengths differ).
+$if ($mach.target.os == $mach.os.windows) {
+    val CMD: str = "C:\\Windows\\System32\\cmd.exe";
+
+    fun make_cmd(a1: str, a2: str) [4]usize {
+        var buf: [4]usize;
+        buf[0] = ("cmd")::usize;
+        buf[1] = a1::usize;
+        buf[2] = a2::usize;
+        buf[3] = 0;
+        ret buf;
+    }
+
+    test "exec: run cmd /c exit 0" {
+        var argv: [4]usize = make_cmd("/c", "exit 0");
+        val r: Result[ExitStatus, str] = run(CMD, (?argv[0])::**u8, nil);
+        if (is_err[ExitStatus, str](r)) { ret 1; }
+        val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
+        if (!exited(s)) { ret 1; }
+        if (code(s) != 0) { ret 1; }
+        ret 0;
+    }
+
+    test "exec: run cmd /c exit 7" {
+        var argv: [4]usize = make_cmd("/c", "exit 7");
+        val r: Result[ExitStatus, str] = run(CMD, (?argv[0])::**u8, nil);
+        if (is_err[ExitStatus, str](r)) { ret 1; }
+        val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
+        if (!exited(s)) { ret 1; }
+        if (code(s) != 7) { ret 1; }
+        ret 0;
+    }
+
+    test "exec: spawn and wait matches run" {
+        var argv: [4]usize = make_cmd("/c", "exit 0");
+        val sr: Result[Child, str] = spawn(CMD, (?argv[0])::**u8, nil);
+        if (is_err[Child, str](sr)) { ret 1; }
+        val child: Child = unwrap_ok[Child, str](sr);
+        val wr: Result[ExitStatus, str] = wait(child);
+        if (is_err[ExitStatus, str](wr)) { ret 1; }
+        val s: ExitStatus = unwrap_ok[ExitStatus, str](wr);
+        if (!exited(s)) { ret 1; }
+        if (code(s) != 0) { ret 1; }
+        ret 0;
+    }
+
+    var cap_buf: [64]u8;
+
+    test "exec: capture cmd echo stdout" {
+        var argv: [4]usize = make_cmd("/c", "echo hello");
+        val r: Result[Capture, str] = capture(CMD, (?argv[0])::**u8, nil, ?cap_buf[0], 64);
+        if (is_err[Capture, str](r)) { ret 1; }
+        val c: Capture = unwrap_ok[Capture, str](r);
+        if (!exited(c.status)) { ret 1; }
+        if (code(c.status) != 0) { ret 1; }
+        # cmd echo appends CRLF: "hello\r\n"
+        if (c.len != 7) { ret 1; }
+        if (cap_buf[0] != 'h') { ret 1; }
+        if (cap_buf[1] != 'e') { ret 1; }
+        if (cap_buf[2] != 'l') { ret 1; }
+        if (cap_buf[3] != 'l') { ret 1; }
+        if (cap_buf[4] != 'o') { ret 1; }
+        if (cap_buf[5] != '\r') { ret 1; }
+        if (cap_buf[6] != '\n') { ret 1; }
+        ret 0;
+    }
+
+    var cap_small: [2]u8;
+
+    # a buffer too small must still report the full output length so callers
+    # can detect truncation (len > cap) and size a retry buffer; the pipe is
+    # drained past the buffer so the child never blocks.
+    test "exec: capture reports full length on truncation" {
+        var argv: [4]usize = make_cmd("/c", "echo hello");
+        val r: Result[Capture, str] = capture(CMD, (?argv[0])::**u8, nil, ?cap_small[0], 2);
+        if (is_err[Capture, str](r)) { ret 1; }
+        val c: Capture = unwrap_ok[Capture, str](r);
+        if (code(c.status) != 0) { ret 1; }
+        if (c.len != 7) { ret 1; }
+        if (cap_small[0] != 'h') { ret 1; }
+        if (cap_small[1] != 'e') { ret 1; }
+        ret 0;
+    }
 }
+$or {
+    fun make_argv1(prog: str) [2]usize {
+        var buf: [2]usize;
+        buf[0] = prog::usize;
+        buf[1] = 0;
+        ret buf;
+    }
 
-fun make_argv2(prog: str, a1: str) [3]usize {
-    var buf: [3]usize;
-    buf[0] = prog::usize;
-    buf[1] = a1::usize;
-    buf[2] = 0;
-    ret buf;
-}
+    fun make_argv2(prog: str, a1: str) [3]usize {
+        var buf: [3]usize;
+        buf[0] = prog::usize;
+        buf[1] = a1::usize;
+        buf[2] = 0;
+        ret buf;
+    }
 
-test "exec: run /bin/true exits 0" {
-    var argv: [2]usize = make_argv1("/bin/true");
-    val r: Result[ExitStatus, str] = run("/bin/true", (?argv[0])::**u8, nil);
-    if (is_err[ExitStatus, str](r)) { ret 1; }
-    val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
-    if (!exited(s)) { ret 1; }
-    if (code(s) != 0) { ret 1; }
-    ret 0;
-}
+    test "exec: run /bin/true exits 0" {
+        var argv: [2]usize = make_argv1("/bin/true");
+        val r: Result[ExitStatus, str] = run("/bin/true", (?argv[0])::**u8, nil);
+        if (is_err[ExitStatus, str](r)) { ret 1; }
+        val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
+        if (!exited(s)) { ret 1; }
+        if (code(s) != 0) { ret 1; }
+        ret 0;
+    }
 
-test "exec: run /bin/false exits 1" {
-    var argv: [2]usize = make_argv1("/bin/false");
-    val r: Result[ExitStatus, str] = run("/bin/false", (?argv[0])::**u8, nil);
-    if (is_err[ExitStatus, str](r)) { ret 1; }
-    val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
-    if (!exited(s)) { ret 1; }
-    if (code(s) != 1) { ret 1; }
-    ret 0;
-}
+    test "exec: run /bin/false exits 1" {
+        var argv: [2]usize = make_argv1("/bin/false");
+        val r: Result[ExitStatus, str] = run("/bin/false", (?argv[0])::**u8, nil);
+        if (is_err[ExitStatus, str](r)) { ret 1; }
+        val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
+        if (!exited(s)) { ret 1; }
+        if (code(s) != 1) { ret 1; }
+        ret 0;
+    }
 
-test "exec: spawn and wait matches run" {
-    var argv: [2]usize = make_argv1("/bin/true");
-    val sr: Result[Child, str] = spawn("/bin/true", (?argv[0])::**u8, nil);
-    if (is_err[Child, str](sr)) { ret 1; }
-    val child: Child = unwrap_ok[Child, str](sr);
-    val wr: Result[ExitStatus, str] = wait(child);
-    if (is_err[ExitStatus, str](wr)) { ret 1; }
-    val s: ExitStatus = unwrap_ok[ExitStatus, str](wr);
-    if (!exited(s)) { ret 1; }
-    if (code(s) != 0) { ret 1; }
-    ret 0;
-}
+    test "exec: spawn and wait matches run" {
+        var argv: [2]usize = make_argv1("/bin/true");
+        val sr: Result[Child, str] = spawn("/bin/true", (?argv[0])::**u8, nil);
+        if (is_err[Child, str](sr)) { ret 1; }
+        val child: Child = unwrap_ok[Child, str](sr);
+        val wr: Result[ExitStatus, str] = wait(child);
+        if (is_err[ExitStatus, str](wr)) { ret 1; }
+        val s: ExitStatus = unwrap_ok[ExitStatus, str](wr);
+        if (!exited(s)) { ret 1; }
+        if (code(s) != 0) { ret 1; }
+        ret 0;
+    }
 
-var cap_buf: [64]u8;
+    var cap_buf: [64]u8;
 
-test "exec: capture /bin/echo stdout" {
-    var argv: [3]usize = make_argv2("/bin/echo", "hello");
-    val r: Result[Capture, str] = capture("/bin/echo", (?argv[0])::**u8, nil, ?cap_buf[0], 64);
-    if (is_err[Capture, str](r)) { ret 1; }
-    val c: Capture = unwrap_ok[Capture, str](r);
-    if (!exited(c.status)) { ret 1; }
-    if (code(c.status) != 0) { ret 1; }
-    if (c.len != 6) { ret 1; }
-    if (cap_buf[0] != 'h') { ret 1; }
-    if (cap_buf[1] != 'e') { ret 1; }
-    if (cap_buf[2] != 'l') { ret 1; }
-    if (cap_buf[3] != 'l') { ret 1; }
-    if (cap_buf[4] != 'o') { ret 1; }
-    if (cap_buf[5] != '\n') { ret 1; }
-    ret 0;
-}
+    test "exec: capture /bin/echo stdout" {
+        var argv: [3]usize = make_argv2("/bin/echo", "hello");
+        val r: Result[Capture, str] = capture("/bin/echo", (?argv[0])::**u8, nil, ?cap_buf[0], 64);
+        if (is_err[Capture, str](r)) { ret 1; }
+        val c: Capture = unwrap_ok[Capture, str](r);
+        if (!exited(c.status)) { ret 1; }
+        if (code(c.status) != 0) { ret 1; }
+        if (c.len != 6) { ret 1; }
+        if (cap_buf[0] != 'h') { ret 1; }
+        if (cap_buf[1] != 'e') { ret 1; }
+        if (cap_buf[2] != 'l') { ret 1; }
+        if (cap_buf[3] != 'l') { ret 1; }
+        if (cap_buf[4] != 'o') { ret 1; }
+        if (cap_buf[5] != '\n') { ret 1; }
+        ret 0;
+    }
 
-var cap_small: [2]u8;
+    var cap_small: [2]u8;
 
-# a buffer too small must still report the full output length so callers
-# can detect truncation (len > cap) and size a retry buffer; the pipe is
-# drained past the buffer so the child never blocks.
-test "exec: capture reports full length on truncation" {
-    var argv: [3]usize = make_argv2("/bin/echo", "hello");
-    val r: Result[Capture, str] = capture("/bin/echo", (?argv[0])::**u8, nil, ?cap_small[0], 2);
-    if (is_err[Capture, str](r)) { ret 1; }
-    val c: Capture = unwrap_ok[Capture, str](r);
-    if (code(c.status) != 0) { ret 1; }
-    if (c.len != 6) { ret 1; }
-    if (cap_small[0] != 'h') { ret 1; }
-    if (cap_small[1] != 'e') { ret 1; }
-    ret 0;
+    # a buffer too small must still report the full output length so callers
+    # can detect truncation (len > cap) and size a retry buffer; the pipe is
+    # drained past the buffer so the child never blocks.
+    test "exec: capture reports full length on truncation" {
+        var argv: [3]usize = make_argv2("/bin/echo", "hello");
+        val r: Result[Capture, str] = capture("/bin/echo", (?argv[0])::**u8, nil, ?cap_small[0], 2);
+        if (is_err[Capture, str](r)) { ret 1; }
+        val c: Capture = unwrap_ok[Capture, str](r);
+        if (code(c.status) != 0) { ret 1; }
+        if (c.len != 6) { ret 1; }
+        if (cap_small[0] != 'h') { ret 1; }
+        if (cap_small[1] != 'e') { ret 1; }
+        ret 0;
+    }
 }

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -174,174 +174,177 @@ pub fun exit(code: i64) {
     os.terminate(code);
 }
 
-# the exec contract is platform-neutral, but the test programs are not:
-# posix targets drive /bin utilities, windows drives cmd.exe builtins
-# (whose echo emits a trailing CRLF, so captured lengths differ).
+# the exec contract is platform-neutral, but the test programs are not;
+# the $if blocks confine the differences to program paths, argv shapes,
+# and echo's line ending (cmd appends CRLF where posix echo appends LF).
 $if ($mach.target.os == $mach.os.windows) {
-    val CMD: str = "C:\\Windows\\System32\\cmd.exe";
+    var comspec_buf: [260]u8;
 
-    fun make_cmd(a1: str, a2: str) [4]usize {
+    # %ComSpec% names the command interpreter; fall back to the canonical
+    # path when unset
+    fun shell_path() str {
+        val n: i64 = os.getenv("ComSpec", ?comspec_buf[0], 260);
+        if (n > 0 && n < 260) {
+            ret (?comspec_buf[0])::str;
+        }
+        ret "C:\\Windows\\System32\\cmd.exe";
+    }
+
+    fun make_shell_argv(command: str) [4]usize {
         var buf: [4]usize;
         buf[0] = ("cmd")::usize;
-        buf[1] = a1::usize;
-        buf[2] = a2::usize;
+        buf[1] = ("/c")::usize;
+        buf[2] = command::usize;
         buf[3] = 0;
         ret buf;
     }
 
-    test "exec: run cmd /c exit 0" {
-        var argv: [4]usize = make_cmd("/c", "exit 0");
-        val r: Result[ExitStatus, str] = run(CMD, (?argv[0])::**u8, nil);
-        if (is_err[ExitStatus, str](r)) { ret 1; }
-        val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
-        if (!exited(s)) { ret 1; }
-        if (code(s) != 0) { ret 1; }
-        ret 0;
-    }
+    fun prog_ok() str { ret shell_path(); }
+    fun argv_ok() [4]usize { ret make_shell_argv("exit 0"); }
+    fun prog_fail() str { ret shell_path(); }
+    fun argv_fail() [4]usize { ret make_shell_argv("exit 1"); }
+    fun prog_echo() str { ret shell_path(); }
+    fun argv_echo() [4]usize { ret make_shell_argv("echo hello"); }
 
-    test "exec: run cmd /c exit 7" {
-        var argv: [4]usize = make_cmd("/c", "exit 7");
-        val r: Result[ExitStatus, str] = run(CMD, (?argv[0])::**u8, nil);
-        if (is_err[ExitStatus, str](r)) { ret 1; }
-        val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
-        if (!exited(s)) { ret 1; }
-        if (code(s) != 7) { ret 1; }
-        ret 0;
-    }
+    # cmd's echo appends CRLF: "hello\r\n"
+    val ECHO_LEN: usize = 7;
 
-    test "exec: spawn and wait matches run" {
-        var argv: [4]usize = make_cmd("/c", "exit 0");
-        val sr: Result[Child, str] = spawn(CMD, (?argv[0])::**u8, nil);
-        if (is_err[Child, str](sr)) { ret 1; }
-        val child: Child = unwrap_ok[Child, str](sr);
-        val wr: Result[ExitStatus, str] = wait(child);
-        if (is_err[ExitStatus, str](wr)) { ret 1; }
-        val s: ExitStatus = unwrap_ok[ExitStatus, str](wr);
-        if (!exited(s)) { ret 1; }
-        if (code(s) != 0) { ret 1; }
-        ret 0;
-    }
+    var leak_buf: [64]u8;
 
-    var cap_buf: [64]u8;
-
-    test "exec: capture cmd echo stdout" {
-        var argv: [4]usize = make_cmd("/c", "echo hello");
-        val r: Result[Capture, str] = capture(CMD, (?argv[0])::**u8, nil, ?cap_buf[0], 64);
-        if (is_err[Capture, str](r)) { ret 1; }
-        val c: Capture = unwrap_ok[Capture, str](r);
-        if (!exited(c.status)) { ret 1; }
-        if (code(c.status) != 0) { ret 1; }
-        # cmd echo appends CRLF: "hello\r\n"
-        if (c.len != 7) { ret 1; }
-        if (cap_buf[0] != 'h') { ret 1; }
-        if (cap_buf[1] != 'e') { ret 1; }
-        if (cap_buf[2] != 'l') { ret 1; }
-        if (cap_buf[3] != 'l') { ret 1; }
-        if (cap_buf[4] != 'o') { ret 1; }
-        if (cap_buf[5] != '\r') { ret 1; }
-        if (cap_buf[6] != '\n') { ret 1; }
-        ret 0;
-    }
-
-    var cap_small: [2]u8;
-
-    # a buffer too small must still report the full output length so callers
-    # can detect truncation (len > cap) and size a retry buffer; the pipe is
-    # drained past the buffer so the child never blocks.
-    test "exec: capture reports full length on truncation" {
-        var argv: [4]usize = make_cmd("/c", "echo hello");
-        val r: Result[Capture, str] = capture(CMD, (?argv[0])::**u8, nil, ?cap_small[0], 2);
-        if (is_err[Capture, str](r)) { ret 1; }
-        val c: Capture = unwrap_ok[Capture, str](r);
-        if (code(c.status) != 0) { ret 1; }
-        if (c.len != 7) { ret 1; }
-        if (cap_small[0] != 'h') { ret 1; }
-        if (cap_small[1] != 'e') { ret 1; }
+    # regression for the handle-inheritance leak: a child spawned while a
+    # prior child's pipe write end is open must not inherit that handle,
+    # or the pipe only reaches EOF once the unrelated child exits. the
+    # sleeper runs ~2s; the drain must complete while it is still alive.
+    test "exec: spawn does not leak prior pipe handles" {
+        var fds: [2]i32;
+        if (os.pipe(?fds[0]) != 0) { ret 1; }
+        var av1: [4]usize = argv_echo();
+        val pid1: i64 = os.spawn_redirected(shell_path(), (?av1[0])::**u8, nil, -1, fds[1], -1);
+        if (pid1 < 0) {
+            os.close(fds[0]);
+            os.close(fds[1]);
+            ret 1;
+        }
+        var av2: [4]usize = make_shell_argv("ping -n 3 127.0.0.1 > NUL");
+        val pid2: i64 = os.spawn(shell_path(), (?av2[0])::**u8, nil);
+        os.close(fds[1]);
+        var st: i32 = 0;
+        if (pid2 < 0) {
+            os.close(fds[0]);
+            os.wait_pid(pid1, ?st, 0);
+            ret 1;
+        }
+        var total: usize = 0;
+        for (true) {
+            val n: i64 = os.read(fds[0], ?leak_buf[0], 64);
+            if (n < 0) { ret 1; }
+            if (n == 0) { brk; }
+            total = total + n::usize;
+        }
+        os.close(fds[0]);
+        val still_running: i64 = os.wait_pid(pid2, ?st, os.WNOHANG);
+        os.wait_pid(pid1, ?st, 0);
+        os.wait_pid(pid2, ?st, 0);
+        if (still_running != 0) { ret 1; }
+        if (total != ECHO_LEN) { ret 1; }
         ret 0;
     }
 }
 $or {
-    fun make_argv1(prog: str) [2]usize {
-        var buf: [2]usize;
+    fun make_argv1(prog: str) [4]usize {
+        var buf: [4]usize;
         buf[0] = prog::usize;
         buf[1] = 0;
+        buf[2] = 0;
+        buf[3] = 0;
         ret buf;
     }
 
-    fun make_argv2(prog: str, a1: str) [3]usize {
-        var buf: [3]usize;
+    fun make_argv2(prog: str, a1: str) [4]usize {
+        var buf: [4]usize;
         buf[0] = prog::usize;
         buf[1] = a1::usize;
         buf[2] = 0;
+        buf[3] = 0;
         ret buf;
     }
 
-    test "exec: run /bin/true exits 0" {
-        var argv: [2]usize = make_argv1("/bin/true");
-        val r: Result[ExitStatus, str] = run("/bin/true", (?argv[0])::**u8, nil);
-        if (is_err[ExitStatus, str](r)) { ret 1; }
-        val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
-        if (!exited(s)) { ret 1; }
-        if (code(s) != 0) { ret 1; }
-        ret 0;
-    }
+    fun prog_ok() str { ret "/bin/true"; }
+    fun argv_ok() [4]usize { ret make_argv1("/bin/true"); }
+    fun prog_fail() str { ret "/bin/false"; }
+    fun argv_fail() [4]usize { ret make_argv1("/bin/false"); }
+    fun prog_echo() str { ret "/bin/echo"; }
+    fun argv_echo() [4]usize { ret make_argv2("/bin/echo", "hello"); }
 
-    test "exec: run /bin/false exits 1" {
-        var argv: [2]usize = make_argv1("/bin/false");
-        val r: Result[ExitStatus, str] = run("/bin/false", (?argv[0])::**u8, nil);
-        if (is_err[ExitStatus, str](r)) { ret 1; }
-        val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
-        if (!exited(s)) { ret 1; }
-        if (code(s) != 1) { ret 1; }
-        ret 0;
-    }
+    # echo emits "hello\n"
+    val ECHO_LEN: usize = 6;
+}
 
-    test "exec: spawn and wait matches run" {
-        var argv: [2]usize = make_argv1("/bin/true");
-        val sr: Result[Child, str] = spawn("/bin/true", (?argv[0])::**u8, nil);
-        if (is_err[Child, str](sr)) { ret 1; }
-        val child: Child = unwrap_ok[Child, str](sr);
-        val wr: Result[ExitStatus, str] = wait(child);
-        if (is_err[ExitStatus, str](wr)) { ret 1; }
-        val s: ExitStatus = unwrap_ok[ExitStatus, str](wr);
-        if (!exited(s)) { ret 1; }
-        if (code(s) != 0) { ret 1; }
-        ret 0;
-    }
+test "exec: run success program exits 0" {
+    var argv: [4]usize = argv_ok();
+    val r: Result[ExitStatus, str] = run(prog_ok(), (?argv[0])::**u8, nil);
+    if (is_err[ExitStatus, str](r)) { ret 1; }
+    val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
+    if (!exited(s)) { ret 1; }
+    if (code(s) != 0) { ret 1; }
+    ret 0;
+}
 
-    var cap_buf: [64]u8;
+test "exec: run failure program exits 1" {
+    var argv: [4]usize = argv_fail();
+    val r: Result[ExitStatus, str] = run(prog_fail(), (?argv[0])::**u8, nil);
+    if (is_err[ExitStatus, str](r)) { ret 1; }
+    val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
+    if (!exited(s)) { ret 1; }
+    if (code(s) != 1) { ret 1; }
+    ret 0;
+}
 
-    test "exec: capture /bin/echo stdout" {
-        var argv: [3]usize = make_argv2("/bin/echo", "hello");
-        val r: Result[Capture, str] = capture("/bin/echo", (?argv[0])::**u8, nil, ?cap_buf[0], 64);
-        if (is_err[Capture, str](r)) { ret 1; }
-        val c: Capture = unwrap_ok[Capture, str](r);
-        if (!exited(c.status)) { ret 1; }
-        if (code(c.status) != 0) { ret 1; }
-        if (c.len != 6) { ret 1; }
-        if (cap_buf[0] != 'h') { ret 1; }
-        if (cap_buf[1] != 'e') { ret 1; }
-        if (cap_buf[2] != 'l') { ret 1; }
-        if (cap_buf[3] != 'l') { ret 1; }
-        if (cap_buf[4] != 'o') { ret 1; }
-        if (cap_buf[5] != '\n') { ret 1; }
-        ret 0;
-    }
+test "exec: spawn and wait matches run" {
+    var argv: [4]usize = argv_ok();
+    val sr: Result[Child, str] = spawn(prog_ok(), (?argv[0])::**u8, nil);
+    if (is_err[Child, str](sr)) { ret 1; }
+    val child: Child = unwrap_ok[Child, str](sr);
+    val wr: Result[ExitStatus, str] = wait(child);
+    if (is_err[ExitStatus, str](wr)) { ret 1; }
+    val s: ExitStatus = unwrap_ok[ExitStatus, str](wr);
+    if (!exited(s)) { ret 1; }
+    if (code(s) != 0) { ret 1; }
+    ret 0;
+}
 
-    var cap_small: [2]u8;
+var cap_buf: [64]u8;
 
-    # a buffer too small must still report the full output length so callers
-    # can detect truncation (len > cap) and size a retry buffer; the pipe is
-    # drained past the buffer so the child never blocks.
-    test "exec: capture reports full length on truncation" {
-        var argv: [3]usize = make_argv2("/bin/echo", "hello");
-        val r: Result[Capture, str] = capture("/bin/echo", (?argv[0])::**u8, nil, ?cap_small[0], 2);
-        if (is_err[Capture, str](r)) { ret 1; }
-        val c: Capture = unwrap_ok[Capture, str](r);
-        if (code(c.status) != 0) { ret 1; }
-        if (c.len != 6) { ret 1; }
-        if (cap_small[0] != 'h') { ret 1; }
-        if (cap_small[1] != 'e') { ret 1; }
-        ret 0;
-    }
+test "exec: capture echo stdout" {
+    var argv: [4]usize = argv_echo();
+    val r: Result[Capture, str] = capture(prog_echo(), (?argv[0])::**u8, nil, ?cap_buf[0], 64);
+    if (is_err[Capture, str](r)) { ret 1; }
+    val c: Capture = unwrap_ok[Capture, str](r);
+    if (!exited(c.status)) { ret 1; }
+    if (code(c.status) != 0) { ret 1; }
+    if (c.len != ECHO_LEN) { ret 1; }
+    if (cap_buf[0] != 'h') { ret 1; }
+    if (cap_buf[1] != 'e') { ret 1; }
+    if (cap_buf[2] != 'l') { ret 1; }
+    if (cap_buf[3] != 'l') { ret 1; }
+    if (cap_buf[4] != 'o') { ret 1; }
+    if (cap_buf[ECHO_LEN - 1] != '\n') { ret 1; }
+    ret 0;
+}
+
+var cap_small: [2]u8;
+
+# a buffer too small must still report the full output length so callers
+# can detect truncation (len > cap) and size a retry buffer; the pipe is
+# drained past the buffer so the child never blocks.
+test "exec: capture reports full length on truncation" {
+    var argv: [4]usize = argv_echo();
+    val r: Result[Capture, str] = capture(prog_echo(), (?argv[0])::**u8, nil, ?cap_small[0], 2);
+    if (is_err[Capture, str](r)) { ret 1; }
+    val c: Capture = unwrap_ok[Capture, str](r);
+    if (code(c.status) != 0) { ret 1; }
+    if (c.len != ECHO_LEN) { ret 1; }
+    if (cap_small[0] != 'h') { ret 1; }
+    if (cap_small[1] != 'e') { ret 1; }
+    ret 0;
 }

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -143,6 +143,7 @@ fwd impl.sleep;
 fwd impl.getcwd;
 fwd impl.getenv;
 fwd impl.environ;
+fwd impl.WNOHANG;
 fwd impl.wait;
 fwd impl.wait_pid;
 fwd impl.has_exited;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -118,6 +118,10 @@ val WAIT_TIMEOUT:  u32 = 258;
 val WAIT_FAILED:   u32 = 0xFFFFFFFF;
 val INFINITE:      u32 = 0xFFFFFFFF;
 
+# CreateProcess / STARTUPINFO
+val STARTF_USESTDHANDLES: u32 = 0x00000100;
+val HANDLE_FLAG_INHERIT:  u32 = 0x00000001;
+
 # FILETIME epoch offset (100-ns intervals from 1601-01-01 to 1970-01-01)
 val FILETIME_UNIX_EPOCH: i64 = 116444736000000000;
 
@@ -238,10 +242,13 @@ ext fun WaitForSingleObject(p0: isize, p1: u32) u32;
 ext fun WaitForMultipleObjects(p0: u32, p1: ptr, p2: i32, p3: u32) u32;
 ext fun GetExitCodeProcess(p0: isize, p1: *u32) i32;
 ext fun CreatePipe(p0: *isize, p1: *isize, p2: ptr, p3: u32) i32;
+ext fun SetHandleInformation(p0: isize, p1: u32, p2: u32) i32;
 $SleepW.symbol = "Sleep";
 ext fun SleepW(p0: u32);
 ext fun GetCurrentDirectoryA(p0: u32, p1: *u8) u32;
 ext fun GetEnvironmentVariableA(p0: *u8, p1: *u8, p2: u32) u32;
+ext fun GetEnvironmentStringsA() *u8;
+ext fun FreeEnvironmentStringsA(p0: *u8) i32;
 
 # Win32 structures
 
@@ -602,6 +609,10 @@ fun build_cmdline(argv: **u8, buf: *u8, cap: usize) {
             }
             j = j + 1;
         }
+        # an empty argument must still emit "" so it survives the round-trip
+        if (arg[0] == 0) {
+            needs_quote = 1;
+        }
         if (needs_quote != 0 && off < cap - 1) {
             buf[off] = 34;
             off = off + 1;
@@ -837,6 +848,11 @@ pub fun read(fd: i32, buf: *u8, count: usize) i64 {
     var bytes_read: u32 = 0;
     val ok: i32 = ReadFile(h, buf, count::u32, ?bytes_read, nil);
     if (ok == 0) {
+        # an anonymous pipe with all write ends closed reports a broken
+        # pipe on read; that is end-of-file under posix read semantics
+        if (GetLastError() == ERROR_BROKEN_PIPE) {
+            ret 0;
+        }
         ret last_error();
     }
     ret bytes_read::i64;
@@ -1112,19 +1128,104 @@ pub fun abort() {
     ExitProcess(255);
 }
 
+# resolve the child handle for a redirected stream: a real fd maps through
+# the handle table; -1 inherits the parent's stream via GetStdHandle.
+fun resolve_child_handle(fd: i32, std_id: u32) isize {
+    if (fd == -1) {
+        ret GetStdHandle(std_id);
+    }
+    ret get_handle(fd);
+}
+
+# build a CreateProcess environment block from a null-terminated envp array.
+#
+# the block is a sequence of null-terminated "NAME=VALUE" strings followed
+# by a final null. ownership transfers to the caller, which frees it with
+# deallocate(block, size) after CreateProcess copies it into the child.
+# ---
+# envp:     null-terminated environment array
+# out_size: receives the block size in bytes (for deallocate)
+# ret:      pointer to the block, or nil on allocation failure
+fun build_env_block(envp: **u8, out_size: *usize) ptr {
+    var total: usize = 0;
+    var i: usize = 0;
+    for (envp[i]::usize != 0) {
+        var j: usize = 0;
+        for (envp[i][j] != 0) {
+            j = j + 1;
+        }
+        total = total + j + 1;
+        i = i + 1;
+    }
+    # +2 terminates the block and keeps an empty environment a valid "\0\0"
+    val size: usize = total + 2;
+    val block: ptr = allocate(size);
+    if (block == nil) {
+        ret nil;
+    }
+    var dst: usize = block::usize;
+    i = 0;
+    for (envp[i]::usize != 0) {
+        var j: usize = 0;
+        for (envp[i][j] != 0) {
+            @(dst::*u8) = envp[i][j];
+            dst = dst + 1;
+            j = j + 1;
+        }
+        @(dst::*u8) = 0;
+        dst = dst + 1;
+        i = i + 1;
+    }
+    @(dst::*u8) = 0;
+    @((dst + 1)::*u8) = 0;
+    @out_size = size;
+    ret block;
+}
+
 # spawn: create a child process running the given program.
 #
-# uses CreateProcess to launch the child. the process handle is tracked
-# in the process table for wait/wait_pid. envp is ignored; the child
-# inherits the parent's environment.
+# collapses onto spawn_redirected with all three streams inherited.
 # ---
 # pathname: path to executable
 # argv:     null-terminated argument array
-# envp:     null-terminated environment array (ignored on windows)
+# envp:     null-terminated environment array, or nil to inherit
 # ret:      child PID on success, or negative errno
 pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
+    ret spawn_redirected(pathname, argv, envp, -1, -1, -1);
+}
+
+# spawn_redirected: spawn a child with its standard streams bound to
+# caller-supplied descriptors (-1 inherits the parent's stream).
+#
+# CreateProcess receives a STARTUPINFO with STARTF_USESTDHANDLES and all
+# three of hStdInput/hStdOutput/hStdError resolved to handles (GetStdHandle
+# for inherited streams). each child stream is marked inheritable and
+# bInheritHandles is set so the child receives them; the parent's other
+# handles stay non-inheritable. the process handle is tracked in the
+# process table for wait/wait_pid. envp maps to the environment block;
+# nil inherits the parent's environment.
+# ---
+# pathname:  path to executable
+# argv:      null-terminated argument array
+# envp:      null-terminated environment array, or nil to inherit
+# stdin_fd:  descriptor to install as the child's stdin, or -1 to inherit
+# stdout_fd: descriptor to install as the child's stdout, or -1 to inherit
+# stderr_fd: descriptor to install as the child's stderr, or -1 to inherit
+# ret:       child PID on success, or negative errno
+pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, stdout_fd: i32, stderr_fd: i32) i64 {
     var cmdline: [32768]u8;
     build_cmdline(argv, ?cmdline[0], 32768);
+
+    val hin:  isize = resolve_child_handle(stdin_fd, STD_INPUT_HANDLE);
+    val hout: isize = resolve_child_handle(stdout_fd, STD_OUTPUT_HANDLE);
+    val herr: isize = resolve_child_handle(stderr_fd, STD_ERROR_HANDLE);
+    if (hin == INVALID_HANDLE_VALUE || hout == INVALID_HANDLE_VALUE || herr == INVALID_HANDLE_VALUE) {
+        ret EBADF;
+    }
+
+    SetHandleInformation(hin, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
+    SetHandleInformation(hout, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
+    SetHandleInformation(herr, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
 
     var si: [104]u8;
     var k: usize = 0;
@@ -1132,17 +1233,33 @@ pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
         si[k] = 0;
         k = k + 1;
     }
-    si[0] = 104;
+    val base: usize = (?si[0])::usize;
+    @(base::*u32) = 104;
+    @((base + 60)::*u32) = STARTF_USESTDHANDLES;
+    @((base + 80)::*isize) = hin;
+    @((base + 88)::*isize) = hout;
+    @((base + 96)::*isize) = herr;
+
+    var env_size: usize = 0;
+    var env_block: ptr = nil;
+    if (envp != nil) {
+        env_block = build_env_block(envp, ?env_size);
+        if (env_block == nil) {
+            ret ENOMEM;
+        }
+    }
 
     var pi: PROCESS_INFORMATION;
-
     val ok: i32 = CreateProcessA(
         pathname, ?cmdline[0],
         nil, nil,
         1, 0,
-        nil, nil,
+        env_block, nil,
         ?si[0], (?pi)::*u8
     );
+    if (env_block != nil) {
+        deallocate(env_block, env_size);
+    }
     if (ok == 0) {
         ret last_error();
     }
@@ -1153,24 +1270,6 @@ pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
         ret EAGAIN;
     }
     ret pi.dwProcessId::i64;
-}
-
-# spawn_redirected: spawn a child with its standard streams bound to
-# caller-supplied descriptors (-1 inherits the parent's stream).
-#
-# unimplemented on windows, which needs STARTUPINFO handle inheritance
-# (STARTF_USESTDHANDLES with all three of hStdInput/hStdOutput/hStdError)
-# rather than the posix fork/dup2/exec path; tracked by issue #221.
-# ---
-# pathname:  path to executable
-# argv:      null-terminated argument array
-# envp:      null-terminated environment array
-# stdin_fd:  descriptor to install as the child's stdin, or -1 to inherit
-# stdout_fd: descriptor to install as the child's stdout, or -1 to inherit
-# stderr_fd: descriptor to install as the child's stderr, or -1 to inherit
-# ret:       ENOTSUP until windows support lands
-pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, stdout_fd: i32, stderr_fd: i32) i64 {
-    ret ENOTSUP;
 }
 
 # getpid: return the current process ID.
@@ -1265,10 +1364,53 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
     ret len::i64;
 }
 
-# environ: windows does not capture a unix-style envp array; always nil.
-# use getenv for individual lookups.
+# captured environment vector, built once from the win32 environment block.
+var _environ_vec:  **u8 = nil;
+var _environ_init: u8 = 0;
+
+# environ: the process environment as a unix-style "NAME=VALUE" vector.
+#
+# parses the win32 environment block (GetEnvironmentStrings) into a
+# null-terminated array of pointers on first call and caches it for the
+# process lifetime; the block backs the entries, so it is retained rather
+# than freed. returns nil if the block is unavailable or allocation fails.
 pub fun environ() **u8 {
-    ret nil;
+    if (_environ_init != 0) {
+        ret _environ_vec;
+    }
+    _environ_init = 1;
+    val block: *u8 = GetEnvironmentStringsA();
+    if (block::usize == 0) {
+        ret nil;
+    }
+    var count: usize = 0;
+    var p: usize = block::usize;
+    for (@(p::*u8) != 0) {
+        count = count + 1;
+        for (@(p::*u8) != 0) {
+            p = p + 1;
+        }
+        p = p + 1;
+    }
+    val arr: ptr = allocate((count + 1) * 8);
+    if (arr == nil) {
+        FreeEnvironmentStringsA(block);
+        ret nil;
+    }
+    var vec: **u8 = arr::**u8;
+    var i: usize = 0;
+    p = block::usize;
+    for (i < count) {
+        vec[i] = p::*u8;
+        for (@(p::*u8) != 0) {
+            p = p + 1;
+        }
+        p = p + 1;
+        i = i + 1;
+    }
+    vec[count] = nil;
+    _environ_vec = vec;
+    ret vec;
 }
 
 # wait: wait for a child process to change state.

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -10,6 +10,7 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.string.str;
+use std.types.string.str_len;
 
 use os_shared: std.system.os.shared;
 use atomic:    std.sync.atomic;
@@ -119,8 +120,12 @@ val WAIT_FAILED:   u32 = 0xFFFFFFFF;
 val INFINITE:      u32 = 0xFFFFFFFF;
 
 # CreateProcess / STARTUPINFO
-val STARTF_USESTDHANDLES: u32 = 0x00000100;
-val HANDLE_FLAG_INHERIT:  u32 = 0x00000001;
+val STARTF_USESTDHANDLES:         u32 = 0x00000100;
+val HANDLE_FLAG_INHERIT:          u32 = 0x00000001;
+val EXTENDED_STARTUPINFO_PRESENT: u32 = 0x00080000;
+val PROC_THREAD_ATTRIBUTE_HANDLE_LIST: usize = 0x20002;
+val STARTUPINFOA_SIZE:   usize = 104;
+val STARTUPINFOEXA_SIZE: usize = 112;
 
 # FILETIME epoch offset (100-ns intervals from 1601-01-01 to 1970-01-01)
 val FILETIME_UNIX_EPOCH: i64 = 116444736000000000;
@@ -242,7 +247,11 @@ ext fun WaitForSingleObject(p0: isize, p1: u32) u32;
 ext fun WaitForMultipleObjects(p0: u32, p1: ptr, p2: i32, p3: u32) u32;
 ext fun GetExitCodeProcess(p0: isize, p1: *u32) i32;
 ext fun CreatePipe(p0: *isize, p1: *isize, p2: ptr, p3: u32) i32;
+ext fun GetHandleInformation(p0: isize, p1: *u32) i32;
 ext fun SetHandleInformation(p0: isize, p1: u32, p2: u32) i32;
+ext fun InitializeProcThreadAttributeList(p0: ptr, p1: u32, p2: u32, p3: *usize) i32;
+ext fun UpdateProcThreadAttribute(p0: ptr, p1: u32, p2: usize, p3: ptr, p4: usize, p5: ptr, p6: ptr) i32;
+ext fun DeleteProcThreadAttributeList(p0: ptr);
 $SleepW.symbol = "Sleep";
 ext fun SleepW(p0: u32);
 ext fun GetCurrentDirectoryA(p0: u32, p1: *u8) u32;
@@ -288,6 +297,35 @@ rec PROCESS_INFORMATION {
     hThread:     isize;
     dwProcessId: u32;
     dwThreadId:  u32;
+}
+
+# explicit padding fields pin the win64 ABI layout (104 bytes)
+rec STARTUPINFOA {
+    cb:              u32;
+    _pad0:           u32;
+    lpReserved:      usize;
+    lpDesktop:       usize;
+    lpTitle:         usize;
+    dwX:             u32;
+    dwY:             u32;
+    dwXSize:         u32;
+    dwYSize:         u32;
+    dwXCountChars:   u32;
+    dwYCountChars:   u32;
+    dwFillAttribute: u32;
+    dwFlags:         u32;
+    wShowWindow:     u16;
+    cbReserved2:     u16;
+    _pad1:           u32;
+    lpReserved2:     usize;
+    hStdInput:       isize;
+    hStdOutput:      isize;
+    hStdError:       isize;
+}
+
+rec STARTUPINFOEXA {
+    StartupInfo:     STARTUPINFOA;
+    lpAttributeList: ptr;
 }
 
 # kernel ABI types (POSIX-compatible layout for os.mach interface)
@@ -586,19 +624,32 @@ fun filetime_to_unix(ft: FILETIME, sec: *i64, nsec: *i64) {
     @nsec = (unix_ticks % 10000000) * 100;
 }
 
+# append one byte to the command line, reserving the terminator slot.
+# ---
+# ret: false when the byte does not fit
+fun cmd_put(buf: *u8, cap: usize, off: *usize, b: u8) bool {
+    if (@off + 1 >= cap) {
+        ret false;
+    }
+    buf[@off] = b;
+    @off = @off + 1;
+    ret true;
+}
+
 # build a command line string from a null-terminated argv array.
-# escapes per the CommandLineToArgvW convention:
+# escapes per the CommandLineToArgvW convention.
 # ---
 # argv: null-terminated array of null-terminated strings
 # buf:  destination buffer
 # cap:  size of buf in bytes
-fun build_cmdline(argv: **u8, buf: *u8, cap: usize) {
+# ret:  true on success, false when the joined line exceeds cap
+#       (buffer contents are then unspecified)
+fun build_cmdline(argv: **u8, buf: *u8, cap: usize) bool {
     var off: usize = 0;
     var i: usize = 0;
-    for (argv[i]::usize != 0 && off < cap - 1) {
-        if (i > 0 && off < cap - 1) {
-            buf[off] = 32;
-            off = off + 1;
+    for (argv[i]::usize != 0) {
+        if (i > 0 && !cmd_put(buf, cap, ?off, 32)) {
+            ret false;
         }
         val arg: *u8 = argv[i];
         var needs_quote: u8 = 0;
@@ -613,58 +664,52 @@ fun build_cmdline(argv: **u8, buf: *u8, cap: usize) {
         if (arg[0] == 0) {
             needs_quote = 1;
         }
-        if (needs_quote != 0 && off < cap - 1) {
-            buf[off] = 34;
-            off = off + 1;
+        if (needs_quote != 0 && !cmd_put(buf, cap, ?off, 34)) {
+            ret false;
         }
         j = 0;
-        for (arg[j] != 0 && off < cap - 1) {
+        for (arg[j] != 0) {
             if (needs_quote != 0 && arg[j] == 92) {
                 var nbs: usize = 0;
                 for (arg[j + nbs] == 92) {
                     nbs = nbs + 1;
                 }
+                # backslashes before a quote (or the closing quote at end
+                # of argument) must be doubled; elsewhere they are literal
+                var emit: usize = nbs;
                 if (arg[j + nbs] == 34 || arg[j + nbs] == 0) {
-                    var k: usize = 0;
-                    for (k < nbs * 2 && off < cap - 1) {
-                        buf[off] = 92;
-                        off = off + 1;
-                        k = k + 1;
+                    emit = nbs * 2;
+                }
+                var k: usize = 0;
+                for (k < emit) {
+                    if (!cmd_put(buf, cap, ?off, 92)) {
+                        ret false;
                     }
-                } or {
-                    var k: usize = 0;
-                    for (k < nbs && off < cap - 1) {
-                        buf[off] = 92;
-                        off = off + 1;
-                        k = k + 1;
-                    }
+                    k = k + 1;
                 }
                 j = j + nbs;
             } or (needs_quote != 0 && arg[j] == 34) {
-                if (off < cap - 1) {
-                    buf[off] = 92;
-                    off = off + 1;
+                if (!cmd_put(buf, cap, ?off, 92)) {
+                    ret false;
                 }
-                if (off < cap - 1) {
-                    buf[off] = 34;
-                    off = off + 1;
+                if (!cmd_put(buf, cap, ?off, 34)) {
+                    ret false;
                 }
                 j = j + 1;
             } or {
-                buf[off] = arg[j];
-                off = off + 1;
+                if (!cmd_put(buf, cap, ?off, arg[j])) {
+                    ret false;
+                }
                 j = j + 1;
             }
         }
-        if (needs_quote != 0 && off < cap - 1) {
-            buf[off] = 34;
-            off = off + 1;
+        if (needs_quote != 0 && !cmd_put(buf, cap, ?off, 34)) {
+            ret false;
         }
         i = i + 1;
     }
-    if (off < cap) {
-        buf[off] = 0;
-    }
+    buf[off] = 0;
+    ret true;
 }
 
 # POSIX prot flags → Win32 page protection
@@ -848,12 +893,13 @@ pub fun read(fd: i32, buf: *u8, count: usize) i64 {
     var bytes_read: u32 = 0;
     val ok: i32 = ReadFile(h, buf, count::u32, ?bytes_read, nil);
     if (ok == 0) {
+        val e: i64 = last_error();
         # an anonymous pipe with all write ends closed reports a broken
         # pipe on read; that is end-of-file under posix read semantics
-        if (GetLastError() == ERROR_BROKEN_PIPE) {
+        if (e == EPIPE) {
             ret 0;
         }
-        ret last_error();
+        ret e;
     }
     ret bytes_read::i64;
 }
@@ -1128,13 +1174,12 @@ pub fun abort() {
     ExitProcess(255);
 }
 
-# resolve the child handle for a redirected stream: a real fd maps through
-# the handle table; -1 inherits the parent's stream via GetStdHandle.
-fun resolve_child_handle(fd: i32, std_id: u32) isize {
-    if (fd == -1) {
-        ret GetStdHandle(std_id);
+fun zero_bytes(p: *u8, n: usize) {
+    var i: usize = 0;
+    for (i < n) {
+        p[i] = 0;
+        i = i + 1;
     }
-    ret get_handle(fd);
 }
 
 # build a CreateProcess environment block from a null-terminated envp array.
@@ -1150,11 +1195,7 @@ fun build_env_block(envp: **u8, out_size: *usize) ptr {
     var total: usize = 0;
     var i: usize = 0;
     for (envp[i]::usize != 0) {
-        var j: usize = 0;
-        for (envp[i][j] != 0) {
-            j = j + 1;
-        }
-        total = total + j + 1;
+        total = total + str_len(envp[i]) + 1;
         i = i + 1;
     }
     # +2 terminates the block and keeps an empty environment a valid "\0\0"
@@ -1166,20 +1207,178 @@ fun build_env_block(envp: **u8, out_size: *usize) ptr {
     var dst: usize = block::usize;
     i = 0;
     for (envp[i]::usize != 0) {
+        val len: usize = str_len(envp[i]);
         var j: usize = 0;
-        for (envp[i][j] != 0) {
+        for (j < len + 1) {
             @(dst::*u8) = envp[i][j];
             dst = dst + 1;
             j = j + 1;
         }
-        @(dst::*u8) = 0;
-        dst = dst + 1;
         i = i + 1;
     }
     @(dst::*u8) = 0;
     @((dst + 1)::*u8) = 0;
     @out_size = size;
     ret block;
+}
+
+# register a freshly created child in the process table for wait/wait_pid.
+fun register_child(pi: PROCESS_INFORMATION) i64 {
+    CloseHandle(pi.hThread);
+    if (!alloc_proc(pi.dwProcessId, pi.hProcess)) {
+        CloseHandle(pi.hProcess);
+        ret EAGAIN;
+    }
+    ret pi.dwProcessId::i64;
+}
+
+# restore the inherit flag of the first n handles to its saved state.
+fun restore_inherit(list: *isize, prev: *u32, n: usize) {
+    var i: usize = 0;
+    for (i < n) {
+        SetHandleInformation(list[i], HANDLE_FLAG_INHERIT, prev[i] & HANDLE_FLAG_INHERIT);
+        i = i + 1;
+    }
+}
+
+# create a child with its standard streams redirected.
+#
+# inheritance is scoped with PROC_THREAD_ATTRIBUTE_HANDLE_LIST so the child
+# receives exactly the listed std handles — concurrent spawns cannot leak
+# unrelated inheritable handles (e.g. another thread's pipe ends) into it.
+# each listed handle is temporarily marked inheritable and restored to its
+# prior state on every path. a parent stream that does not exist (NULL or
+# invalid from GetStdHandle on a detached parent) passes through in hStd*
+# but is excluded from the inherit list.
+fun create_redirected(pathname: *u8, cmdline: *u8, env_block: ptr, stdin_fd: i32, stdout_fd: i32, stderr_fd: i32) i64 {
+    var fds: [3]i32;
+    fds[0] = stdin_fd;
+    fds[1] = stdout_fd;
+    fds[2] = stderr_fd;
+    var ids: [3]u32;
+    ids[0] = STD_INPUT_HANDLE;
+    ids[1] = STD_OUTPUT_HANDLE;
+    ids[2] = STD_ERROR_HANDLE;
+    var hs: [3]isize;
+
+    var i: usize = 0;
+    for (i < 3) {
+        if (fds[i] == -1) {
+            hs[i] = GetStdHandle(ids[i]);
+        } or {
+            hs[i] = get_handle(fds[i]);
+            if (hs[i] == INVALID_HANDLE_VALUE || hs[i] == 0) {
+                ret EBADF;
+            }
+        }
+        i = i + 1;
+    }
+
+    # unique valid handles to inherit; at least one exists because some
+    # stream was explicitly redirected through a validated fd
+    var list: [3]isize;
+    var prev: [3]u32;
+    var n: usize = 0;
+    i = 0;
+    for (i < 3) {
+        if (hs[i] != 0 && hs[i] != INVALID_HANDLE_VALUE) {
+            var dup: bool = false;
+            var j: usize = 0;
+            for (j < n) {
+                if (list[j] == hs[i]) {
+                    dup = true;
+                }
+                j = j + 1;
+            }
+            if (!dup) {
+                list[n] = hs[i];
+                n = n + 1;
+            }
+        }
+        i = i + 1;
+    }
+
+    # mark each listed handle inheritable, remembering its prior flags
+    i = 0;
+    for (i < n) {
+        if (GetHandleInformation(list[i], ?prev[i]) == 0) {
+            val e: i64 = last_error();
+            restore_inherit(?list[0], ?prev[0], i);
+            ret e;
+        }
+        if (SetHandleInformation(list[i], HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT) == 0) {
+            val e: i64 = last_error();
+            restore_inherit(?list[0], ?prev[0], i);
+            ret e;
+        }
+        i = i + 1;
+    }
+
+    var attr_buf: [128]u8;
+    var attr_size: usize = 0;
+    InitializeProcThreadAttributeList(nil, 1, 0, ?attr_size);
+    if (attr_size == 0 || attr_size > 128) {
+        restore_inherit(?list[0], ?prev[0], n);
+        ret ENOMEM;
+    }
+    if (InitializeProcThreadAttributeList((?attr_buf[0])::ptr, 1, 0, ?attr_size) == 0) {
+        val e: i64 = last_error();
+        restore_inherit(?list[0], ?prev[0], n);
+        ret e;
+    }
+    if (UpdateProcThreadAttribute((?attr_buf[0])::ptr, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, (?list[0])::ptr, n * 8, nil, nil) == 0) {
+        val e: i64 = last_error();
+        DeleteProcThreadAttributeList((?attr_buf[0])::ptr);
+        restore_inherit(?list[0], ?prev[0], n);
+        ret e;
+    }
+
+    var six: STARTUPINFOEXA;
+    zero_bytes((?six)::*u8, STARTUPINFOEXA_SIZE);
+    six.StartupInfo.cb = STARTUPINFOEXA_SIZE::u32;
+    six.StartupInfo.dwFlags = STARTF_USESTDHANDLES;
+    six.StartupInfo.hStdInput = hs[0];
+    six.StartupInfo.hStdOutput = hs[1];
+    six.StartupInfo.hStdError = hs[2];
+    six.lpAttributeList = (?attr_buf[0])::ptr;
+
+    var pi: PROCESS_INFORMATION;
+    val ok: i32 = CreateProcessA(
+        pathname, cmdline,
+        nil, nil,
+        1, EXTENDED_STARTUPINFO_PRESENT,
+        env_block, nil,
+        (?six)::*u8, (?pi)::*u8
+    );
+    val spawn_err: i64 = last_error();
+    DeleteProcThreadAttributeList((?attr_buf[0])::ptr);
+    restore_inherit(?list[0], ?prev[0], n);
+    if (ok == 0) {
+        ret spawn_err;
+    }
+    ret register_child(pi);
+}
+
+# create a child that inherits all three parent standard streams natively
+# (no STARTF_USESTDHANDLES), preserving working defaults even when the
+# parent is detached and GetStdHandle would report no stream.
+fun create_inherit(pathname: *u8, cmdline: *u8, env_block: ptr) i64 {
+    var si: STARTUPINFOA;
+    zero_bytes((?si)::*u8, STARTUPINFOA_SIZE);
+    si.cb = STARTUPINFOA_SIZE::u32;
+
+    var pi: PROCESS_INFORMATION;
+    val ok: i32 = CreateProcessA(
+        pathname, cmdline,
+        nil, nil,
+        1, 0,
+        env_block, nil,
+        (?si)::*u8, (?pi)::*u8
+    );
+    if (ok == 0) {
+        ret last_error();
+    }
+    ret register_child(pi);
 }
 
 # spawn: create a child process running the given program.
@@ -1197,13 +1396,13 @@ pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
 # spawn_redirected: spawn a child with its standard streams bound to
 # caller-supplied descriptors (-1 inherits the parent's stream).
 #
-# CreateProcess receives a STARTUPINFO with STARTF_USESTDHANDLES and all
-# three of hStdInput/hStdOutput/hStdError resolved to handles (GetStdHandle
-# for inherited streams). each child stream is marked inheritable and
-# bInheritHandles is set so the child receives them; the parent's other
-# handles stay non-inheritable. the process handle is tracked in the
-# process table for wait/wait_pid. envp maps to the environment block;
-# nil inherits the parent's environment.
+# with no redirection the child inherits the parent's streams natively;
+# otherwise inheritance is scoped to exactly the child's std handles via
+# PROC_THREAD_ATTRIBUTE_HANDLE_LIST (see create_redirected). the process
+# handle is tracked in the process table for wait/wait_pid. envp maps to
+# the CreateProcess environment block; nil inherits the parent's
+# environment. an argv whose joined command line exceeds the 32 KiB
+# windows limit fails with E2BIG.
 # ---
 # pathname:  path to executable
 # argv:      null-terminated argument array
@@ -1214,31 +1413,9 @@ pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
 # ret:       child PID on success, or negative errno
 pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, stdout_fd: i32, stderr_fd: i32) i64 {
     var cmdline: [32768]u8;
-    build_cmdline(argv, ?cmdline[0], 32768);
-
-    val hin:  isize = resolve_child_handle(stdin_fd, STD_INPUT_HANDLE);
-    val hout: isize = resolve_child_handle(stdout_fd, STD_OUTPUT_HANDLE);
-    val herr: isize = resolve_child_handle(stderr_fd, STD_ERROR_HANDLE);
-    if (hin == INVALID_HANDLE_VALUE || hout == INVALID_HANDLE_VALUE || herr == INVALID_HANDLE_VALUE) {
-        ret EBADF;
+    if (!build_cmdline(argv, ?cmdline[0], 32768)) {
+        ret E2BIG;
     }
-
-    SetHandleInformation(hin, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
-    SetHandleInformation(hout, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
-    SetHandleInformation(herr, HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT);
-
-    var si: [104]u8;
-    var k: usize = 0;
-    for (k < 104) {
-        si[k] = 0;
-        k = k + 1;
-    }
-    val base: usize = (?si[0])::usize;
-    @(base::*u32) = 104;
-    @((base + 60)::*u32) = STARTF_USESTDHANDLES;
-    @((base + 80)::*isize) = hin;
-    @((base + 88)::*isize) = hout;
-    @((base + 96)::*isize) = herr;
 
     var env_size: usize = 0;
     var env_block: ptr = nil;
@@ -1249,27 +1426,16 @@ pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, s
         }
     }
 
-    var pi: PROCESS_INFORMATION;
-    val ok: i32 = CreateProcessA(
-        pathname, ?cmdline[0],
-        nil, nil,
-        1, 0,
-        env_block, nil,
-        ?si[0], (?pi)::*u8
-    );
+    var r: i64 = 0;
+    if (stdin_fd == -1 && stdout_fd == -1 && stderr_fd == -1) {
+        r = create_inherit(pathname, ?cmdline[0], env_block);
+    } or {
+        r = create_redirected(pathname, ?cmdline[0], env_block, stdin_fd, stdout_fd, stderr_fd);
+    }
     if (env_block != nil) {
         deallocate(env_block, env_size);
     }
-    if (ok == 0) {
-        ret last_error();
-    }
-
-    CloseHandle(pi.hThread);
-    if (!alloc_proc(pi.dwProcessId, pi.hProcess)) {
-        CloseHandle(pi.hProcess);
-        ret EAGAIN;
-    }
-    ret pi.dwProcessId::i64;
+    ret r;
 }
 
 # getpid: return the current process ID.
@@ -1367,49 +1533,72 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
 # captured environment vector, built once from the win32 environment block.
 var _environ_vec:  **u8 = nil;
 var _environ_init: u8 = 0;
+var _environ_lock: i64 = 0;
+
+fun environ_spin_lock() {
+    var expected: i64 = 0;
+    for (!atomic.cas(?_environ_lock, ?expected, 1)) {
+        expected = 0;
+    }
+}
+
+fun environ_spin_unlock() {
+    atomic.store(?_environ_lock, 0);
+}
 
 # environ: the process environment as a unix-style "NAME=VALUE" vector.
 #
 # parses the win32 environment block (GetEnvironmentStrings) into a
 # null-terminated array of pointers on first call and caches it for the
 # process lifetime; the block backs the entries, so it is retained rather
-# than freed. returns nil if the block is unavailable or allocation fails.
+# than freed. the hidden drive-cwd entries the block prepends (names
+# starting with '=', e.g. "=C:=C:\...") are skipped — they violate the
+# NAME=value contract. returns nil if the block is unavailable or
+# allocation fails; failure is not cached, so a later call may succeed.
 pub fun environ() **u8 {
     if (_environ_init != 0) {
         ret _environ_vec;
     }
-    _environ_init = 1;
+    environ_spin_lock();
+    if (_environ_init != 0) {
+        environ_spin_unlock();
+        ret _environ_vec;
+    }
     val block: *u8 = GetEnvironmentStringsA();
     if (block::usize == 0) {
+        environ_spin_unlock();
         ret nil;
     }
     var count: usize = 0;
     var p: usize = block::usize;
     for (@(p::*u8) != 0) {
-        count = count + 1;
-        for (@(p::*u8) != 0) {
-            p = p + 1;
+        if (@(p::*u8) != '=') {
+            count = count + 1;
         }
-        p = p + 1;
+        p = p + str_len(p::*u8) + 1;
     }
     val arr: ptr = allocate((count + 1) * 8);
     if (arr == nil) {
         FreeEnvironmentStringsA(block);
+        environ_spin_unlock();
         ret nil;
     }
     var vec: **u8 = arr::**u8;
     var i: usize = 0;
     p = block::usize;
-    for (i < count) {
-        vec[i] = p::*u8;
-        for (@(p::*u8) != 0) {
-            p = p + 1;
+    for (@(p::*u8) != 0) {
+        if (@(p::*u8) != '=') {
+            vec[i] = p::*u8;
+            i = i + 1;
         }
-        p = p + 1;
-        i = i + 1;
+        p = p + str_len(p::*u8) + 1;
     }
     vec[count] = nil;
+    # publish the vector before the init flag so a lock-free fast-path
+    # reader never observes the flag without the data
     _environ_vec = vec;
+    _environ_init = 1;
+    environ_spin_unlock();
     ret vec;
 }
 

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -1222,6 +1222,24 @@ fun build_env_block(envp: **u8, out_size: *usize) ptr {
     ret block;
 }
 
+# spawn lock: serializes the inheritance-sensitive span of process
+# creation. a redirected spawn temporarily marks its pipe handles
+# inheritable; any CreateProcess with bInheritHandles executing inside
+# that mark→create→restore window would inherit them, holding the pipe
+# open in an unrelated child.
+var _spawn_lock: i64 = 0;
+
+fun spawn_spin_lock() {
+    var expected: i64 = 0;
+    for (!atomic.cas(?_spawn_lock, ?expected, 1)) {
+        expected = 0;
+    }
+}
+
+fun spawn_spin_unlock() {
+    atomic.store(?_spawn_lock, 0);
+}
+
 # register a freshly created child in the process table for wait/wait_pid.
 fun register_child(pi: PROCESS_INFORMATION) i64 {
     CloseHandle(pi.hThread);
@@ -1298,17 +1316,21 @@ fun create_redirected(pathname: *u8, cmdline: *u8, env_block: ptr, stdin_fd: i32
         i = i + 1;
     }
 
-    # mark each listed handle inheritable, remembering its prior flags
+    # mark each listed handle inheritable, remembering its prior flags;
+    # the spawn lock covers the whole mark→create→restore window
+    spawn_spin_lock();
     i = 0;
     for (i < n) {
         if (GetHandleInformation(list[i], ?prev[i]) == 0) {
             val e: i64 = last_error();
             restore_inherit(?list[0], ?prev[0], i);
+            spawn_spin_unlock();
             ret e;
         }
         if (SetHandleInformation(list[i], HANDLE_FLAG_INHERIT, HANDLE_FLAG_INHERIT) == 0) {
             val e: i64 = last_error();
             restore_inherit(?list[0], ?prev[0], i);
+            spawn_spin_unlock();
             ret e;
         }
         i = i + 1;
@@ -1319,17 +1341,20 @@ fun create_redirected(pathname: *u8, cmdline: *u8, env_block: ptr, stdin_fd: i32
     InitializeProcThreadAttributeList(nil, 1, 0, ?attr_size);
     if (attr_size == 0 || attr_size > 128) {
         restore_inherit(?list[0], ?prev[0], n);
+        spawn_spin_unlock();
         ret ENOMEM;
     }
     if (InitializeProcThreadAttributeList((?attr_buf[0])::ptr, 1, 0, ?attr_size) == 0) {
         val e: i64 = last_error();
         restore_inherit(?list[0], ?prev[0], n);
+        spawn_spin_unlock();
         ret e;
     }
     if (UpdateProcThreadAttribute((?attr_buf[0])::ptr, 0, PROC_THREAD_ATTRIBUTE_HANDLE_LIST, (?list[0])::ptr, n * 8, nil, nil) == 0) {
         val e: i64 = last_error();
         DeleteProcThreadAttributeList((?attr_buf[0])::ptr);
         restore_inherit(?list[0], ?prev[0], n);
+        spawn_spin_unlock();
         ret e;
     }
 
@@ -1353,6 +1378,7 @@ fun create_redirected(pathname: *u8, cmdline: *u8, env_block: ptr, stdin_fd: i32
     val spawn_err: i64 = last_error();
     DeleteProcThreadAttributeList((?attr_buf[0])::ptr);
     restore_inherit(?list[0], ?prev[0], n);
+    spawn_spin_unlock();
     if (ok == 0) {
         ret spawn_err;
     }
@@ -1362,12 +1388,16 @@ fun create_redirected(pathname: *u8, cmdline: *u8, env_block: ptr, stdin_fd: i32
 # create a child that inherits all three parent standard streams natively
 # (no STARTF_USESTDHANDLES), preserving working defaults even when the
 # parent is detached and GetStdHandle would report no stream.
+#
+# bInheritHandles is set with no attribute list, so the spawn lock keeps
+# this create out of a concurrent redirected spawn's mark→restore window.
 fun create_inherit(pathname: *u8, cmdline: *u8, env_block: ptr) i64 {
     var si: STARTUPINFOA;
     zero_bytes((?si)::*u8, STARTUPINFOA_SIZE);
     si.cb = STARTUPINFOA_SIZE::u32;
 
     var pi: PROCESS_INFORMATION;
+    spawn_spin_lock();
     val ok: i32 = CreateProcessA(
         pathname, cmdline,
         nil, nil,
@@ -1375,6 +1405,7 @@ fun create_inherit(pathname: *u8, cmdline: *u8, env_block: ptr) i64 {
         env_block, nil,
         (?si)::*u8, (?pi)::*u8
     );
+    spawn_spin_unlock();
     if (ok == 0) {
         ret last_error();
     }


### PR DESCRIPTION
Implements the native windows process-exec backend over kernel32, completing `std.process.exec` on windows (previously linux/darwin-only).

## What changed
- `spawn_redirected` over `CreateProcessA` + `STARTUPINFO`/`STARTF_USESTDHANDLES`, with the three child streams resolved to handles (`GetStdHandle` for inherited, the fd table otherwise), marked inheritable, and passed under `bInheritHandles`. `spawn` now collapses onto it, matching the linux model.
- `envp` maps to a CreateProcess environment block (nil inherits the parent env).
- `read` translates `ERROR_BROKEN_PIPE` to EOF so `capture` drains an anonymous pipe cleanly.
- `environ()` is populated from `GetEnvironmentStrings` (cached for the process lifetime) instead of always-nil; resolves the windows half of #188.
- `build_cmdline` now quotes an empty argv entry as `""`.
- exec tests are now OS-conditional: windows drives `cmd.exe` builtins, posix keeps `/bin` utilities.

## Verification
- linux `mach test`: 538 passed, 0 failed (no regression).
- windows cross-build (full codegen) clean; `mach test --target windows` under wine 11.10: all 5 exec tests and all 5 env tests pass (`run` exit codes, `capture` of `echo hello` -> `hello\r\n`, `environ`). The 23 unrelated failures (path `\\`-separator semantics, dns hosts path) are pre-existing windows porting gaps, out of scope.

Closes #221