### PR TITLE
fix(darwin): read XNU child-indicator register in vfork()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   x86_64, x1 on aarch64) and returns 0 in the child instead of the child
   PID, so `spawn`/`spawn_redirected` take the exec path in the child rather
   than duplicating the parent program (#232).
+- darwin `vfork()` reads the same XNU child-indicator register as `fork()` and
+  returns 0 in the child instead of the child PID, fixing the identical
+  child-indicator bug in the previously plain `syscall0` wrapper (#234).
 
 ## [0.6.0] - 2026-06-12
 

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -742,8 +742,50 @@ pub fun fork() i64 {
     ret out;
 }
 
+# vfork: create a child process sharing the parent's address space,
+# suspending the parent until the child execs or exits.
+#
+# the XNU vfork trap uses the same two-register return convention as
+# fork: the child PID lands in the primary register (rax/x0) for BOTH
+# processes and the child is flagged via the second return register
+# (rdx == 1 on x86_64, x1 == 1 on aarch64). a plain syscall0 would leave
+# the child seeing pid != 0, so this wrapper reads the child indicator
+# and returns 0 in the child, mirroring fork. the carry flag is
+# materialized into `fail` (`setc`/`cset`) and the branch happens in
+# mach code. the parent-suspension semantics are kernel-side; the
+# wrapper shape matches fork.
+# ---
+# ret: child PID in the parent, 0 in the child, or negative errno
 pub fun vfork() i64 {
-    ret syscall0(SYS_VFORK);
+    var n: usize = SYS_VFORK;
+    var out: i64 = 0;
+    var fail: i64 = 0;
+    var child: i64 = 0;
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, 0x2000000
+            or rax, {n}
+            syscall
+            mov rcx, 0
+            setc cl
+            mov {fail}, rcx
+            mov {out}, rax
+            mov {child}, rdx
+        }
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            mov x16, {n}
+            svc 0x80
+            cset x9, cs
+            str x9, {fail}
+            str x0, {out}
+            str x1, {child}
+        }
+    }
+    if (fail != 0) { ret -out; }
+    if (child != 0) { ret 0; }
+    ret out;
 }
 
 pub fun exec(pathname: *u8, argv: **u8, envp: **u8) i64 {


### PR DESCRIPTION
Fixes the same XNU child-indicator bug in darwin `vfork()` that #232 fixed for `fork()`.

`vfork()` in `src/system/os/darwin/shared.mach` was still a plain `ret syscall0(SYS_VFORK)`. XNU's vfork trap returns the child PID in the primary register (rax/x0) for BOTH processes and flags the child via the second return register (rdx on x86_64, x1 on aarch64), so a vfork child saw `pid != 0` and would never take the child branch.

## Decision: fix, not remove

The linux backend exposes `vfork()` symmetrically in its shared interface (`src/system/os/linux/shared.mach`, forwarded via `linux.mach` / `linux/x86_64.mach`), so the OS interface carries `vfork` across backends. Removing only darwin's wrapper would break that symmetry. Linux's `vfork` syscall returns 0 in the child the normal way and needs no wrapper; only XNU has the two-register convention, so only darwin's wrapper changes.

The new wrapper mirrors the merged `fork()` pattern exactly (`$if`/`$or` per-arch asm, carry into `fail` via `setc`/`cset`, child indicator into `child`, `fail != 0 → ret -out`, `child != 0 → ret 0`). vfork's parent-suspension semantics are kernel-side; the wrapper shape is identical to fork.

No std consumer calls `vfork` today (`spawn`/`spawn_redirected` use `fork`), but the interface symmetry keeps the wrapper.

## Verification

darwin codegen is broken in mach 1.4.1 (x86_64 `setc cl` codegen error, no aarch64 abi), same limit as #232 — verified via parse/typecheck reaching the known failure point. Linux stays green:

- `mach build` (linux): exit 0
- `mach test` (linux): 538 passed, 0 failed

mach.toml left untouched.

Closes #234