### PR TITLE
fix(windows): per-symbol DLL attribution for winsock and RtlGenRandom imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Windows DLL import attribution: the winsock bindings (`WSAStartup`,
+  `WSAGetLastError`, `socket`/`bind`/`listen`/`accept`/`connect`/`sendto`/
+  `recvfrom`/`shutdown`/`setsockopt`/`send`/`recv`, `closesocket`) now import
+  from `ws2_32.dll` and `SystemFunction036` (RtlGenRandom) from `advapi32.dll`
+  via the compiler's per-symbol `$<sym>.library` attribution, instead of every
+  import collapsing onto `kernel32.dll` and aborting at call time. `ws2_32.dll`
+  and `advapi32.dll` are added to the windows link libraries, and the `SleepW`
+  binding is renamed to its real export `Sleep` (#235, #241).
 - `std.net.dns.resolve` now resolves `localhost` and any `.localhost`
   subdomain to `127.0.0.1` per RFC 6761, without consulting the hosts file or
   a nameserver, so loopback resolution is portable on platforms (e.g. windows)

--- a/mach.toml
+++ b/mach.toml
@@ -17,7 +17,7 @@ os  = "linux"
 abi = "sysv64"
 
 [os.windows]
-libs = ["kernel32.dll"]
+libs = ["kernel32.dll", "ws2_32.dll", "advapi32.dll"]
 
 [lib.std]
 entry = "lib.mach"

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -1,8 +1,11 @@
 # std.system.os.windows.shared: code shared across all windows ISA implementations.
 #
 # windows has no stable syscall interface. all OS interaction goes through
-# kernel32.dll and ntdll.dll via ext fun declarations. a HANDLE-to-fd
-# mapping table bridges the POSIX-style fd interface used by os.mach.
+# kernel32.dll and ntdll.dll via ext fun declarations, plus ws2_32.dll for
+# sockets and advapi32.dll for RtlGenRandom; the latter two are pinned with
+# `$<sym>.library` so the PE import directory attributes them to the right DLL
+# rather than the first dependency. a HANDLE-to-fd mapping table bridges the
+# POSIX-style fd interface used by os.mach.
 
 use std.types.size.usize;
 use std.types.size.isize;
@@ -211,35 +214,52 @@ ext fun CreateThread(p0: ptr, p1: usize, p2: usize, p3: ptr, p4: u32, p5: *u32) 
 ext fun WaitOnAddress(p0: ptr, p1: ptr, p2: usize, p3: u32) i32;
 ext fun WakeByAddressSingle(p0: ptr);
 
-# Winsock2 API imports (ws2_32.dll)
+# Winsock2 API imports (ws2_32.dll). each is pinned to ws2_32.dll with
+# `$<sym>.library`; without it an `ext` import binds to the first dependency
+# (kernel32.dll) and aborts at call time on a real loader.
 
+$WSAStartup.library = "ws2_32.dll";
 ext fun WSAStartup(p0: u16, p1: *u8) i32;
+$WSAGetLastError.library = "ws2_32.dll";
 ext fun WSAGetLastError() i32;
-$ws2_socket.symbol = "socket";
+$ws2_socket.library = "ws2_32.dll";
+$ws2_socket.symbol  = "socket";
 ext fun ws2_socket(p0: i32, p1: i32, p2: i32) usize;
-$ws2_bind.symbol = "bind";
+$ws2_bind.library = "ws2_32.dll";
+$ws2_bind.symbol  = "bind";
 ext fun ws2_bind(p0: usize, p1: *u8, p2: i32) i32;
-$ws2_listen.symbol = "listen";
+$ws2_listen.library = "ws2_32.dll";
+$ws2_listen.symbol  = "listen";
 ext fun ws2_listen(p0: usize, p1: i32) i32;
-$ws2_accept.symbol = "accept";
+$ws2_accept.library = "ws2_32.dll";
+$ws2_accept.symbol  = "accept";
 ext fun ws2_accept(p0: usize, p1: *u8, p2: *i32) usize;
-$ws2_connect.symbol = "connect";
+$ws2_connect.library = "ws2_32.dll";
+$ws2_connect.symbol  = "connect";
 ext fun ws2_connect(p0: usize, p1: *u8, p2: i32) i32;
-$ws2_sendto.symbol = "sendto";
+$ws2_sendto.library = "ws2_32.dll";
+$ws2_sendto.symbol  = "sendto";
 ext fun ws2_sendto(p0: usize, p1: *u8, p2: i32, p3: i32, p4: *u8, p5: i32) i32;
-$ws2_recvfrom.symbol = "recvfrom";
+$ws2_recvfrom.library = "ws2_32.dll";
+$ws2_recvfrom.symbol  = "recvfrom";
 ext fun ws2_recvfrom(p0: usize, p1: *u8, p2: i32, p3: i32, p4: *u8, p5: *i32) i32;
-$ws2_shutdown.symbol = "shutdown";
+$ws2_shutdown.library = "ws2_32.dll";
+$ws2_shutdown.symbol  = "shutdown";
 ext fun ws2_shutdown(p0: usize, p1: i32) i32;
-$ws2_setsockopt.symbol = "setsockopt";
+$ws2_setsockopt.library = "ws2_32.dll";
+$ws2_setsockopt.symbol  = "setsockopt";
 ext fun ws2_setsockopt(p0: usize, p1: i32, p2: i32, p3: *u8, p4: i32) i32;
-$ws2_send.symbol = "send";
+$ws2_send.library = "ws2_32.dll";
+$ws2_send.symbol  = "send";
 ext fun ws2_send(p0: usize, p1: *u8, p2: i32, p3: i32) i32;
-$ws2_recv.symbol = "recv";
+$ws2_recv.library = "ws2_32.dll";
+$ws2_recv.symbol  = "recv";
 ext fun ws2_recv(p0: usize, p1: *u8, p2: i32, p3: i32) i32;
+$closesocket.library = "ws2_32.dll";
 ext fun closesocket(p0: usize) i32;
 
 # advapi32.dll
+$SystemFunction036.library = "advapi32.dll";
 ext fun SystemFunction036(p0: *u8, p1: u32) i32;
 
 ext fun GetCurrentProcessId() u32;
@@ -254,8 +274,7 @@ ext fun SetHandleInformation(p0: isize, p1: u32, p2: u32) i32;
 ext fun InitializeProcThreadAttributeList(p0: ptr, p1: u32, p2: u32, p3: *usize) i32;
 ext fun UpdateProcThreadAttribute(p0: ptr, p1: u32, p2: usize, p3: ptr, p4: usize, p5: ptr, p6: ptr) i32;
 ext fun DeleteProcThreadAttributeList(p0: ptr);
-$SleepW.symbol = "Sleep";
-ext fun SleepW(p0: u32);
+ext fun Sleep(p0: u32);
 ext fun GetCurrentDirectoryA(p0: u32, p1: *u8) u32;
 ext fun GetEnvironmentVariableA(p0: *u8, p1: *u8, p2: u32) u32;
 ext fun GetEnvironmentStringsA() *u8;
@@ -1584,7 +1603,7 @@ pub fun pipe(fds: *i32) i64 {
 pub fun sleep(nsec: i64) {
     if (nsec <= 0) { ret; }
     val ms: u32 = (nsec / 1000000)::u32;
-    SleepW(ms);
+    Sleep(ms);
 }
 
 # getcwd: get the current working directory.


### PR DESCRIPTION
## Summary

Attributes the windows `ext` imports to their real DLLs using mach 1.5.0's
per-symbol `$<sym>.library` directive (octalide/mach#1383), so the PE import
directory no longer collapses every import onto `kernel32.dll`. Adds
`ws2_32.dll` and `advapi32.dll` to `[os.windows] libs`, and renames the `SleepW`
binding to its real export `Sleep` now that `.symbol` overrides survive the
`register_ext_fun` clobber.

Closes #235.
Addresses #241 (winsock half fixed; RtlGenRandom half blocked by a mach
compiler bug — see "Blocker" below). **Kept as draft pending that decision.**

## Directive syntax (as shipped in mach 1.5.0)

```mach
# bare export name + library pin
$WSAStartup.library = "ws2_32.dll";
ext fun WSAStartup(p0: u16, p1: *u8) i32;

# .library composes with .symbol (rename + DLL pin on one decl)
$ws2_socket.library = "ws2_32.dll";
$ws2_socket.symbol  = "socket";
ext fun ws2_socket(p0: i32, p1: i32, p2: i32) usize;
```

- The named library **must** be among the link's dependencies (`[os.windows]
  libs` here); pinning to an absent library is a hard link error, not a silent
  fallback — hence the `mach.toml` `libs` additions.
- An unattributed `ext` import binds to the **first** dependency (`kernel32.dll`),
  which is why only the non-kernel32 imports need pinning.
- `[os.windows] libs` is the OS-level dependency set; it merges into the windows
  link for every dependent, so the std test binaries inherit ws2_32/advapi32
  without any per-test manifest change.

## Import-table evidence (`llvm-readobj --coff-imports`, cross-built test exe)

**Before** — a single `kernel32.dll` descriptor carrying every import (the
`.symbol` renames already resolve under 1.5.0, but the DLL attribution is wrong):

```
Name: kernel32.dll
  kernel32.dll <= Sleep
  kernel32.dll <= send / recv / closesocket / WSAGetLastError / WSAStartup /
                  socket / bind / listen / accept / connect / sendto /
                  recvfrom / shutdown / setsockopt
  kernel32.dll <= SystemFunction036
```

Runtime (wine): `Call to unimplemented function kernel32.dll.WSAStartup, aborting`.

**After** — three correct descriptors, real export names under the right DLL:

```
Name: kernel32.dll   (Win32 set unchanged, incl. Sleep)
Name: ws2_32.dll
  ws2_32.dll <= WSAStartup, WSAGetLastError, socket, bind, listen, accept,
                connect, sendto, recvfrom, shutdown, setsockopt, send, recv,
                closesocket
Name: advapi32.dll
  advapi32.dll <= SystemFunction036
```

Every import resolves to the right DLL with the right export name, matching the
#235 audit table exactly.

## Verification (mach 1.5.0)

#243 (path-separator fix, PR #246) merged into `dev` mid-flight and is merged
into this branch; it fixed the 7 `path` failures and added 5 new path tests, so
the windows total shifted 539 → 544. Numbers below are re-baselined on the
merged tree; the relative delta of *this* change is **+4** (the winsock half).

| Target | dev (incl. #243) | dev + this PR |
|---|---|---|
| Linux `mach build`+`mach test` | 538 / 0 / 538 | **538 / 0 / 538** (windows module not compiled on linux) |
| Windows under wine (`--runner wine`) | 531 / 13 / 544 | **535 / 9 / 544** |

The 4 winsock tests (`tcp create`/`tcp bind`/`udp create`/`udp bind`) flip to
passing — the ws2_32 attribution works end-to-end under wine. The remaining 9
(`crypto rand fill`/`u64`/`u32`, `rand init`, `filesystem
temp`/`rw`/`info`/`create-read`/`unlink`) are the RtlGenRandom set, blocked
below. (Pre-#243 the same change measured 519/20/539 → 523/16/539.)

## Blocker: mach compiler PLT/IAT thunk bug (advapi32 half)

The import **table** is correct, but the 9 `SystemFunction036` tests still crash
at runtime — and this is a mach compiler bug, not an attribution problem:

- The advapi32 descriptor's `FirstThunk` (where the loader writes the resolved
  address) is RVA `0xC84A0`, but the `SystemFunction036` PLT call-thunk jumps
  through RVA `0xC8498`:
  ```
  1400c718c: ff 25 06 13 00 00   jmpq *0x1306(%rip)   # 0x1400c8498
  ```
  `0xC8498` is ws2_32's IAT **null terminator** (always 0) → `jmp 0` → page fault
  on execute at `0x0`. The thunk is off by one IAT slot (8 bytes) for the third
  import descriptor — it accounts for one inter-descriptor null terminator but
  not the second.
- This is independent of wine (a null IAT slot would fault on real Windows too)
  and independent of this PR's source (the descriptors/names/DLLs are all
  correct). A minimal 3-descriptor program (kernel32+ws2_32+advapi32) links the
  thunk correctly; the std test binaries (52 kernel32 + 14 ws2_32 + 1 advapi32)
  trip it deterministically (reproduced on a clean rebuild).

This needs a compiler fix analogous to #1383 (the import-directory writer must
target each PLT thunk at its descriptor's `FirstThunk` slot, not a running
contiguous offset). Once that lands, the 9 RtlGenRandom tests pass with no
further mach-std change — the attribution here is already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
