### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-06-12
+
+Windows-stabilization release: native process spawning (CreateProcess backend
+with stdio redirection and capture), correct per-DLL import attribution
+(ws2_32/advapi32), dual-separator path parsing, RFC 6761 localhost resolution,
+and darwin fork/vfork child-indicator fixes. Requires mach v1.5.0 (per-symbol
+DLL attribution).
 
 ### Added
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "std"
 name    = "Mach Standard Library"
-version = "0.6.0"
+version = "0.7.0"
 src     = "src"
 dep     = "dep"
 target  = "native"


### PR DESCRIPTION
Rolls Unreleased into [0.7.0] and bumps the manifest version. Windows-stabilization release pairing with mach v1.5.0; see CHANGELOG for the full Added/Fixed list. Verified: build + 538/538 tests green under the mach v1.5.0 release binary.