### PR TITLE
feat(path): recognize windows drive-letter and UNC absolute roots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wine, whose kernel32 lacks the `WaitOnAddress`/`WakeByAddressSingle`
   exports that real windows 8+ provides; the thread sync code is unchanged
   and correct on real windows (#244).
+- `std.types.path` now recognizes windows absolute roots: drive-letter
+  roots (`C:\`, `C:/`) and UNC roots (`\\server\share`) are absolute, and
+  `is_root`/`filename`/`extension`/`stem`/`parent` never split inside them
+  (`parent("C:\\foo")` → `C:\`, `parent("\\server\share\foo")` →
+  `\\server\share`, each root being its own parent). A bare drive reference
+  `C:` is drive-relative — a root unit but not absolute, matching Win32.
+  POSIX behavior is unchanged (#248).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `std.types.path` now recognizes windows absolute roots: drive-letter
+  roots (`C:\`, `C:/`) and UNC roots (`\\server\share`) are absolute, and
+  `is_root`/`filename`/`extension`/`stem`/`parent` never split inside them
+  (`parent("C:\foo")` → `C:\`, `parent("\\server\share\foo")` →
+  `\\server\share`, each root being its own parent). A bare drive reference
+  `C:` is drive-relative — a root unit but not absolute, matching Win32.
+  POSIX behavior is unchanged (#248).
+
 ## [0.7.0] - 2026-06-12
 
 Windows-stabilization release: native process spawning (CreateProcess backend
@@ -45,13 +57,6 @@ DLL attribution).
   wine, whose kernel32 lacks the `WaitOnAddress`/`WakeByAddressSingle`
   exports that real windows 8+ provides; the thread sync code is unchanged
   and correct on real windows (#244).
-- `std.types.path` now recognizes windows absolute roots: drive-letter
-  roots (`C:\`, `C:/`) and UNC roots (`\\server\share`) are absolute, and
-  `is_root`/`filename`/`extension`/`stem`/`parent` never split inside them
-  (`parent("C:\\foo")` → `C:\`, `parent("\\server\share\foo")` →
-  `\\server\share`, each root being its own parent). A bare drive reference
-  `C:` is drive-relative — a root unit but not absolute, matching Win32.
-  POSIX behavior is unchanged (#248).
 
 ### Fixed
 

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -10,10 +10,21 @@
 # posix only '/' separates ('\' is a legal filename byte). construction
 # (join, separator) emits the platform-preferred separator, and stored
 # paths are never normalized.
+#
+# windows absolute roots: drive-letter roots ('C:\', 'C:/') and UNC roots
+# ('\\server\share') are recognized as absolute, and filename/parent/is_root
+# never split inside them. a bare drive reference 'C:' (or 'C:foo') is
+# drive-relative: it is a root unit (its own parent, empty filename) but is
+# NOT absolute, matching Win32 where 'C:foo' resolves against the current
+# directory on drive C. a UNC '\\server\share' is one indivisible root unit
+# (a bare '\\server' is not a usable path and is likewise treated as a whole
+# root). join does no drive-relative special-casing: join("C:", "foo")
+# inserts a separator yielding "C:\foo".
 
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
+use std.types.char.char_is_alpha;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
@@ -49,24 +60,70 @@ fun is_separator(c: u8) bool {
     }
 }
 
+# root_len: byte length of the absolute root prefix at the head of p.
+#
+# recognizes windows drive roots ('C:' or 'C:\') and UNC roots
+# ('\\server\share'); returns 0 for relative paths, single-separator roots,
+# and on all non-windows targets. callers use it so filename/parent/is_root
+# never split inside a volume or UNC root.
+fun root_len(p: Path) usize {
+    $if ($mach.target.os == $mach.os.windows) {
+        if (is_empty(p)) { ret 0; }
+        val len: usize = str_len(p);
+
+        # UNC: two leading separators, root spans '\\server\share'.
+        if (len >= 2 && is_separator(p[0]) && is_separator(p[1])) {
+            var i: usize = 2;
+            for (i < len && !is_separator(p[i])) { i = i + 1; }
+            for (i < len && is_separator(p[i]))  { i = i + 1; }
+            for (i < len && !is_separator(p[i])) { i = i + 1; }
+            ret i;
+        }
+
+        # drive: 'X:' plus its root separator when present.
+        if (char_is_alpha(p[0]) && len >= 2 && p[1] == ':') {
+            if (len >= 3 && is_separator(p[2])) { ret 3; }
+            ret 2;
+        }
+
+        ret 0;
+    }
+    $or {
+        ret 0;
+    }
+}
+
 # is_empty: check whether a path is empty or nil.
 pub fun is_empty(p: Path) bool {
     ret p == nil || p[0] == 0;
 }
 
 # is_abs: check whether a path is absolute.
+#
+# a path is absolute when it begins with a separator (a posix or UNC root)
+# or, on windows, with a drive-letter root 'X:\' / 'X:/'. a bare drive
+# reference 'C:' or 'C:foo' is drive-relative and is not absolute.
 pub fun is_abs(p: Path) bool {
     if (p == nil) { ret false; }
+    if (is_separator(p[0])) { ret true; }
 
-    ret is_separator(p[0]);
+    $if ($mach.target.os == $mach.os.windows) {
+        if (char_is_alpha(p[0]) && p[1] == ':' && is_separator(p[2])) { ret true; }
+    }
+
+    ret false;
 }
 
-# is_root: check whether a path consists only of separators.
+# is_root: check whether a path is a root unit.
+#
+# true when p is only separators, or (on windows) exactly a drive or UNC
+# root followed by any trailing separators.
 pub fun is_root(p: Path) bool {
     if (is_empty(p)) { ret false; }
 
     val len: usize = str_len(p);
-    var i:   usize = 0;
+    val rl:  usize = root_len(p);
+    var i:   usize = rl;
 
     for (i < len) {
         if (!is_separator(p[i])) { ret false; }
@@ -86,14 +143,18 @@ pub fun is_root(p: Path) bool {
 pub fun filename(p: Path) str {
     if (is_empty(p)) { ret nil; }
     val len: usize = str_len(p);
+    val rl:  usize = root_len(p);
     var i:   usize = len;
 
-    for (i > 0) {
+    for (i > rl) {
         i = i - 1;
         if (is_separator(p[i])) {
             ret (p::usize + i + 1)::str;
         }
     }
+
+    # nothing follows the root: the path is exactly its root prefix.
+    if (rl > 0) { ret (p::usize + rl)::str; }
 
     ret p;
 }
@@ -230,6 +291,8 @@ pub fun parent(a: *allocator.Allocator, p: Path) Result[Path, str] {
     if (is_empty(p)) { ret clone(a, "."); }
 
     val len: usize = str_len(p);
+    val rl:  usize = root_len(p);
+    if (rl > 0) { ret parent_rooted(a, p, rl); }
 
     # root results preserve the input's leading separator rather than
     # forcing the platform one, so a '/'-rooted path stays '/'-rooted.
@@ -277,6 +340,44 @@ fun clone_sep(a: *allocator.Allocator, sep: u8) Result[Path, str] {
     buf[1] = 0;
 
     ret ok[Path, str](buf::*u8);
+}
+
+# clone_prefix: clone the first n bytes of p as a null-terminated path.
+fun clone_prefix(a: *allocator.Allocator, p: Path, n: usize) Result[Path, str] {
+    val r: Result[*u8, str] = allocator.allocate[u8](a, n + 1);
+    if (is_err[*u8, str](r)) {
+        ret err[Path, str](unwrap_err[*u8, str](r));
+    }
+
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    mem.raw_copy(buf::ptr, p::ptr, n);
+    buf[n] = 0;
+
+    ret ok[Path, str](buf::*u8);
+}
+
+# parent_rooted: parent of a path whose head is an absolute root of length
+# rl (> 0). a path at the root returns the root itself, so the volume or
+# UNC root is never split or crossed.
+fun parent_rooted(a: *allocator.Allocator, p: Path, rl: usize) Result[Path, str] {
+    val len: usize = str_len(p);
+
+    var end: usize = len;
+    for (end > rl && is_separator(p[end - 1])) { end = end - 1; }
+    if (end <= rl) { ret clone_prefix(a, p, rl); }
+
+    var i: usize = end;
+    for (i > rl) {
+        i = i - 1;
+        if (is_separator(p[i])) { brk; }
+    }
+    if (i <= rl) { ret clone_prefix(a, p, rl); }
+
+    var parent_end: usize = i;
+    for (parent_end > rl && is_separator(p[parent_end - 1])) { parent_end = parent_end - 1; }
+    if (parent_end <= rl) { ret clone_prefix(a, p, rl); }
+
+    ret clone_prefix(a, p, parent_end);
 }
 
 test "path: is_abs with absolute path" {
@@ -407,6 +508,178 @@ $if ($mach.target.os == $mach.os.windows) {
         if (is_err[Path, str](r)) { ret 1; }
         val p: str = unwrap_ok[Path, str](r);
         if (!str_equals(p, "/foo")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: is_abs drive backslash root" {
+        if (!is_abs("C:\\foo")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: is_abs drive forward-slash root" {
+        if (!is_abs("C:/foo")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: is_abs bare drive is relative" {
+        if (is_abs("C:")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: is_abs drive-relative is relative" {
+        if (is_abs("C:foo")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: is_abs UNC root" {
+        if (!is_abs("\\\\server\\share")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: is_root drive backslash" {
+        if (!is_root("C:\\")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: is_root drive forward-slash" {
+        if (!is_root("C:/")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: is_root drive with component is not root" {
+        if (is_root("C:\\foo")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: is_root UNC share" {
+        if (!is_root("\\\\server\\share")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: is_root UNC with component is not root" {
+        if (is_root("\\\\server\\share\\foo")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: filename drive root component" {
+        val f: str = filename("C:\\foo.txt");
+        if (!str_equals(f, "foo.txt")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: filename drive-relative keeps drive out" {
+        val f: str = filename("C:foo.txt");
+        if (!str_equals(f, "foo.txt")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: filename UNC component" {
+        val f: str = filename("\\\\server\\share\\foo.txt");
+        if (!str_equals(f, "foo.txt")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: filename drive root is empty" {
+        val f: str = filename("C:\\");
+        if (!str_equals(f, "")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: filename UNC root is empty" {
+        val f: str = filename("\\\\server\\share");
+        if (!str_equals(f, "")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: extension drive path" {
+        val e: str = extension("C:\\foo.txt");
+        if (!str_equals(e, "txt")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: extension drive path none" {
+        val e: str = extension("C:\\foo");
+        if (e != nil) { ret 1; }
+        ret 0;
+    }
+
+    test "path: stem drive path" {
+        var a: allocator.Allocator;
+        page.make(?a);
+        val r: Result[Path, str] = stem(?a, "C:\\foo.txt");
+        if (is_err[Path, str](r)) { ret 1; }
+        val s: str = unwrap_ok[Path, str](r);
+        if (!str_equals(s, "foo")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: parent drive component" {
+        var a: allocator.Allocator;
+        page.make(?a);
+        val r: Result[Path, str] = parent(?a, "C:\\foo");
+        if (is_err[Path, str](r)) { ret 1; }
+        val p: str = unwrap_ok[Path, str](r);
+        if (!str_equals(p, "C:\\")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: parent drive nested" {
+        var a: allocator.Allocator;
+        page.make(?a);
+        val r: Result[Path, str] = parent(?a, "C:\\foo\\bar");
+        if (is_err[Path, str](r)) { ret 1; }
+        val p: str = unwrap_ok[Path, str](r);
+        if (!str_equals(p, "C:\\foo")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: parent drive root is itself" {
+        var a: allocator.Allocator;
+        page.make(?a);
+        val r: Result[Path, str] = parent(?a, "C:\\");
+        if (is_err[Path, str](r)) { ret 1; }
+        val p: str = unwrap_ok[Path, str](r);
+        if (!str_equals(p, "C:\\")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: parent drive forward-slash root" {
+        var a: allocator.Allocator;
+        page.make(?a);
+        val r: Result[Path, str] = parent(?a, "C:/foo");
+        if (is_err[Path, str](r)) { ret 1; }
+        val p: str = unwrap_ok[Path, str](r);
+        if (!str_equals(p, "C:/")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: parent drive-relative is drive" {
+        var a: allocator.Allocator;
+        page.make(?a);
+        val r: Result[Path, str] = parent(?a, "C:foo");
+        if (is_err[Path, str](r)) { ret 1; }
+        val p: str = unwrap_ok[Path, str](r);
+        if (!str_equals(p, "C:")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: parent UNC component" {
+        var a: allocator.Allocator;
+        page.make(?a);
+        val r: Result[Path, str] = parent(?a, "\\\\server\\share\\foo");
+        if (is_err[Path, str](r)) { ret 1; }
+        val p: str = unwrap_ok[Path, str](r);
+        if (!str_equals(p, "\\\\server\\share")) { ret 1; }
+        ret 0;
+    }
+
+    test "path: parent UNC root is itself" {
+        var a: allocator.Allocator;
+        page.make(?a);
+        val r: Result[Path, str] = parent(?a, "\\\\server\\share");
+        if (is_err[Path, str](r)) { ret 1; }
+        val p: str = unwrap_ok[Path, str](r);
+        if (!str_equals(p, "\\\\server\\share")) { ret 1; }
         ret 0;
     }
 }


### PR DESCRIPTION
Closes #248

Follow-up to #243/#246 (dual-separator parsing). Teaches `std.types.path` to recognize windows-specific absolute roots, extending the private `is_separator` design with a new `root_len` helper. Windows-gated via `$if ($mach.target.os == $mach.os.windows)`; POSIX behavior is byte-identical.

## Semantics chosen

- **`is_abs`** — absolute when the path begins with a separator (posix/UNC root) or, on windows, a drive-letter root `X:\` / `X:/`. A bare drive reference `C:` or `C:foo` is **drive-relative and NOT absolute** (Win32 `GetFullPathName` resolves it against the current dir on drive C).
- **`root_len` (new, private)** — byte length of the absolute root prefix: drive `C:` (2) or `C:\` (3), or UNC `\\server\share` (through the share). Returns 0 for relative, single-separator, and all non-windows paths. `filename`/`parent`/`is_root` use it so they never split inside a volume or UNC root.
- **`parent`** — `parent("C:\\foo")` → `C:\`, `parent("C:\\")` → `C:\` (root is its own parent, mirroring `parent("/")` → `/`); `parent("C:foo")` → `C:`; `parent("\\server\share\\foo")` → `\\server\share`; `parent("\\server\share")` → itself.
- **`filename`/`extension`/`stem`** — never treat the `C:` / UNC prefix as part of a filename (`filename("C:\\foo.txt")` → `foo.txt`, `filename("C:foo.txt")` → `foo.txt`). `filename` of a bare root is the empty string, like `filename("/")`.
- **UNC** — `\\server\share` is one indivisible root unit; a bare `\\server` (no share) is likewise treated as a whole root since it is not a usable path.
- **`is_root`** — true for `C:\`, `C:/`, `\\server\share` (plus trailing separators) and the existing all-separator forms. A bare drive `C:` is a root unit too (its own parent) though not absolute — the one rooted-but-not-absolute case, documented in the module header.
- **`join`** — unchanged; no drive-relative special-casing. `join("C:", "foo")` inserts a separator → `C:\foo` (documented).

No path normalization, no stored-path rewriting, construction unchanged.

## Tests

Extended the existing `$if windows` block with 25 drive/UNC cases across `is_abs`, `is_root`, `filename`, `extension`, `stem`, and `parent`.

- linux (`mach test`, v1.5.0): **538 passed / 0 failed** (unchanged from dev baseline).
- windows under wine (`mach test --target windows`, v1.5.0): **556 passed / 13 failed / 569 total** — the 13 failures are pre-existing wine limitations (unchanged from the 531/13/544 dev baseline); the +25 delta is the new path tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)