### PR TITLE
fix(windows): pin wait-on-address family to synch apiset dll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `C:` is drive-relative — a root unit but not absolute, matching Win32.
   POSIX behavior is unchanged (#248).
 
+### Fixed
+
+- Windows `WaitOnAddress`/`WakeByAddressSingle` are now pinned to
+  `api-ms-win-core-synch-l1-2-0.dll` (added to `[os.windows] libs`). Real
+  windows' kernel32 does not export the wait-on-address family — only wine's
+  does — so the unpinned imports bound to kernel32 and the native loader
+  rejected every mach exe with `STATUS_ENTRYPOINT_NOT_FOUND` before main
+  (#253).
+
 ## [0.7.0] - 2026-06-12
 
 Windows-stabilization release: native process spawning (CreateProcess backend

--- a/mach.toml
+++ b/mach.toml
@@ -17,7 +17,7 @@ os  = "linux"
 abi = "sysv64"
 
 [os.windows]
-libs = ["kernel32.dll", "ws2_32.dll", "advapi32.dll"]
+libs = ["kernel32.dll", "ws2_32.dll", "advapi32.dll", "api-ms-win-core-synch-l1-2-0.dll"]
 
 [lib.std]
 entry = "lib.mach"

--- a/src/sync/thread.mach
+++ b/src/sync/thread.mach
@@ -109,9 +109,12 @@ test "thread: Thread record initializes" {
 
 test "thread: spawn and join" {
     $if ($mach.target.os == $mach.os.windows) {
-        # wine 11.10's kernel32 lacks WaitOnAddress/WakeByAddressSingle (a genuine
-        # gap; real windows 8+ exports them), so join's wait path aborts. skip
-        # under wine — the sync code is correct on real windows. see issue #244.
+        # WaitOnAddress/WakeByAddressSingle are correctly pinned to the synch
+        # apiset (#253), and wine resolves it (apiset -> kernelbase/ntdll) — but
+        # mach v1.5.0 omits the import call-thunk for the last PE import
+        # descriptor (mach#1388, the same codegen gap behind the #241 RtlGenRandom
+        # failures), so the wait path dispatches through a null pointer and
+        # faults. skip under wine until mach#1388 lands.
         if (win.running_under_wine()) { ret 0; }
     }
     atomic_mod.store(?test_flag, 0);
@@ -125,8 +128,8 @@ test "thread: spawn and join" {
 
 test "thread: is_done after join" {
     $if ($mach.target.os == $mach.os.windows) {
-        # see "thread: spawn and join" above — wine 11.10 lacks the kernel32
-        # wait-on-address exports, so skip under wine. issue #244.
+        # see "thread: spawn and join" above — the synch-apiset wait path faults
+        # under wine on mach#1388's missing last-descriptor thunk. skip under wine.
         if (win.running_under_wine()) { ret 0; }
     }
     atomic_mod.store(?test_flag, 0);

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -2,10 +2,11 @@
 #
 # windows has no stable syscall interface. all OS interaction goes through
 # kernel32.dll and ntdll.dll via ext fun declarations, plus ws2_32.dll for
-# sockets and advapi32.dll for RtlGenRandom; the latter two are pinned with
-# `$<sym>.library` so the PE import directory attributes them to the right DLL
-# rather than the first dependency. a HANDLE-to-fd mapping table bridges the
-# POSIX-style fd interface used by os.mach.
+# sockets, advapi32.dll for RtlGenRandom, and api-ms-win-core-synch-l1-2-0.dll
+# for the wait-on-address family; these are pinned with `$<sym>.library` so the
+# PE import directory attributes them to the right DLL rather than the first
+# dependency. a HANDLE-to-fd mapping table bridges the POSIX-style fd interface
+# used by os.mach.
 
 use std.types.size.usize;
 use std.types.size.isize;
@@ -211,7 +212,15 @@ ext fun QueryPerformanceCounter(p0: *i64) i32;
 ext fun QueryPerformanceFrequency(p0: *i64) i32;
 
 ext fun CreateThread(p0: ptr, p1: usize, p2: usize, p3: ptr, p4: u32, p5: *u32) isize;
+
+# WaitOnAddress / WakeByAddressSingle live in the synch apiset DLL, not kernel32.
+# real windows' kernel32 does not export them (only wine's does), so without
+# `$<sym>.library` the import binds to kernel32 and the native loader rejects the
+# exe with STATUS_ENTRYPOINT_NOT_FOUND. pin them to the canonical apiset DLL. see
+# issue #253.
+$WaitOnAddress.library = "api-ms-win-core-synch-l1-2-0.dll";
 ext fun WaitOnAddress(p0: ptr, p1: ptr, p2: usize, p3: u32) i32;
+$WakeByAddressSingle.library = "api-ms-win-core-synch-l1-2-0.dll";
 ext fun WakeByAddressSingle(p0: ptr);
 
 # Winsock2 API imports (ws2_32.dll). each is pinned to ws2_32.dll with


### PR DESCRIPTION
Closes #253

`WaitOnAddress`/`WakeByAddressSingle` (src/system/os/windows/shared.mach) had no `$<sym>.library` pin, so they bound to the first dependency (kernel32.dll). Real windows' kernel32 does **not** export the wait-on-address family — only wine's does — so the native loader rejected every mach exe with `STATUS_ENTRYPOINT_NOT_FOUND` (0xC0000139) before main. Canonical DLL per MS docs and real-runner probing: `api-ms-win-core-synch-l1-2-0.dll`.

## Changes

- Add `api-ms-win-core-synch-l1-2-0.dll` to `[os.windows] libs` in mach.toml.
- Pin `$WaitOnAddress.library` and `$WakeByAddressSingle.library` to it. (`WakeByAddressAll` is bound nowhere.)
- Correct the `thread.mach` wine-skip rationale (the old text claimed kernel32 exports these on real windows — #253 disproves that).

Same shape as merged PR #249.

## Import-table evidence

Cross-built `545-thread__spawn_and_join` (x86_64 / win64), `llvm-readobj --coff-imports`:

```
Name: kernel32.dll
Name: ws2_32.dll
Name: advapi32.dll
Name: api-ms-win-core-synch-l1-2-0.dll
  ImportLookupTableRVA: 0xCA288
  ImportAddressTableRVA: 0xCA4C0
  Symbol: WakeByAddressSingle (0)
  Symbol: WaitOnAddress (0)
```

The new `api-ms-win-core-synch-l1-2-0.dll` descriptor now carries both names; they are no longer in the kernel32 descriptor.

## Test counts

- linux (`mach test`, v1.5.0): **538 passed / 0 failed** — unchanged.
- windows under wine (`mach test --target windows --runner wine`): **560 passed / 9 failed / 569 total** — unchanged from the dev baseline. All 9 failures are the #241 RtlGenRandom set (5 filesystem temp-file tests + 3 `crypto/rand` + 1 `rand` init), blocked on compiler bug mach#1388. No thread test regresses (the two spawn/join tests stay skipped under wine).

## Wine thread-test skip: KEPT (with corrected rationale)

Per the follow-on, I tested whether the pin lets the two thread tests pass under wine. **It does not** — but for a reason that corrects the old comment twice over:

- The old comment said wine lacks the exports and real windows' kernel32 has them. **Both are false.** #253 shows real kernel32 lacks them; tracing wine shows it resolves the apiset fine (`WaitOnAddress -> kernelbase`, `WakeByAddressSingle -> ntdll RtlWakeAddressSingle`, both non-null).
- The wait path still faults under wine because **mach v1.5.0 omits the import call-thunk for the *last* PE import descriptor** (the same codegen gap behind the #241/mach#1388 RtlGenRandom crashes). With the synch apiset appended last, its IAT slots (`0x1400ca4d0`/`0x1400ca4d8`) are referenced by no instruction — the thunk table stops at `0x1400c918c` — so `thread_wait`'s `WaitOnAddress(...)` call dispatches through a null pointer (`EXCEPTION_ACCESS_VIOLATION rip=0`, args `r8=8`/`r9=INFINITE` confirm the call).

Confirming it's mach#1388 and not a std bug: moving the synch apiset out of the last `libs` slot makes its thunk appear and **the thread spawn/join test passes under wine**. I did **not** ship that reorder — it's a workaround that exploits the compiler bug and merely shifts the breakage onto whatever ends up last (advapi32/RtlGenRandom). The proper fix is mach#1388; the skip stays until it lands.

## kernel32 audit (item 4) — clean

Audited every remaining unpinned (kernel32-bound) `ext fun` against MS docs. The distinguishing signal vs WaitOnAddress: WaitOnAddress's doc lists `Library: Synchronization.lib` / DLL an apiset, with **no bare `Kernel32.dll`** in `api_location`. Every other unpinned import lists `req.dll: Kernel32.dll` + `Kernel32.lib` and a bare `Kernel32.dll` in `api_location` (true export, not apiset-only). Spot-verified the highest-risk adjacent/post-Vista candidates: `WaitForSingleObject` (same synch-apiset neighborhood), `InitializeProcThreadAttributeList`, `GetFinalPathNameByHandleA` — all true kernel32 exports. **No further repins needed.** WaitOnAddress was the unique exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
