### PR TITLE
fix(windows): resolve temp dir per-OS for native windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `std.system.os.temp_dir(buf, cap)` resolves the OS temporary directory at
+  use time under the `env.get` truncation contract. Lookup order is per-OS:
+  posix consults `$TMPDIR` and falls back to `/tmp`; windows uses
+  `GetTempPathA` (`TMP` → `TEMP` → `USERPROFILE` → the windows directory).
+  `std.types.path.is_separator` is now public.
+
+### Fixed
+
+- `std.filesystem.temp_create` no longer hardcodes `/tmp`, which does not
+  exist on native windows; it resolves the temp directory per call via
+  `os.temp_dir`, fixing temp-file creation (and everything routed through it)
+  on windows while preserving posix behavior (#258).
+
 ## [0.8.0] - 2026-06-12
 
 Native-windows loader compliance: the wait-on-address family is pinned to its

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -76,7 +76,6 @@ pub val stdin:  File = File{fd: 0};
 pub val stdout: File = File{fd: 1};
 pub val stderr: File = File{fd: 2};
 
-val TEMP_DIR:          str   = "/tmp";
 val TEMP_MAX_ATTEMPTS: usize = 100;
 val HEX_CHARS:         str   = "0123456789abcdef";
 
@@ -402,9 +401,12 @@ pub fun create_dir_all(a: *allocator.Allocator, p: str, mode: i32) Result[bool, 
 }
 
 # temp_create: create a temporary file with a unique name.
+#
+# the file is created under the OS temp directory resolved at call time
+# (see os.temp_dir): $TMPDIR or "/tmp" on posix, GetTempPathA on windows.
 # ---
 # a:      allocator for the path
-# prefix: name prefix (e.g. "test" → "/tmp/test_<n>")
+# prefix: name prefix (e.g. "test" → "<tempdir>/test_<n>")
 # ret:    the created TempFile, or an error message
 pub fun temp_create(a: *allocator.Allocator, prefix: str) Result[TempFile, str] {
     var attempt: usize = 0;
@@ -480,24 +482,33 @@ fun file_read_cb(ctx: ptr, buf: *u8, len: usize) Result[usize, str] {
 }
 
 fun temp_build_path(a: *allocator.Allocator, prefix: str, rnd: *u8) Result[path.Path, str] {
-    var buf: [256]u8;
-    var off: usize = 0;
+    var buf: [512]u8;
 
-    val dir_len: usize = str_len(TEMP_DIR);
+    val dir_raw: i64 = os.temp_dir(?buf[0], 512);
+    if (dir_raw < 0) {
+        ret err[path.Path, str]("temp file: temp directory unavailable");
+    }
+    if (dir_raw::usize >= 512) {
+        ret err[path.Path, str]("temp path too long");
+    }
+    var off: usize = dir_raw::usize;
+
+    # GetTempPathA yields a trailing separator; $TMPDIR and "/tmp" do not.
+    # insert exactly one separator between the directory and the file name.
+    if (off == 0 || !path.is_separator(buf[off - 1])) {
+        buf[off] = os.separator;
+        off = off + 1;
+    }
+
     var prefix_len: usize = 0;
     if (prefix != nil) {
         prefix_len = str_len(prefix);
     }
-    val needed: usize = dir_len + 1 + prefix_len + 1 + 16 + 1;
-    if (needed > 256) {
+
+    val needed: usize = off + prefix_len + 1 + 16 + 1;
+    if (needed > 512) {
         ret err[path.Path, str]("temp path too long");
     }
-
-    mem.raw_copy(?buf[0], TEMP_DIR, dir_len);
-    off = dir_len;
-
-    buf[off] = 47;
-    off = off + 1;
 
     if (prefix != nil) {
         mem.raw_copy(?buf[off], prefix, prefix_len);

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -4,7 +4,9 @@
 # for platform-specific functionality, import the target module
 # directly (e.g. std.system.os.linux).
 
+use std.types.size.usize;
 use std.types.string.str;
+use std.types.string.str_len;
 
 use shared: std.system.os.shared;
 
@@ -189,6 +191,49 @@ fwd impl.random_fill;
 fwd impl.thread_spawn;
 fwd impl.thread_wait;
 fwd impl.thread_wake;
+
+# temp directory
+
+# temp_dir: resolve the directory designated for temporary files.
+#
+# follows the env.get truncation contract: ret < cap means the path was
+# copied and null-terminated; ret >= cap signals truncation and ret is the
+# full path length. lookup order is per-OS:
+#   windows: GetTempPathA — TMP, then TEMP, then USERPROFILE, then the
+#            windows directory; the result ends with a path separator
+#   posix:   the $TMPDIR environment variable, falling back to "/tmp"
+# ---
+# buf: destination buffer for the path
+# cap: buffer capacity in bytes
+# ret: full length of the path, or negative on error
+pub fun temp_dir(buf: *u8, cap: usize) i64 {
+    $if ($mach.target.os == $mach.os.windows) {
+        ret impl.temp_dir(buf, cap);
+    }
+    $or {
+        val n: i64 = impl.getenv("TMPDIR", buf, cap);
+        if (n > 0) { ret n; }
+        ret temp_dir_posix_default(buf, cap);
+    }
+}
+
+$if ($mach.target.os != $mach.os.windows) {
+    val TEMP_DIR_DEFAULT: str = "/tmp";
+
+    # copy the posix fallback temp directory into buf under the temp_dir
+    # truncation contract (used when $TMPDIR is unset or empty).
+    fun temp_dir_posix_default(buf: *u8, cap: usize) i64 {
+        val src: *u8 = TEMP_DIR_DEFAULT::*u8;
+        val len: usize = str_len(TEMP_DIR_DEFAULT);
+        var i: usize = 0;
+        for (i + 1 < cap && i < len) {
+            buf[i] = src[i];
+            i = i + 1;
+        }
+        if (i < cap) { buf[i] = 0; }
+        ret len::i64;
+    }
+}
 
 # time
 

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -121,6 +121,7 @@ fwd impl.pipe;
 fwd impl.sleep;
 fwd impl.getcwd;
 fwd impl.getenv;
+fwd impl.temp_dir;
 fwd impl.environ;
 fwd impl.wait;
 fwd impl.wait_pid;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -285,6 +285,7 @@ ext fun UpdateProcThreadAttribute(p0: ptr, p1: u32, p2: usize, p3: ptr, p4: usiz
 ext fun DeleteProcThreadAttributeList(p0: ptr);
 ext fun Sleep(p0: u32);
 ext fun GetCurrentDirectoryA(p0: u32, p1: *u8) u32;
+ext fun GetTempPathA(p0: u32, p1: *u8) u32;
 ext fun GetEnvironmentVariableA(p0: *u8, p1: *u8, p2: u32) u32;
 ext fun GetEnvironmentStringsA() *u8;
 ext fun FreeEnvironmentStringsA(p0: *u8) i32;
@@ -1657,6 +1658,30 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
     }
     # on truncation the api reports the required size including the
     # null terminator; normalize to the value length
+    if (len::usize >= cap) {
+        ret len::i64 - 1;
+    }
+    ret len::i64;
+}
+
+# temp_dir: resolve the directory designated for temporary files.
+#
+# GetTempPathA consults TMP, then TEMP, then USERPROFILE, then the windows
+# directory, returning the first as a path that ends with a separator. it
+# follows the getenv truncation contract: ret < cap means the path was
+# copied and null-terminated; ret >= cap means the buffer was too small and
+# ret is the full path length.
+# ---
+# buf: destination buffer for the path
+# cap: buffer capacity in bytes
+# ret: full length of the path, or negative errno
+pub fun temp_dir(buf: *u8, cap: usize) i64 {
+    val len: u32 = GetTempPathA(cap::u32, buf);
+    if (len == 0) {
+        ret last_error();
+    }
+    # on truncation the api reports the required size including the null
+    # terminator; normalize to the path length
     if (len::usize >= cap) {
         ret len::i64 - 1;
     }

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -120,6 +120,7 @@ fwd shared.pipe;
 fwd shared.sleep;
 fwd shared.getcwd;
 fwd shared.getenv;
+fwd shared.temp_dir;
 fwd shared.environ;
 fwd shared.wait;
 fwd shared.wait_pid;

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -51,7 +51,7 @@ pub fun separator() u8 {
 # is_separator: whether c separates path components on the target.
 #
 # windows accepts both '/' and '\'; posix treats only '/' as a separator.
-fun is_separator(c: u8) bool {
+pub fun is_separator(c: u8) bool {
     $if ($mach.target.os == $mach.os.windows) {
         ret c == separator() || c == '/';
     }


### PR DESCRIPTION
Closes #258.

Native windows could not create temp files because `filesystem` hardcoded `TEMP_DIR = "/tmp"`, a path that does not exist on windows. `temp_create` failed and cascaded into the filesystem temp tests plus the compiler repo's elf/coff round-trip tests (which all route through `fs.temp_create`).

## Change
- New OS-layer primitive `os.temp_dir(buf, cap)` resolves the temp directory at use time under the `env.get` truncation contract.
  - **posix:** `$TMPDIR`, falling back to `/tmp`.
  - **windows:** `GetTempPathA` — the canonical API, which walks `TMP -> TEMP -> USERPROFILE -> windows directory` and returns a backslash-terminated path. It is a genuine bare `Kernel32.dll` export (MS docs list `req.dll: Kernel32.dll`, unlike the apiset-only wait-on-address family from #253), and `kernel32.dll` is already in `[os.windows] libs`, so the import is pin-free.
- `filesystem.temp_build_path` now resolves the directory per call and inserts exactly one separator (GetTempPathA already trails one; `$TMPDIR`/`/tmp` do not), using the now-public `path.is_separator` and `os.separator`.

## Note on the exec half of #258
The issue also lists the exec tests spawning `/bin/*`. That was already fixed on `dev` by **#236** (merged before the cited native run): the exec fixtures are `$if`-gated to `cmd.exe` builtins via `%ComSpec%` on windows. The native lane run `27450090511` still hit `/bin/*` because the compiler repo consumes a **pinned mach-std release** that predates #236 — not because dev's gating is wrong (the `/bin/*` literals live only in the compile-time-pruned posix branch). Releasing std with this PR + #236 closes both halves once the compiler bumps its pin. No exec code change is needed here.

## Verification
- linux `mach build` + `mach test`: **538 passed, 0 failed** (baseline preserved).
- `$TMPDIR` override exercised against the `temp_create` test binary: unset -> `/tmp` (pass), existing custom dir -> pass, nonexistent dir -> `temp_create` fails (proving the env var is consulted).
- windows under wine: pending (reported in a follow-up comment).

Native windows cannot be tested locally; the mach agent's native lane is ground truth. The windows path uses GetTempPathA exactly as documented, conservatively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)