### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] - 2026-06-13
+
+Native-windows temp-file support: the temp directory is resolved per-OS at
+use time (GetTempPathA on windows, $TMPDIR with /tmp fallback on posix). With v0.8.0's
+loader fixes this completes the std side of the compiler's native windows
+CI lane (octalide/mach#1351); the exec-fixture half of #258 was already
+fixed in v0.7.0's OS-gated tests and ships via the pin bump.
 
 ### Added
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "std"
 name    = "Mach Standard Library"
-version = "0.8.0"
+version = "0.9.0"
 src     = "src"
 dep     = "dep"
 target  = "native"


### PR DESCRIPTION
Rolls Unreleased into [0.9.0]. Per-OS temp-dir resolution (#258) — completes the std side of the native windows CI lane. Verified: build + 538/538 under mach v1.5.0.