### PR TITLE
feat(fs): symlink creation + recursive remove primitives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `std.filesystem.symlink(target, linkpath)` creates a symbolic link
+  (`symlink(2)` on posix, `CreateSymbolicLinkA` on windows). Relative targets
+  are preserved verbatim so links keep resolving after their containing tree
+  is moved. The windows path requests unprivileged creation and reports a
+  privilege refusal as "operation not permitted". This gives the compiler's
+  dep machinery a primitive to replace its `ln -s` shell-out (#257).
+- `std.filesystem.remove_all(a, path)` removes a file, directory, or symbolic
+  link recursively, depth-first. Symbolic links are removed as links and never
+  followed, so a link pointing outside the tree leaves its target untouched;
+  removing a missing path succeeds. Replaces the dep machinery's `rm -rf`
+  shell-out (#257).
+- `std.filesystem.info_link(p)` is the `lstat` counterpart of `info_path`,
+  reporting a symbolic link's own metadata without following it.
+- `std.system.os.symlink(target, linkpath)` wires the new OS primitive through
+  the linux, darwin, and windows layers.
+
 ## [0.9.0] - 2026-06-13
 
 Native-windows temp-file support: the temp directory is resolved per-OS at

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -312,6 +312,22 @@ pub fun info_path(p: str) Result[FileInfo, str] {
     ret ok[FileInfo, str](info_from_stat(?st));
 }
 
+# info_link: get metadata for a path without following a final symbolic link.
+#
+# the lstat counterpart to info_path: a symbolic link reports its own metadata
+# (info_is_symlink is true) rather than the target's. use it to detect links
+# without resolving them.
+# ---
+# p:   path to query
+# ret: file metadata, or an error message
+pub fun info_link(p: str) Result[FileInfo, str] {
+    if (p == nil) { ret err[FileInfo, str]("path is nil"); }
+    var st: os.stat_t;
+    val raw: i64 = os.stat_path(os.AT_FDCWD, p, ?st, os.AT_SYMLINK_NOFOLLOW);
+    if (raw < 0) { ret err[FileInfo, str](os.message(raw)); }
+    ret ok[FileInfo, str](info_from_stat(?st));
+}
+
 # is_dir: check whether a path is an existing directory.
 pub fun is_dir(p: str) bool {
     val r: Result[FileInfo, str] = info_path(p);
@@ -350,6 +366,25 @@ pub fun unlink(p: str) Result[bool, str] {
 # ret:  true on success, or an error message
 pub fun rename(from: str, to: str) Result[bool, str] {
     val raw: i64 = os.rename(os.AT_FDCWD, from, os.AT_FDCWD, to);
+    if (raw < 0) { ret err[bool, str](os.message(raw)); }
+    ret ok[bool, str](true);
+}
+
+# symlink: create a symbolic link at linkpath pointing to target.
+#
+# the target is stored verbatim: a relative target is preserved as given, with
+# no resolution or normalization, so the link keeps resolving correctly after
+# its containing tree is moved. on posix this is symlink(2); on windows it is
+# CreateSymbolicLinkA requesting unprivileged creation, and a refusal for lack
+# of privilege surfaces as "operation not permitted".
+# ---
+# target:   path the link points to (preserved verbatim)
+# linkpath: path of the link to create
+# ret:      true on success, or an error message
+pub fun symlink(target: str, linkpath: str) Result[bool, str] {
+    if (target == nil)   { ret err[bool, str]("target is nil"); }
+    if (linkpath == nil) { ret err[bool, str]("linkpath is nil"); }
+    val raw: i64 = os.symlink(target, linkpath);
     if (raw < 0) { ret err[bool, str](os.message(raw)); }
     ret ok[bool, str](true);
 }
@@ -398,6 +433,170 @@ pub fun create_dir_all(a: *allocator.Allocator, p: str, mode: i32) Result[bool, 
     if (is_ok[bool, str](final_res)) { ret final_res; }
     if (is_dir(p)) { ret ok[bool, str](true); }
     ret final_res;
+}
+
+# bound on recursion depth for remove_all, guarding against unbounded
+# directory nesting (and any cyclic structure a symlink walk could never
+# create, since symlinks are removed rather than followed).
+val REMOVE_MAX_DEPTH: usize = 1024;
+
+# size of the stack buffer used per directory level to read raw directory
+# entries; large enough to hold several entries per read_dir call.
+val DIRENT_BUF_SIZE: usize = 8192;
+
+# remove_all: recursively remove a file, directory, or symbolic link.
+#
+# directories are removed depth-first — their contents first, then the
+# directory itself. symbolic links are removed as links and never followed:
+# a link inside the tree that points outside it leaves the target untouched.
+# this is the safety property a recursive delete must hold, and it relies on
+# an lstat-equivalent type check (info_is_symlink) rather than following the
+# link. removing a path that does not exist succeeds, so the operation is
+# idempotent like `rm -rf`.
+# ---
+# a:   allocator for transient child-path strings
+# p:   path to remove
+# ret: true on success, or an error message
+pub fun remove_all(a: *allocator.Allocator, p: str) Result[bool, str] {
+    if (a == nil) { ret err[bool, str]("allocator is nil"); }
+    if (p == nil) { ret err[bool, str]("path is nil"); }
+    ret remove_all_at(a, p, 0);
+}
+
+fun remove_all_at(a: *allocator.Allocator, p: str, depth: usize) Result[bool, str] {
+    if (depth >= REMOVE_MAX_DEPTH) {
+        ret err[bool, str]("remove_all: directory tree too deep");
+    }
+
+    # lstat (AT_SYMLINK_NOFOLLOW) so a symlink reports as a link, not its
+    # target — the walk must remove the link itself, never descend through it.
+    var st: os.stat_t;
+    val sr: i64 = os.stat_path(os.AT_FDCWD, p, ?st, os.AT_SYMLINK_NOFOLLOW);
+    if (sr < 0) {
+        if (sr == os.ENOENT) { ret ok[bool, str](true); }
+        ret err[bool, str](os.message(sr));
+    }
+    val fi: FileInfo = info_from_stat(?st);
+
+    # only a real directory is descended into; a symlink (even to a directory)
+    # is unlinked as a link
+    if (!info_is_dir(?fi) || info_is_symlink(?fi)) {
+        ret unlink(p);
+    }
+
+    val contents: Result[bool, str] = remove_dir_contents(a, p, depth);
+    if (is_err[bool, str](contents)) { ret contents; }
+
+    val rr: i64 = os.unlink(os.AT_FDCWD, p, os.AT_REMOVEDIR);
+    if (rr < 0) { ret err[bool, str](os.message(rr)); }
+    ret ok[bool, str](true);
+}
+
+# remove every entry inside directory p, then leave p empty for the caller to
+# remove. the full set of child names is collected before any removal so the
+# directory is never modified while it is being enumerated.
+fun remove_dir_contents(a: *allocator.Allocator, p: str, depth: usize) Result[bool, str] {
+    val open_res: i64 = os.open(os.AT_FDCWD, p, os.O_RDONLY | os.O_DIRECTORY, 0);
+    if (open_res < 0) { ret err[bool, str](os.message(open_res)); }
+    val dfd: i32 = open_res::i32;
+
+    var names: *u8 = nil;
+    var names_len: usize = 0;
+    var names_cap: usize = 0;
+    val read_res: Result[bool, str] = read_dir_names(a, dfd, ?names, ?names_len, ?names_cap);
+    os.close(dfd);
+    if (is_err[bool, str](read_res)) { ret read_res; }
+
+    var result: Result[bool, str] = ok[bool, str](true);
+    var off: usize = 0;
+    for (off < names_len) {
+        val name: str = (names::usize + off)::str;
+        off = off + str_len(name) + 1;
+
+        val join_res: Result[path.Path, str] = path.join(a, p, name);
+        if (is_err[path.Path, str](join_res)) {
+            result = err[bool, str](unwrap_err[path.Path, str](join_res));
+            brk;
+        }
+        val child: path.Path = unwrap_ok[path.Path, str](join_res);
+        val rr: Result[bool, str] = remove_all_at(a, child, depth + 1);
+        allocator.deallocate[u8](a, child::ptr::*u8, str_len(child) + 1);
+        if (is_err[bool, str](rr)) { result = rr; brk; }
+    }
+
+    if (names != nil) { allocator.deallocate[u8](a, names, names_cap); }
+    ret result;
+}
+
+# read all child names of an open directory fd into a single allocated buffer
+# of NUL-terminated strings, skipping "." and "..". on success the buffer,
+# its used length, and its capacity are returned through the out-pointers
+# (nil/0/0 for an empty directory); on error the buffer is freed.
+fun read_dir_names(a: *allocator.Allocator, dfd: i32, out_buf: **u8, out_len: *usize, out_cap: *usize) Result[bool, str] {
+    var dbuf: [DIRENT_BUF_SIZE]u8;
+    var buf: *u8 = nil;
+    var len: usize = 0;
+    var cap: usize = 0;
+
+    for (true) {
+        val n: i64 = os.read_dir(dfd, (?dbuf[0])::*os.dirent64, DIRENT_BUF_SIZE);
+        if (n < 0) {
+            if (buf != nil) { allocator.deallocate[u8](a, buf, cap); }
+            ret err[bool, str](os.message(n));
+        }
+        if (n == 0) { brk; }
+
+        var pos: usize = 0;
+        for (pos < n::usize) {
+            val ent:    *os.dirent64 = ((?dbuf[0])::usize + pos)::*os.dirent64;
+            val reclen: usize        = ent.d_reclen::usize;
+            val name:   *u8          = ?ent.d_name[0];
+
+            if (!is_dot_name(name)) {
+                val nl:   usize = str_len(name);
+                val need: usize = len + nl + 1;
+                if (need > cap) {
+                    var newcap: usize = cap;
+                    if (newcap == 0) { newcap = 256; }
+                    for (newcap < need) { newcap = newcap * 2; }
+                    val gr: Result[*u8, str] = grow_names(a, buf, cap, newcap);
+                    if (is_err[*u8, str](gr)) {
+                        if (buf != nil) { allocator.deallocate[u8](a, buf, cap); }
+                        ret err[bool, str](unwrap_err[*u8, str](gr));
+                    }
+                    buf = unwrap_ok[*u8, str](gr);
+                    cap = newcap;
+                }
+                mem.raw_copy((buf::usize + len)::ptr, name::ptr, nl);
+                buf[len + nl] = 0;
+                len = len + nl + 1;
+            }
+
+            # a zero record length would never advance pos; guard against a
+            # malformed buffer rather than spin forever
+            if (reclen == 0) { brk; }
+            pos = pos + reclen;
+        }
+    }
+
+    @out_buf = buf;
+    @out_len = len;
+    @out_cap = cap;
+    ret ok[bool, str](true);
+}
+
+fun grow_names(a: *allocator.Allocator, buf: *u8, cap: usize, newcap: usize) Result[*u8, str] {
+    if (buf == nil) { ret allocator.allocate[u8](a, newcap); }
+    ret allocator.reallocate[u8](a, buf, cap, newcap);
+}
+
+# whether a directory entry name is "." or ".." (the self/parent links that a
+# recursive walk must skip).
+fun is_dot_name(name: *u8) bool {
+    if (name[0] != '.'::u8) { ret false; }
+    if (name[1] == 0) { ret true; }
+    if (name[1] == '.'::u8 && name[2] == 0) { ret true; }
+    ret false;
 }
 
 # temp_create: create a temporary file with a unique name.
@@ -674,5 +873,130 @@ test "filesystem: unlink removes file" {
 
     val open_res: Result[File, str] = open(p);
     if (is_ok[File, str](open_res)) { ret 3; }
+    ret 0;
+}
+
+# allocate a unique, currently-unused path under the temp directory by
+# creating and removing a temp file, leaving its name free for the caller to
+# use as a fresh file or directory. the returned path string is caller-owned.
+fun temp_unique_name(a: *allocator.Allocator, prefix: str) Result[path.Path, str] {
+    val tr: Result[TempFile, str] = temp_create(a, prefix);
+    if (is_err[TempFile, str](tr)) {
+        ret err[path.Path, str](unwrap_err[TempFile, str](tr));
+    }
+    var tf: TempFile = unwrap_ok[TempFile, str](tr);
+    temp_close_and_remove(?tf);
+    ret ok[path.Path, str](tf.path);
+}
+
+test "filesystem: symlink relative target survives tree move" {
+    var a: allocator.Allocator;
+    page.make(?a);
+
+    val da: Result[path.Path, str] = temp_unique_name(?a, "symmv");
+    if (is_err[path.Path, str](da)) { ret 1; }
+    val dir_a: path.Path = unwrap_ok[path.Path, str](da);
+    if (is_err[bool, str](create_dir(dir_a, 0o755))) { ret 2; }
+
+    val tgt_res: Result[path.Path, str] = path.join(?a, dir_a, "target.txt");
+    if (is_err[path.Path, str](tgt_res)) { ret 3; }
+    val tgt: path.Path = unwrap_ok[path.Path, str](tgt_res);
+    val data: str = "verbatim-survives";
+    if (is_err[bool, str](write_file(tgt, data, str_len(data), 0o644))) { ret 4; }
+
+    val link_res: Result[path.Path, str] = path.join(?a, dir_a, "link");
+    if (is_err[path.Path, str](link_res)) { ret 5; }
+    val link: path.Path = unwrap_ok[path.Path, str](link_res);
+
+    # relative target, stored verbatim
+    if (is_err[bool, str](symlink("target.txt", link))) { ret 6; }
+
+    # lstat reports the link itself, not its target
+    val li: Result[FileInfo, str] = info_link(link);
+    if (is_err[FileInfo, str](li)) { ret 7; }
+    val lfi: FileInfo = unwrap_ok[FileInfo, str](li);
+    if (!info_is_symlink(?lfi)) { ret 8; }
+
+    # the link resolves to the target's contents in place
+    val rd1: Result[str, str] = read_all(?a, link);
+    if (is_err[str, str](rd1)) { ret 9; }
+    if (!str_starts_with(unwrap_ok[str, str](rd1), "verbatim-survives")) { ret 10; }
+
+    # move the whole tree: a verbatim relative target keeps resolving, while a
+    # resolved absolute target would now dangle
+    val nb: Result[path.Path, str] = temp_unique_name(?a, "symmv2");
+    if (is_err[path.Path, str](nb)) { ret 11; }
+    val dir_b: path.Path = unwrap_ok[path.Path, str](nb);
+    if (is_err[bool, str](rename(dir_a, dir_b))) { ret 12; }
+
+    val link_b_res: Result[path.Path, str] = path.join(?a, dir_b, "link");
+    if (is_err[path.Path, str](link_b_res)) { ret 13; }
+    val link_b: path.Path = unwrap_ok[path.Path, str](link_b_res);
+    val rd2: Result[str, str] = read_all(?a, link_b);
+    if (is_err[str, str](rd2)) { ret 14; }
+    if (!str_starts_with(unwrap_ok[str, str](rd2), "verbatim-survives")) { ret 15; }
+
+    remove_all(?a, dir_b);
+    ret 0;
+}
+
+test "filesystem: remove_all clears tree without following symlinks" {
+    var a: allocator.Allocator;
+    page.make(?a);
+
+    # an outside directory holding a file that must survive intact
+    val od: Result[path.Path, str] = temp_unique_name(?a, "rmout");
+    if (is_err[path.Path, str](od)) { ret 1; }
+    val outside: path.Path = unwrap_ok[path.Path, str](od);
+    if (is_err[bool, str](create_dir(outside, 0o755))) { ret 2; }
+    val keep_res: Result[path.Path, str] = path.join(?a, outside, "keep.txt");
+    if (is_err[path.Path, str](keep_res)) { ret 3; }
+    val keep: path.Path = unwrap_ok[path.Path, str](keep_res);
+    val kdata: str = "keepme";
+    if (is_err[bool, str](write_file(keep, kdata, str_len(kdata), 0o644))) { ret 4; }
+
+    # a small nested tree to remove
+    val rt: Result[path.Path, str] = temp_unique_name(?a, "rmtree");
+    if (is_err[path.Path, str](rt)) { ret 5; }
+    val root: path.Path = unwrap_ok[path.Path, str](rt);
+    if (is_err[bool, str](create_dir(root, 0o755))) { ret 6; }
+    val sub_res: Result[path.Path, str] = path.join(?a, root, "sub");
+    if (is_err[path.Path, str](sub_res)) { ret 7; }
+    val sub: path.Path = unwrap_ok[path.Path, str](sub_res);
+    if (is_err[bool, str](create_dir(sub, 0o755))) { ret 8; }
+    val f_res: Result[path.Path, str] = path.join(?a, sub, "file.txt");
+    if (is_err[path.Path, str](f_res)) { ret 9; }
+    val f: path.Path = unwrap_ok[path.Path, str](f_res);
+    if (is_err[bool, str](write_file(f, kdata, str_len(kdata), 0o644))) { ret 10; }
+
+    # a symlink inside the tree pointing at the outside directory; remove_all
+    # must delete the link and never recurse through it into `outside`
+    val danger_res: Result[path.Path, str] = path.join(?a, sub, "danger");
+    if (is_err[path.Path, str](danger_res)) { ret 11; }
+    val danger: path.Path = unwrap_ok[path.Path, str](danger_res);
+    if (is_err[bool, str](symlink(outside, danger))) { ret 12; }
+
+    if (is_err[bool, str](remove_all(?a, root))) { ret 13; }
+    if (exists(root)) { ret 14; }
+
+    # the outside directory and its file survived: the link was removed, not
+    # followed
+    if (!is_dir(outside)) { ret 15; }
+    if (!is_file(keep)) { ret 16; }
+
+    remove_all(?a, outside);
+    ret 0;
+}
+
+test "filesystem: remove_all on a missing path succeeds" {
+    var a: allocator.Allocator;
+    page.make(?a);
+
+    val miss: Result[path.Path, str] = temp_unique_name(?a, "rmgone");
+    if (is_err[path.Path, str](miss)) { ret 1; }
+    val gone: path.Path = unwrap_ok[path.Path, str](miss);
+
+    # the placeholder was already removed, so the path does not exist
+    if (is_err[bool, str](remove_all(?a, gone))) { ret 2; }
     ret 0;
 }

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -876,17 +876,50 @@ test "filesystem: unlink removes file" {
     ret 0;
 }
 
-# allocate a unique, currently-unused path under the temp directory by
-# creating and removing a temp file, leaving its name free for the caller to
-# use as a fresh file or directory. the returned path string is caller-owned.
+# allocate a unique, currently-unused path under the temp directory, built
+# from the prefix and the process id (no entropy source), and cleared of any
+# leftover from a prior interrupted run. avoiding the random temp name keeps
+# these tests off the RtlGenRandom path, which faults under wine on mach#1388;
+# the returned path string is caller-owned.
 fun temp_unique_name(a: *allocator.Allocator, prefix: str) Result[path.Path, str] {
-    val tr: Result[TempFile, str] = temp_create(a, prefix);
-    if (is_err[TempFile, str](tr)) {
-        ret err[path.Path, str](unwrap_err[TempFile, str](tr));
+    var buf: [512]u8;
+
+    val dir_raw: i64 = os.temp_dir(?buf[0], 512);
+    if (dir_raw < 0 || dir_raw::usize >= 512) {
+        ret err[path.Path, str]("temp directory unavailable");
     }
-    var tf: TempFile = unwrap_ok[TempFile, str](tr);
-    temp_close_and_remove(?tf);
-    ret ok[path.Path, str](tf.path);
+    var off: usize = dir_raw::usize;
+    if (off == 0 || !path.is_separator(buf[off - 1])) {
+        buf[off] = os.separator;
+        off = off + 1;
+    }
+
+    off = append_str(?buf[0], 512, off, "machstd_");
+    if (prefix != nil) { off = append_str(?buf[0], 512, off, prefix); }
+    off = append_str(?buf[0], 512, off, "_");
+    off = write_u64(off, ?buf[0], 512, os.getpid()::u64);
+    if (off + 1 >= 512) { ret err[path.Path, str]("temp path too long"); }
+    buf[off] = 0;
+
+    val r: Result[*u8, str] = allocator.allocate[u8](a, off + 1);
+    if (is_err[*u8, str](r)) {
+        ret err[path.Path, str](unwrap_err[*u8, str](r));
+    }
+    val out: *u8 = unwrap_ok[*u8, str](r);
+    mem.raw_copy(out::ptr, ?buf[0], off);
+    out[off] = 0;
+
+    remove_all(a, out::str);
+    ret ok[path.Path, str](out::str);
+}
+
+# append s to buf at off, returning the new offset (unchanged if it would not
+# fit, reserving the terminator slot).
+fun append_str(buf: *u8, cap: usize, off: usize, s: str) usize {
+    val len: usize = str_len(s);
+    if (off + len + 1 > cap) { ret off; }
+    mem.raw_copy((buf::usize + off)::ptr, s::ptr, len);
+    ret off + len;
 }
 
 test "filesystem: symlink relative target survives tree move" {

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -129,6 +129,7 @@ fwd impl.stat;
 fwd impl.stat_path;
 fwd impl.unlink;
 fwd impl.rename;
+fwd impl.symlink;
 fwd impl.make_dir;
 fwd impl.read_dir;
 fwd impl.access;

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -118,6 +118,7 @@ fwd impl.stat;
 fwd impl.stat_path;
 fwd impl.unlink;
 fwd impl.rename;
+fwd impl.symlink;
 fwd impl.make_dir;
 fwd impl.read_dir;
 fwd impl.access;

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -172,6 +172,7 @@ fwd shared.stat;
 fwd shared.stat_path;
 fwd shared.unlink;
 fwd shared.rename;
+fwd shared.symlink;
 fwd shared.make_dir;
 fwd shared.read_dir;
 fwd shared.access;

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -45,6 +45,7 @@ val SYS_RENAMEAT:         usize = 465;
 val SYS_UNLINKAT:         usize = 466;
 val SYS_FACCESSAT:        usize = 468;
 val SYS_FSTATAT64:        usize = 470;
+val SYS_SYMLINK:          usize = 57;
 val SYS_PIPE:             usize = 42;
 val SYS_SELECT:           usize = 93;
 val SYS_GETTIMEOFDAY:     usize = 116;
@@ -677,6 +678,18 @@ pub fun unlink(dirfd: i32, path: *u8, flags: i32) i64 {
 
 pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
     ret syscall4(SYS_RENAMEAT, olddir::isize::usize, oldpath::usize, newdir::isize::usize, newpath::usize);
+}
+
+# symlink: create a symbolic link at linkpath pointing to target.
+#
+# target is stored verbatim: a relative target stays relative, so the link
+# keeps resolving correctly after the containing tree is moved.
+# ---
+# target:   path the link points to (stored as given, not resolved)
+# linkpath: path of the link to create
+# ret:      0 on success, or negative errno
+pub fun symlink(target: *u8, linkpath: *u8) i64 {
+    ret syscall2(SYS_SYMLINK, target::usize, linkpath::usize);
 }
 
 pub fun make_dir(dirfd: i32, path: *u8, mode: i32) i64 {

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -173,6 +173,7 @@ fwd shared.stat;
 fwd shared.stat_path;
 fwd shared.unlink;
 fwd shared.rename;
+fwd shared.symlink;
 fwd shared.make_dir;
 fwd shared.read_dir;
 fwd shared.access;

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -124,6 +124,7 @@ fwd impl.stat;
 fwd impl.stat_path;
 fwd impl.unlink;
 fwd impl.rename;
+fwd impl.symlink;
 fwd impl.make_dir;
 fwd impl.read_dir;
 fwd impl.access;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -53,6 +53,7 @@ $if ($mach.target.arch == $mach.arch.x86_64) {
     val SYS_UNLINKAT:      usize = 263;
     val SYS_RENAMEAT:      usize = 264;
     val SYS_FACCESSAT:     usize = 269;
+    val SYS_SYMLINK:       usize = 88;
     pub val SYS_FUTEX:     usize = 202;
     val SYS_SENDTO:        usize = 44;
     val SYS_RECVFROM:      usize = 45;
@@ -743,6 +744,18 @@ pub fun unlink(dirfd: i32, path: *u8, flags: i32) i64 {
 # ret:     0 on success, or negative errno
 pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
     ret syscall4(SYS_RENAMEAT, olddir::isize::usize, oldpath::usize, newdir::isize::usize, newpath::usize);
+}
+
+# symlink: create a symbolic link at linkpath pointing to target.
+#
+# target is stored verbatim: a relative target stays relative, so the link
+# keeps resolving correctly after the containing tree is moved.
+# ---
+# target:   path the link points to (stored as given, not resolved)
+# linkpath: path of the link to create
+# ret:      0 on success, or negative errno
+pub fun symlink(target: *u8, linkpath: *u8) i64 {
+    ret syscall2(SYS_SYMLINK, target::usize, linkpath::usize);
 }
 
 # mkdirat: create a directory relative to a directory fd.

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -231,6 +231,7 @@ fwd shared.stat;
 fwd shared.stat_path;
 fwd shared.unlink;
 fwd shared.rename;
+fwd shared.symlink;
 fwd shared.make_dir;
 fwd shared.read_dir;
 fwd shared.access;

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -106,6 +106,7 @@ fwd impl.stat;
 fwd impl.stat_path;
 fwd impl.unlink;
 fwd impl.rename;
+fwd impl.symlink;
 fwd impl.make_dir;
 fwd impl.read_dir;
 fwd impl.access;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -111,6 +111,11 @@ val ERROR_TOO_MANY_OPEN_FILES: u32 = 4;
 val ERROR_BROKEN_PIPE:      u32 = 109;
 val ERROR_BUSY:             u32 = 170;
 val ERROR_ENVVAR_NOT_FOUND: u32 = 203;
+val ERROR_PRIVILEGE_NOT_HELD: u32 = 1314;
+
+# CreateSymbolicLink flags
+val SYMBOLIC_LINK_FLAG_DIRECTORY:                 u32 = 0x1;
+val SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE: u32 = 0x2;
 
 # lseek whence
 val SEEK_SET: i32 = 0;
@@ -206,6 +211,10 @@ ext fun FindFirstFileA(p0: *u8, p1: *u8) isize;
 ext fun FindNextFileA(p0: isize, p1: *u8) i32;
 ext fun FindClose(p0: isize) i32;
 ext fun GetFinalPathNameByHandleA(p0: isize, p1: *u8, p2: u32, p3: u32) u32;
+# CreateSymbolicLinkA is exported by kernel32.dll (the first dependency), so
+# an unqualified import binds correctly without a `$<sym>.library` pin (unlike
+# the synch-apiset functions of #253). it returns a BOOLEAN — a single byte.
+ext fun CreateSymbolicLinkA(p0: *u8, p1: *u8, p2: u32) u8;
 
 ext fun GetSystemTimeAsFileTime(p0: *u8);
 ext fun QueryPerformanceCounter(p0: *i64) i32;
@@ -680,6 +689,8 @@ fun last_error() i64 {
     val err: u32 = GetLastError();
     if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND) { ret ENOENT; }
     or (err == ERROR_ACCESS_DENIED) { ret EACCES; }
+    # symlink creation without developer mode or SeCreateSymbolicLinkPrivilege
+    or (err == ERROR_PRIVILEGE_NOT_HELD) { ret EPERM; }
     or (err == ERROR_ALREADY_EXISTS || err == ERROR_FILE_EXISTS) { ret EEXIST; }
     or (err == ERROR_INVALID_HANDLE || err == ERROR_INVALID_PARAMETER) { ret EINVAL; }
     or (err == ERROR_NOT_ENOUGH_MEMORY || err == ERROR_OUTOFMEMORY) { ret ENOMEM; }
@@ -1103,6 +1114,18 @@ pub fun stat_path(dirfd: i32, path: *u8, st: *stat_t, flags: i32) i64 {
     if (attr == 0xFFFFFFFF) {
         ret last_error();
     }
+    # lstat: under AT_SYMLINK_NOFOLLOW a reparse point is reported as a symlink
+    # without opening it, so the type reflects the link itself rather than its
+    # target. this is the property the recursive-remove walk relies on to delete
+    # the link and never follow it. only the type is populated; a symlink's
+    # size and timestamps are not read.
+    if ((flags & AT_SYMLINK_NOFOLLOW) != 0 && (attr & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
+        zero_bytes(st::*u8, $size_of(stat_t));
+        st.st_mode = S_IFLNK | 0o777::u32;
+        st.st_nlink = 1;
+        st.st_blksize = 4096;
+        ret 0;
+    }
     var open_flags: i32 = O_RDONLY;
     if ((attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
         open_flags = open_flags | O_DIRECTORY;
@@ -1125,6 +1148,19 @@ pub fun unlink(dirfd: i32, path: *u8, flags: i32) i64 {
         }
         ret 0;
     }
+    # a directory symlink or junction is a reparse point that also carries the
+    # directory attribute; like posix unlinkat on a symlink it is removed with
+    # RemoveDirectoryA, which unlinks the link itself and never the target.
+    # this keeps the recursive remove from failing on directory links.
+    val attr: u32 = GetFileAttributesA(path);
+    if (attr != 0xFFFFFFFF
+        && (attr & FILE_ATTRIBUTE_REPARSE_POINT) != 0
+        && (attr & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+        if (RemoveDirectoryA(path) == 0) {
+            ret last_error();
+        }
+        ret 0;
+    }
     if (DeleteFileA(path) == 0) {
         ret last_error();
     }
@@ -1137,6 +1173,100 @@ pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
         ret last_error();
     }
     ret 0;
+}
+
+# symlink: create a symbolic link at linkpath pointing to target.
+#
+# uses CreateSymbolicLinkA (the -A/ANSI entry point, consistent with the rest
+# of this layer; the file is uniformly ANSI and no UTF-8→UTF-16 helper exists).
+# target is passed verbatim so relative targets stay relative. the directory
+# flag is set when the target resolves to a directory — relative targets are
+# resolved against linkpath's parent, matching how the link itself resolves at
+# use time. ALLOW_UNPRIVILEGED_CREATE is always requested (it is honored under
+# developer mode and ignored otherwise); when the OS refuses for lack of
+# privilege the error maps to EPERM ("operation not permitted").
+# ---
+# target:   path the link points to (stored as given, not resolved)
+# linkpath: path of the link to create
+# ret:      0 on success, or negative errno
+pub fun symlink(target: *u8, linkpath: *u8) i64 {
+    var flags: u32 = SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE;
+    if (symlink_target_is_dir(target, linkpath)) {
+        flags = flags | SYMBOLIC_LINK_FLAG_DIRECTORY;
+    }
+    if (CreateSymbolicLinkA(linkpath, target, flags) == 0) {
+        ret last_error();
+    }
+    ret 0;
+}
+
+# whether the link target names a directory, for the CreateSymbolicLink
+# directory flag. an absolute target is queried directly; a relative target is
+# resolved against linkpath's parent directory (the same base the link resolves
+# against). a target that does not exist yet returns false, so a dangling link
+# is created as a file link.
+fun symlink_target_is_dir(target: *u8, linkpath: *u8) bool {
+    var attr: u32 = 0xFFFFFFFF;
+    if (path_is_abs(target)) {
+        attr = GetFileAttributesA(target);
+    }
+    or {
+        var buf: [520]u8;
+        if (!symlink_resolve_target(target, linkpath, ?buf[0], 520)) {
+            ret false;
+        }
+        attr = GetFileAttributesA((?buf[0])::*u8);
+    }
+    if (attr == 0xFFFFFFFF) {
+        ret false;
+    }
+    ret (attr & FILE_ATTRIBUTE_DIRECTORY) != 0;
+}
+
+# build "<linkpath-parent><sep><target>" into buf for the directory probe.
+# when linkpath has no directory component the target is left relative to the
+# cwd (copied as-is). returns false when the joined path would overflow buf.
+fun symlink_resolve_target(target: *u8, linkpath: *u8, buf: *u8, cap: usize) bool {
+    val link_len: usize = str_len(linkpath);
+    var parent_len: usize = 0;
+    var i: usize = 0;
+    for (i < link_len) {
+        if (linkpath[i] == '/'::u8 || linkpath[i] == '\\'::u8) {
+            parent_len = i + 1;
+        }
+        i = i + 1;
+    }
+    val target_len: usize = str_len(target);
+    if (parent_len + target_len + 1 > cap) {
+        ret false;
+    }
+    var j: usize = 0;
+    for (j < parent_len) {
+        buf[j] = linkpath[j];
+        j = j + 1;
+    }
+    var k: usize = 0;
+    for (k < target_len) {
+        buf[parent_len + k] = target[k];
+        k = k + 1;
+    }
+    buf[parent_len + target_len] = 0;
+    ret true;
+}
+
+# whether a path is absolute on windows: a leading separator, or a drive
+# letter followed by a colon (e.g. "C:\\...").
+fun path_is_abs(p: *u8) bool {
+    val c: u8 = p[0];
+    if (c == '/'::u8 || c == '\\'::u8) {
+        ret true;
+    }
+    if ((c >= 'A'::u8 && c <= 'Z'::u8) || (c >= 'a'::u8 && c <= 'z'::u8)) {
+        if (p[1] == ':'::u8) {
+            ret true;
+        }
+    }
+    ret false;
 }
 
 pub fun make_dir(dirfd: i32, path: *u8, mode: i32) i64 {

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -105,6 +105,7 @@ fwd shared.stat;
 fwd shared.stat_path;
 fwd shared.unlink;
 fwd shared.rename;
+fwd shared.symlink;
 fwd shared.make_dir;
 fwd shared.read_dir;
 fwd shared.access;


### PR DESCRIPTION
Closes #257

Adds the two filesystem primitives the compiler's dep machinery needs so it
can stop shelling out to `ln -s` and `rm` (hard failures on native windows).

## `std.filesystem.symlink(target, linkpath)`

- POSIX: `symlink(2)` (linux `SYS_symlink` 88, darwin 57).
- Windows: `CreateSymbolicLinkA` with `ALLOW_UNPRIVILEGED_CREATE`, and
  `SYMBOLIC_LINK_FLAG_DIRECTORY` when the target resolves to a directory
  (relative targets resolved against the link's parent dir). A privilege
  refusal surfaces as `EPERM` / "operation not permitted".
- Relative targets are stored **verbatim** — no resolution or normalization —
  so links keep resolving after their tree is moved.
- `info_link` (lstat counterpart of `info_path`) added to read a link's own
  metadata without following it.

## `std.filesystem.remove_all(a, path)`

- Depth-first directory walk; collects each level's child names before
  removing anything (never modifies a directory while enumerating it).
- **Symlinks are removed as links, never followed** — verified via an
  lstat-equivalent (`AT_SYMLINK_NOFOLLOW`) type check. fd usage is O(1) (the
  dir fd is closed before recursing); recursion depth is bounded.
- Idempotent: removing a missing path succeeds (`rm -rf` semantics).

## A-vs-W / directory-flag decisions

- **CreateSymbolicLinkA** (ANSI), consistent with the uniformly `-A` windows
  layer; no UTF-8→UTF-16 helper exists and none was added. Documented inline.
- **Directory flag**: stat the target relative to the link's parent (no caller
  hint), so the uniform `symlink(target, linkpath)` surface is preserved on
  all platforms. A dangling target defaults to a file link.

## Tests

- symlink create + `info_is_symlink` readback + relative-target verbatim
  survival across a tree move.
- `remove_all` on a nested tree containing a symlink to an outside directory;
  asserts the outside dir and its file survive (link not followed).
- `remove_all` on a missing path succeeds.

Linux `mach test`: 538 → 541 (0 failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification

- **Linux** (`mach test`): 538 → 541, 0 failed.
- **Windows under wine** (temporary `[target.windows]`): 563 passed, 9 failed,
  572 total. The 9 failures are the pre-existing RtlGenRandom/`temp_create`
  tests (mach#1388 missing import-thunk), unchanged. All 3 new tests pass —
  the test paths are derived from the pid rather than the entropy source so
  they exercise `CreateSymbolicLinkA` and directory-symlink removal under wine
  instead of crashing in `temp_create`. No `running_under_wine` gate needed.
