### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.10.0] - 2026-06-13
+
+Filesystem symlink and recursive-removal primitives, giving the compiler's
+dep machinery `symlink`/`remove_all` to replace its `ln -s`/`rm -rf`
+shell-outs (cross-platform, including native windows).
 
 ### Added
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "std"
 name    = "Mach Standard Library"
-version = "0.9.0"
+version = "0.10.0"
 src     = "src"
 dep     = "dep"
 target  = "native"


### PR DESCRIPTION
Rolls Unreleased into [0.10.0]. Filesystem symlink + recursive-removal primitives (#257). Verified: build + 541/541 under mach v1.5.0.