### PR TITLE
fix(sync,system): error on unsupported arch instead of silent miscompile

### DIFF
--- a/src/sync/atomic.mach
+++ b/src/sync/atomic.mach
@@ -38,6 +38,9 @@ pub fun load(ptr: *i64) i64 {
             ldar {result}, [x12]
         }
     }
+    $or {
+        $error("std.sync.atomic.load: unsupported architecture");
+    }
     ret result;
 }
 
@@ -62,6 +65,9 @@ pub fun store(ptr: *i64, v: i64) {
             mov x12, {ptr}
             stlr {v}, [x12]
         }
+    }
+    $or {
+        $error("std.sync.atomic.store: unsupported architecture");
     }
 }
 
@@ -104,6 +110,9 @@ pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
             dmb ish
         }
     }
+    $or {
+        $error("std.sync.atomic.cas: unsupported architecture");
+    }
     if (old == exp) { ret true; }
     @expected = old;
     ret false;
@@ -140,6 +149,9 @@ pub fun fetch_add(ptr: *i64, v: i64) i64 {
             dmb ish
         }
     }
+    $or {
+        $error("std.sync.atomic.fetch_add: unsupported architecture");
+    }
     ret old;
 }
 
@@ -175,6 +187,9 @@ pub fun fetch_sub(ptr: *i64, v: i64) i64 {
             dmb ish
         }
     }
+    $or {
+        $error("std.sync.atomic.fetch_sub: unsupported architecture");
+    }
     ret old;
 }
 
@@ -208,6 +223,9 @@ pub fun exchange(ptr: *i64, v: i64) i64 {
             dmb ish
         }
     }
+    $or {
+        $error("std.sync.atomic.exchange: unsupported architecture");
+    }
     ret old;
 }
 
@@ -223,6 +241,9 @@ pub fun fence() {
             dmb ish
         }
     }
+    $or {
+        $error("std.sync.atomic.fence: unsupported architecture");
+    }
 }
 
 # cpu yield hint for spin loops.
@@ -236,6 +257,9 @@ pub fun spin_hint() {
         asm aarch64 {
             yield
         }
+    }
+    $or {
+        $error("std.sync.atomic.spin_hint: unsupported architecture");
     }
 }
 

--- a/src/system/panic.mach
+++ b/src/system/panic.mach
@@ -41,6 +41,9 @@ pub fun panic(msg: *u8) {
                 svc 0x80
             }
         }
+        $or {
+            $error("std.system.panic: unsupported darwin architecture");
+        }
     }
 
     $if ($mach.target.arch == $mach.arch.x86_64) {
@@ -48,5 +51,8 @@ pub fun panic(msg: *u8) {
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         asm aarch64 { brk 0 }
+    }
+    $or {
+        $error("std.system.panic: unsupported architecture");
     }
 }


### PR DESCRIPTION
## Summary
Adds `$or { $error(...) }` fallbacks to every architecture `$if` chain in `src/sync/atomic.mach` (all 8 ops) and `src/system/panic.mach` (the darwin-write and terminate chains). Previously these branched x86_64/aarch64 with no else, so an unhandled arch (riscv64) compiled to **empty/no-op bodies with no error** — atomics silently returning 0 / doing nothing, panic failing to terminate, poisoning mutex, thread fences, and all lock-free code.

## Why
v1.6 stabilization before adding targets — converts a silent-miscompile landmine into a clear compile error. Maintainer-endorsed policy: every arch/os `$if` chain ends in `$or { $error }` (`os/linux.mach` is the model).

## Verification
Pure safety — **zero behavior change on x86_64/aarch64** (both already handled; the new branch is comptime-false). `mach build` + `mach test` green on x86_64: **541 passed, 0 failed**.

Note: `panic.mach`'s linux-write block (x86_64-hardcoded) is intentionally untouched here — its arch-split is the separate aarch64 self-host PR (#269), a different block of the file.

Closes #268. Part of the aarch64-linux readiness for octalide/mach#1431.