### PR TITLE
feat(runtime): aarch64-linux _start entry

### DIFF
--- a/src/runtime/linux.mach
+++ b/src/runtime/linux.mach
@@ -1,6 +1,9 @@
 $if ($mach.target.arch == $mach.arch.x86_64) {
     use std.runtime.linux.x86_64;
 }
+$or ($mach.target.arch == $mach.arch.aarch64) {
+    use std.runtime.linux.aarch64;
+}
 $or {
     $error("std.runtime.linux: unsupported architecture");
 }

--- a/src/runtime/linux/aarch64.mach
+++ b/src/runtime/linux/aarch64.mach
@@ -1,0 +1,85 @@
+# std.runtime.linux.aarch64: aarch64 (AAPCS64) linux entrypoint
+# ---
+# provides `_start`, the ELF entry point for aarch64 linux executables.
+#
+# on entry, the kernel places the following on the stack (same layout as
+# every LP64 linux triple — 8-byte slots):
+#   [sp]      = argc
+#   [sp+8]    = argv[0]
+#   [sp+16]   = argv[1]
+#   ...
+#   argv + (argc+1)*8 = envp[0]
+#
+# this entrypoint mirrors the x86_64 one:
+#   1. extracts argc, argv, and envp from the initial stack
+#   2. stores them into the runtime globals
+#   3. calls _rt_init to publish envp into the OS layer
+#   4. calls user-supplied `main(argc, argv)` (x0 = argc, x1 = argv)
+#   5. exits via SYS_exit_group with main's return code (terminates all
+#      threads; SYS_exit would leave non-main threads alive)
+#
+# user code must define:
+#   $main.symbol = "main";
+#   fun main(argc: i64, argv: **u8) i64 { ... }
+#
+# VERIFICATION STATUS — written ahead of the mach aarch64 backend; two
+# assumptions cannot be checked until the backend + qemu are available and
+# MUST be confirmed there (tracked with #270 / octalide/mach#1431):
+#   (a) Entry frame: like x86_64 `_start`, the first asm instruction reads the
+#       raw kernel-supplied sp (argc at [sp]). This relies on mach not emitting
+#       a frame-setup prologue that moves sp before the asm block for the entry
+#       function — the same guarantee the x86_64 entry depends on.
+#   (b) Symbol references in inline asm: the `adrp ; str/ldr [reg, :lo12:sym]`
+#       data-symbol idiom and `bl <sym>` calls require the arm64 inline-asm
+#       path to lower symbol operands to the page/lo12 + call relocations
+#       (the kinds added in #1163). If the arm64 asm DSL spells these
+#       differently, this block needs adjusting to match.
+
+use os: std.system.os.linux.aarch64;
+
+$_rt_argc.symbol = "_rt_argc";
+var _rt_argc: i64 = 0;
+$_rt_argv.symbol = "_rt_argv";
+var _rt_argv: u64 = 0;
+$_rt_envp.symbol = "_rt_envp";
+var _rt_envp: u64 = 0;
+
+$_rt_init.symbol = "_rt_init";
+fun _rt_init() {
+    os._envp = _rt_envp;
+}
+
+$_start.symbol = "_start";
+pub fun _start() {
+    asm aarch64 {
+        mov x9, sp            # x9 = initial stack pointer (argc at [x9])
+        ldr x0, [x9]          # argc -> x0 (1st argument to main)
+        add x1, x9, 8         # argv -> x1 (2nd argument to main)
+
+        # envp = argv + (argc + 1) * 8
+        add x10, x0, 1
+        lsl x10, x10, 3
+        add x10, x1, x10      # x10 = envp
+
+        adrp x11, _rt_argc
+        str x0, [x11, :lo12:_rt_argc]
+        adrp x11, _rt_argv
+        str x1, [x11, :lo12:_rt_argv]
+        adrp x11, _rt_envp
+        str x10, [x11, :lo12:_rt_envp]
+
+        # sp is 16-byte aligned on kernel entry (AAPCS64 invariant), so no
+        # realignment is needed before the calls.
+        bl _rt_init
+
+        adrp x11, _rt_argc
+        ldr x0, [x11, :lo12:_rt_argc]
+        adrp x11, _rt_argv
+        ldr x1, [x11, :lo12:_rt_argv]
+        bl main
+
+        # exit_group with main's return value (already in x0)
+        mov x8, 94           # SYS_exit_group
+        svc 0
+    }
+}


### PR DESCRIPTION
## Summary
`runtime/linux` was x86_64-only. Adds `src/runtime/linux/aarch64.mach` — an AAPCS64 `_start` mirroring the x86_64 entry (argc/argv/envp from the initial stack → runtime globals → `_rt_init` → `main(argc, argv)` → `SYS_exit_group`=94) — and wires the linux dispatch to select it.

## Verification
x86_64 unaffected: the dispatch only `use`s the matching-arch backend, so `aarch64.mach` is **not compiled for an x86_64 build**. `mach build` + `mach test` green: **541 passed, 0 failed**.

## Draft — two backend prerequisites (verify under qemu when the mach aarch64 backend converges)
1. **Entry frame:** the first asm instruction reads the raw kernel sp (argc at [sp]); relies on mach not emitting a frame prologue that moves sp before the asm for the entry function — the same guarantee the x86_64 `_start` depends on.
2. **arm64 inline-asm symbol references:** the `adrp ; str/ldr [reg, :lo12:sym]` data idiom and `bl <sym>` calls require the arm64 asm path to lower symbol operands to the page/lo12 + call relocations (#1163). **The arm64 backend does not yet show adrp/lo12 inline-asm support** — this can't compile for aarch64 until that lands; if the DSL spells symbol refs differently, the block needs adjusting.

Kept draft until qemu-verified (same posture as #267). Closes #270. aarch64-linux self-host enablement for octalide/mach#1431.