### PR TITLE
feat(format,print): gate varargs API on aarch64 (deferred to v1.6.x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Known limitations
+
+- **aarch64-linux: variadic formatting is unavailable.** `std.format.format`/`vformat`
+  and `std.print.printf`/`eprintf`/`printlnf`/`eprintlnf` are arch-gated out on aarch64;
+  AAPCS64 varargs lowering is deferred to v1.6.x pending a cross-platform varargs
+  redesign. Non-variadic output (`std.print.print`/`println`/`eprint`,
+  `std.format.write_*`, all of `std.log`) is fully available. (#276)
+
 ## [0.10.0] - 2026-06-13
 
 Filesystem symlink and recursive-removal primitives, giving the compiler's

--- a/src/format.mach
+++ b/src/format.mach
@@ -159,6 +159,10 @@ pub fun write_ptr(w: *writer.Writer, p: ptr) Result[usize, str] {
 
 pub val ERR_BAD_FORMAT: str = "bad format";
 
+# aarch64 varargs is deferred to v1.6.x (#276): gate the variadic surface so
+# the rest of std cross-compiles. the write_* primitives above stay available.
+$if ($mach.target.arch != $mach.arch.aarch64) {
+
 # vformat: format variadic arguments into a writer.
 #
 # format specifiers: %% (literal %), %s (string), %d (signed i64),
@@ -363,3 +367,4 @@ test "variadic: baseline f64 vararg" {
     if (va_f64(0, 1234.0)::i64 != 1234) { ret 1; }
     ret 0;
 }
+}  # end $if (arch != aarch64) — varargs deferred to v1.6.x (#276)

--- a/src/print.mach
+++ b/src/print.mach
@@ -95,6 +95,10 @@ pub fun eu64(n: u64) Result[usize, str] {
     ret f.write_u64(?w, n);
 }
 
+# aarch64 varargs is deferred to v1.6.x (#276): gate the variadic print API
+# so the rest of std cross-compiles. non-varargs print/println/u64 stay.
+$if ($mach.target.arch != $mach.arch.aarch64) {
+
 # formatted output to stdout.
 # ---
 # format: format string (see std.format.vformat for specifiers)
@@ -166,3 +170,4 @@ pub fun eprintlnf(format: str, ...) Result[usize, str] {
 
     ret ok[usize, str](unwrap_ok[usize, str](r1) + unwrap_ok[usize, str](r2));
 }
+}  # end $if (arch != aarch64) — varargs deferred to v1.6.x (#276)


### PR DESCRIPTION
Arch-gates the varargs surface (format.vformat/format + print.printf/eprintf/printlnf/eprintlnf) behind `$if (arch != aarch64)` so std cross-compiles on aarch64 without varargs, which octalide deferred to v1.6.x (cross-platform-syntax redesign). Non-varargs write_*/print/println/log stay available; log untouched. Minimal-diff (trivially un-gated when varargs lands).

**Verified:** x86_64 byte-identical (541/541); the aarch64 cross-build sweep confirmed codegen sails cleanly past std.format AND std.print with this gate. Required for the v1.6.0 self-host (so the compiler's whole-module compile of std.print doesn't hit the varargs stub). Closes #276.