### PR TITLE
release: integrate dev → main for v1.6.0 (aarch64 runtime)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Known limitations
+
+- **aarch64-linux: variadic formatting is unavailable.** `std.format.format`/`vformat`
+  and `std.print.printf`/`eprintf`/`printlnf`/`eprintlnf` are arch-gated out on aarch64;
+  AAPCS64 varargs lowering is deferred to v1.6.x pending a cross-platform varargs
+  redesign. Non-variadic output (`std.print.print`/`println`/`eprint`,
+  `std.format.write_*`, all of `std.log`) is fully available. (#276)
+
 ## [0.10.0] - 2026-06-13
 
 Filesystem symlink and recursive-removal primitives, giving the compiler's

--- a/src/data/toml.mach
+++ b/src/data/toml.mach
@@ -16,6 +16,8 @@ use std.types.size.usize;
 use std.types.option.Option;
 use std.types.option.some;
 use std.types.option.none;
+use std.types.option.is_some;
+use std.types.option.unwrap;
 use std.types.string.str;
 use std.types.string.str_equals;
 use std.types.string.str_len;
@@ -24,6 +26,7 @@ use std.allocator.Allocator;
 use std.allocator.allocate;
 
 use mem: std.memory;
+use page: std.allocator.page;
 
 pub val TYPE_STRING:  u8 = 0;
 pub val TYPE_INTEGER: u8 = 1;
@@ -1459,4 +1462,63 @@ pub fun parse(a: *Allocator, src: str) Result[Table, str] {
     }
 
     ret ok[Table, str](root);
+}
+
+# float regression tests (#278). these exercise the f64 paths that transit
+# memory — apply_pow10's [20]f64 array-element load feeding an FP multiply
+# (exponents) and the Value f64 union field store/load (value_float/get_float).
+# they catch an aarch64 f64 memory-load/store miscompile that produced wrong
+# values with zero test signal; before that compiler fix they fail on aarch64,
+# after it they pass (and they always pass on x86_64).
+
+test "toml: plain fractional float round-trips" {
+    var a: Allocator;
+    page.make(?a);
+    val r: Result[Table, str] = parse(?a, "x = 3.14");
+    if (is_err[Table, str](r)) { ret 1; }
+    var t: Table = unwrap_ok[Table, str](r);
+    val o: Option[f64] = get_float(?t, "x");
+    if (!is_some[f64](o)) { ret 2; }
+    val v: f64 = unwrap[f64](o);
+    if (v < 3.13 || v > 3.15) { ret 3; }
+    ret 0;
+}
+
+test "toml: float with positive exponent (apply_pow10 multiply)" {
+    var a: Allocator;
+    page.make(?a);
+    val r: Result[Table, str] = parse(?a, "x = 1.5e3");
+    if (is_err[Table, str](r)) { ret 1; }
+    var t: Table = unwrap_ok[Table, str](r);
+    val o: Option[f64] = get_float(?t, "x");
+    if (!is_some[f64](o)) { ret 2; }
+    val v: f64 = unwrap[f64](o);
+    if (v < 1499.0 || v > 1501.0) { ret 3; }
+    ret 0;
+}
+
+test "toml: float with large exponent (multi-chunk apply_pow10)" {
+    var a: Allocator;
+    page.make(?a);
+    val r: Result[Table, str] = parse(?a, "x = 2e10");
+    if (is_err[Table, str](r)) { ret 1; }
+    var t: Table = unwrap_ok[Table, str](r);
+    val o: Option[f64] = get_float(?t, "x");
+    if (!is_some[f64](o)) { ret 2; }
+    val v: f64 = unwrap[f64](o);
+    if (v < 19999990000.0 || v > 20000010000.0) { ret 3; }
+    ret 0;
+}
+
+test "toml: float with negative exponent (apply_pow10 divide)" {
+    var a: Allocator;
+    page.make(?a);
+    val r: Result[Table, str] = parse(?a, "x = 1.5e-2");
+    if (is_err[Table, str](r)) { ret 1; }
+    var t: Table = unwrap_ok[Table, str](r);
+    val o: Option[f64] = get_float(?t, "x");
+    if (!is_some[f64](o)) { ret 2; }
+    val v: f64 = unwrap[f64](o);
+    if (v < 0.0149 || v > 0.0151) { ret 3; }
+    ret 0;
 }

--- a/src/format.mach
+++ b/src/format.mach
@@ -159,6 +159,10 @@ pub fun write_ptr(w: *writer.Writer, p: ptr) Result[usize, str] {
 
 pub val ERR_BAD_FORMAT: str = "bad format";
 
+# aarch64 varargs is deferred to v1.6.x (#276): gate the variadic surface so
+# the rest of std cross-compiles. the write_* primitives above stay available.
+$if ($mach.target.arch != $mach.arch.aarch64) {
+
 # vformat: format variadic arguments into a writer.
 #
 # format specifiers: %% (literal %), %s (string), %d (signed i64),
@@ -363,3 +367,4 @@ test "variadic: baseline f64 vararg" {
     if (va_f64(0, 1234.0)::i64 != 1234) { ret 1; }
     ret 0;
 }
+}  # end $if (arch != aarch64) — varargs deferred to v1.6.x (#276)

--- a/src/print.mach
+++ b/src/print.mach
@@ -95,6 +95,10 @@ pub fun eu64(n: u64) Result[usize, str] {
     ret f.write_u64(?w, n);
 }
 
+# aarch64 varargs is deferred to v1.6.x (#276): gate the variadic print API
+# so the rest of std cross-compiles. non-varargs print/println/u64 stay.
+$if ($mach.target.arch != $mach.arch.aarch64) {
+
 # formatted output to stdout.
 # ---
 # format: format string (see std.format.vformat for specifiers)
@@ -166,3 +170,4 @@ pub fun eprintlnf(format: str, ...) Result[usize, str] {
 
     ret ok[usize, str](unwrap_ok[usize, str](r1) + unwrap_ok[usize, str](r2));
 }
+}  # end $if (arch != aarch64) — varargs deferred to v1.6.x (#276)

--- a/src/runtime/linux.mach
+++ b/src/runtime/linux.mach
@@ -1,6 +1,9 @@
 $if ($mach.target.arch == $mach.arch.x86_64) {
     use std.runtime.linux.x86_64;
 }
+$or ($mach.target.arch == $mach.arch.aarch64) {
+    use std.runtime.linux.aarch64;
+}
 $or {
     $error("std.runtime.linux: unsupported architecture");
 }

--- a/src/runtime/linux/aarch64.mach
+++ b/src/runtime/linux/aarch64.mach
@@ -1,0 +1,85 @@
+# std.runtime.linux.aarch64: aarch64 (AAPCS64) linux entrypoint
+# ---
+# provides `_start`, the ELF entry point for aarch64 linux executables.
+#
+# on entry, the kernel places the following on the stack (same layout as
+# every LP64 linux triple — 8-byte slots):
+#   [sp]      = argc
+#   [sp+8]    = argv[0]
+#   [sp+16]   = argv[1]
+#   ...
+#   argv + (argc+1)*8 = envp[0]
+#
+# this entrypoint mirrors the x86_64 one:
+#   1. extracts argc, argv, and envp from the initial stack
+#   2. stores them into the runtime globals
+#   3. calls _rt_init to publish envp into the OS layer
+#   4. calls user-supplied `main(argc, argv)` (x0 = argc, x1 = argv)
+#   5. exits via SYS_exit_group with main's return code (terminates all
+#      threads; SYS_exit would leave non-main threads alive)
+#
+# user code must define:
+#   $main.symbol = "main";
+#   fun main(argc: i64, argv: **u8) i64 { ... }
+#
+# VERIFICATION STATUS — written ahead of the mach aarch64 backend; two
+# assumptions cannot be checked until the backend + qemu are available and
+# MUST be confirmed there (tracked with #270 / octalide/mach#1431):
+#   (a) Entry frame: like x86_64 `_start`, the first asm instruction reads the
+#       raw kernel-supplied sp (argc at [sp]). This relies on mach not emitting
+#       a frame-setup prologue that moves sp before the asm block for the entry
+#       function — the same guarantee the x86_64 entry depends on.
+#   (b) Symbol references in inline asm: the `adrp ; str/ldr [reg, :lo12:sym]`
+#       data-symbol idiom and `bl <sym>` calls require the arm64 inline-asm
+#       path to lower symbol operands to the page/lo12 + call relocations
+#       (the kinds added in #1163). If the arm64 asm DSL spells these
+#       differently, this block needs adjusting to match.
+
+use os: std.system.os.linux.aarch64;
+
+$_rt_argc.symbol = "_rt_argc";
+var _rt_argc: i64 = 0;
+$_rt_argv.symbol = "_rt_argv";
+var _rt_argv: u64 = 0;
+$_rt_envp.symbol = "_rt_envp";
+var _rt_envp: u64 = 0;
+
+$_rt_init.symbol = "_rt_init";
+fun _rt_init() {
+    os._envp = _rt_envp;
+}
+
+$_start.symbol = "_start";
+pub fun _start() {
+    asm aarch64 {
+        mov x9, sp            # x9 = initial stack pointer (argc at [x9])
+        ldr x0, [x9]          # argc -> x0 (1st argument to main)
+        add x1, x9, 8         # argv -> x1 (2nd argument to main)
+
+        # envp = argv + (argc + 1) * 8
+        add x10, x0, 1
+        lsl x10, x10, 3
+        add x10, x1, x10      # x10 = envp
+
+        adrp x11, _rt_argc
+        str x0, [x11, :lo12:_rt_argc]
+        adrp x11, _rt_argv
+        str x1, [x11, :lo12:_rt_argv]
+        adrp x11, _rt_envp
+        str x10, [x11, :lo12:_rt_envp]
+
+        # sp is 16-byte aligned on kernel entry (AAPCS64 invariant), so no
+        # realignment is needed before the calls.
+        bl _rt_init
+
+        adrp x11, _rt_argc
+        ldr x0, [x11, :lo12:_rt_argc]
+        adrp x11, _rt_argv
+        ldr x1, [x11, :lo12:_rt_argv]
+        bl main
+
+        # exit_group with main's return value (already in x0)
+        mov x8, 94           # SYS_exit_group
+        svc 0
+    }
+}

--- a/src/sync/atomic.mach
+++ b/src/sync/atomic.mach
@@ -38,6 +38,9 @@ pub fun load(ptr: *i64) i64 {
             ldar {result}, [x12]
         }
     }
+    $or {
+        $error("std.sync.atomic.load: unsupported architecture");
+    }
     ret result;
 }
 
@@ -62,6 +65,9 @@ pub fun store(ptr: *i64, v: i64) {
             mov x12, {ptr}
             stlr {v}, [x12]
         }
+    }
+    $or {
+        $error("std.sync.atomic.store: unsupported architecture");
     }
 }
 
@@ -104,6 +110,9 @@ pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
             dmb ish
         }
     }
+    $or {
+        $error("std.sync.atomic.cas: unsupported architecture");
+    }
     if (old == exp) { ret true; }
     @expected = old;
     ret false;
@@ -140,6 +149,9 @@ pub fun fetch_add(ptr: *i64, v: i64) i64 {
             dmb ish
         }
     }
+    $or {
+        $error("std.sync.atomic.fetch_add: unsupported architecture");
+    }
     ret old;
 }
 
@@ -175,6 +187,9 @@ pub fun fetch_sub(ptr: *i64, v: i64) i64 {
             dmb ish
         }
     }
+    $or {
+        $error("std.sync.atomic.fetch_sub: unsupported architecture");
+    }
     ret old;
 }
 
@@ -208,6 +223,9 @@ pub fun exchange(ptr: *i64, v: i64) i64 {
             dmb ish
         }
     }
+    $or {
+        $error("std.sync.atomic.exchange: unsupported architecture");
+    }
     ret old;
 }
 
@@ -223,6 +241,9 @@ pub fun fence() {
             dmb ish
         }
     }
+    $or {
+        $error("std.sync.atomic.fence: unsupported architecture");
+    }
 }
 
 # cpu yield hint for spin loops.
@@ -236,6 +257,9 @@ pub fun spin_hint() {
         asm aarch64 {
             yield
         }
+    }
+    $or {
+        $error("std.sync.atomic.spin_hint: unsupported architecture");
     }
 }
 

--- a/src/sync/atomic.mach
+++ b/src/sync/atomic.mach
@@ -34,8 +34,9 @@ pub fun load(ptr: *i64) i64 {
         # load-acquire pairs with STLR stores for seq-cst ordering
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
-            mov x12, {ptr}
-            ldar {result}, [x12]
+            ldr x12, {ptr}
+            ldar x9, [x12]
+            str x9, {result}
         }
     }
     ret result;
@@ -59,8 +60,9 @@ pub fun store(ptr: *i64, v: i64) {
         # store-release pairs with LDAR loads for seq-cst ordering
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
-            mov x12, {ptr}
-            stlr {v}, [x12]
+            ldr x12, {ptr}
+            ldr x9, {v}
+            stlr x9, [x12]
         }
     }
 }
@@ -91,16 +93,17 @@ pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
         # LDAXR/STLXR retry loop; trailing DMB ISH gives full seq-cst order
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
-            mov x9, {exp}
-            mov x12, {ptr}
-        cas_retry:
+            ldr x9, {exp}
+            ldr x12, {ptr}
+            ldr x13, {desired}
+        1:
             ldaxr x10, [x12]
             cmp x10, x9
-            b.ne cas_done
-            stlxr w11, {desired}, [x12]
-            cbnz w11, cas_retry
-        cas_done:
-            mov {old}, x10
+            b.ne 2f
+            stlxr w11, x13, [x12]
+            cbnz w11, 1b
+        2:
+            str x10, {old}
             dmb ish
         }
     }
@@ -130,13 +133,14 @@ pub fun fetch_add(ptr: *i64, v: i64) i64 {
         # LDAXR/STLXR add loop; trailing DMB ISH gives full seq-cst order
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
-            mov x12, {ptr}
-        fadd_retry:
+            ldr x12, {ptr}
+            ldr x14, {v}
+        1:
             ldaxr x9, [x12]
-            add x10, x9, {v}
+            add x10, x9, x14
             stlxr w11, x10, [x12]
-            cbnz w11, fadd_retry
-            mov {old}, x9
+            cbnz w11, 1b
+            str x9, {old}
             dmb ish
         }
     }
@@ -165,13 +169,14 @@ pub fun fetch_sub(ptr: *i64, v: i64) i64 {
         # LDAXR/STLXR sub loop; trailing DMB ISH gives full seq-cst order
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
-            mov x12, {ptr}
-        fsub_retry:
+            ldr x12, {ptr}
+            ldr x14, {v}
+        1:
             ldaxr x9, [x12]
-            sub x10, x9, {v}
+            sub x10, x9, x14
             stlxr w11, x10, [x12]
-            cbnz w11, fsub_retry
-            mov {old}, x9
+            cbnz w11, 1b
+            str x9, {old}
             dmb ish
         }
     }
@@ -199,12 +204,13 @@ pub fun exchange(ptr: *i64, v: i64) i64 {
         # LDAXR/STLXR swap loop; trailing DMB ISH gives full seq-cst order
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
-            mov x12, {ptr}
-        xchg_retry:
+            ldr x12, {ptr}
+            ldr x14, {v}
+        1:
             ldaxr x9, [x12]
-            stlxr w11, {v}, [x12]
-            cbnz w11, xchg_retry
-            mov {old}, x9
+            stlxr w11, x14, [x12]
+            cbnz w11, 1b
+            str x9, {old}
             dmb ish
         }
     }

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -11,6 +11,9 @@ $if ($mach.target.os != $mach.os.linux) {
 $if ($mach.target.arch == $mach.arch.x86_64) {
     use impl: std.system.os.linux.x86_64;
 }
+$or ($mach.target.arch == $mach.arch.aarch64) {
+    use impl: std.system.os.linux.aarch64;
+}
 $or {
     $error("std.system.os.linux: unsupported architecture");
 }

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -69,8 +69,8 @@ fun thread_trampoline() {
     shared.syscall6(shared.SYS_FUTEX, done_addr, shared.FUTEX_WAKE, 1, 0, 0, 0);
     asm aarch64 {
         # munmap stack then exit
-        mov x0, {stack_base}
-        mov x1, {stack_size}
+        ldr x0, {stack_base}
+        ldr x1, {stack_size}
         mov x8, 215           # SYS_munmap
         svc 0
         mov x0, 0
@@ -117,8 +117,8 @@ pub fun thread_spawn(f: fun(), done_ptr: *i64, stack_base: usize, stack_size: us
     # flags/stack are zero here.
     asm aarch64 { dmb ish }
     asm aarch64 {
-        mov x0, {flags}
-        mov x1, {stack_ptr}
+        ldr x0, {flags}
+        ldr x1, {stack_ptr}
         mov x2, 0
         mov x3, 0
         mov x4, 0

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -1,0 +1,312 @@
+# std.system.os.linux.aarch64: aarch64-specific linux OS primitives.
+#
+# provides page_size and thread_spawn which require arch-specific assembly.
+# everything else is in shared.mach.
+
+use std.types.size.usize;
+
+use shared: std.system.os.linux.shared;
+
+# imported unaliased so the clone-flag constants bind under their bare names
+# into this module's comptime context; `THREAD_CLONE_FLAGS` then folds at
+# compile time (a module-qualified `shared.CLONE_*` member path is not
+# comptime-evaluable, so the global would otherwise have no constant value).
+use std.system.os.linux.shared.CLONE_VM;
+use std.system.os.linux.shared.CLONE_FS;
+use std.system.os.linux.shared.CLONE_FILES;
+use std.system.os.linux.shared.CLONE_SIGHAND;
+use std.system.os.linux.shared.CLONE_THREAD;
+use std.system.os.linux.shared.CLONE_SYSVSEM;
+
+$if ($mach.target.os != $mach.os.linux) {
+    $error("std.system.os.linux.aarch64: requires linux target");
+}
+
+$if ($mach.target.arch != $mach.arch.aarch64) {
+    $error("std.system.os.linux.aarch64: requires aarch64 target");
+}
+
+# page_size: return the system page size.
+# ---
+# NOTE: aarch64 linux supports 4 KiB, 16 KiB, and 64 KiB pages depending on
+# kernel configuration; 4096 is the common default and what qemu-user presents.
+# the robust fix is to query AT_PAGESZ from the auxiliary vector at startup;
+# tracked for follow-up once the runtime aux-vector plumbing lands.
+# ---
+# ret: page size in bytes
+pub fun page_size() usize {
+    ret 4096;
+}
+
+val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM;
+
+# entered by a direct branch from the child side of clone (see thread_spawn);
+# the symbol is pinned so the inline-asm branch can target it. at entry sp
+# points at the argument block on the child stack; the standard frame-record
+# prologue (stp x29,x30,[sp,#-16]!; mov x29,sp) then places the four args at
+# [x29+16..x29+40]. NOTE: this offset assumes that frame-record convention and
+# must be confirmed against the mach aarch64 prologue under qemu.
+$thread_trampoline.symbol = "_std_thread_trampoline";
+fun thread_trampoline() {
+    var fn_addr: usize = 0;
+    var done_addr: usize = 0;
+    var stack_base: usize = 0;
+    var stack_size: usize = 0;
+    asm aarch64 {
+        ldr x0, [x29, 16]
+        str x0, {fn_addr}
+        ldr x0, [x29, 24]
+        str x0, {done_addr}
+        ldr x0, [x29, 32]
+        str x0, {stack_base}
+        ldr x0, [x29, 40]
+        str x0, {stack_size}
+    }
+    val fn_ptr: fun() = fn_addr::fun();
+    fn_ptr();
+    val done: *i64 = done_addr::*i64;
+    @done = 1;
+    shared.syscall6(shared.SYS_FUTEX, done_addr, shared.FUTEX_WAKE, 1, 0, 0, 0);
+    asm aarch64 {
+        # munmap stack then exit
+        mov x0, {stack_base}
+        mov x1, {stack_size}
+        mov x8, 215           # SYS_munmap
+        svc 0
+        mov x0, 0
+        mov x8, 93            # SYS_exit
+        svc 0
+    }
+    asm aarch64 { brk 0 }
+}
+
+# thread_spawn: create a new thread sharing the current address space.
+#
+# uses clone with shared VM, FS, files, and signals. the child's stack
+# carries the function pointer and done_ptr, so no globals are needed.
+# the child calls the entry function, sets *done_ptr to 1, wakes one
+# futex waiter, and exits.
+# ---
+# f:          function to execute in the new thread
+# done_ptr:   pointer to a completion flag (set to 1 when thread exits)
+# stack_base: base address of the pre-allocated stack region
+# stack_size: size of the stack in bytes
+# ret:        thread ID on success, or negative errno on failure
+pub fun thread_spawn(f: fun(), done_ptr: *i64, stack_base: usize, stack_size: usize) i64 {
+    val stack_top: usize = stack_base + stack_size;
+    # 48 keeps the child sp 16-byte aligned (aarch64 ABI) while leaving four
+    # 8-byte argument slots at +0..+24.
+    val child_sp: usize = stack_top - 48;
+    @(child_sp::*usize) = f::usize;
+    @((child_sp + 8)::*usize) = done_ptr::usize;
+    @((child_sp + 16)::*usize) = stack_base;
+    @((child_sp + 24)::*usize) = stack_size;
+
+    var flags: usize = THREAD_CLONE_FLAGS;
+    var stack_ptr: usize = child_sp;
+    var result: i64 = 0;
+
+    # parent/child discrimination must stay in registers: under CLONE_VM the
+    # child's frame pointer still addresses the parent frame, so a shared stack
+    # local would race (both sides writing the same slot — see issue #195). the
+    # child branches straight to the trampoline off its own stack; the parent
+    # falls through and stores the tid. clone arg order on aarch64 is
+    # (flags, stack, ptid, tls, ctid); all but flags/stack are zero here.
+    asm aarch64 { dmb ish }
+    asm aarch64 {
+        mov x0, {flags}
+        mov x1, {stack_ptr}
+        mov x2, 0
+        mov x3, 0
+        mov x4, 0
+        mov x8, 220           # SYS_clone
+        svc 0
+        cbz x0, _std_thread_trampoline
+        str x0, {result}      # parent: tid, or negative errno on failure
+    }
+
+    ret result;
+}
+
+# kernel ABI types
+fwd shared.stat_t;
+fwd shared.timespec;
+fwd shared.dirent64;
+
+# path
+fwd shared.separator;
+
+# constants
+fwd shared.STDIN_FD;
+fwd shared.STDOUT_FD;
+fwd shared.STDERR_FD;
+
+fwd shared.O_RDONLY;
+fwd shared.O_WRONLY;
+fwd shared.O_RDWR;
+fwd shared.O_CREAT;
+fwd shared.O_EXCL;
+fwd shared.O_TRUNC;
+fwd shared.O_APPEND;
+fwd shared.O_DIRECTORY;
+
+fwd shared.AT_FDCWD;
+fwd shared.AT_SYMLINK_NOFOLLOW;
+fwd shared.AT_REMOVEDIR;
+
+fwd shared.S_IFMT;
+fwd shared.S_IFDIR;
+fwd shared.S_IFREG;
+fwd shared.S_IFLNK;
+
+fwd shared.WNOHANG;
+fwd shared.WUNTRACED;
+fwd shared.WCONTINUED;
+
+fwd shared.CLOCK_REALTIME;
+fwd shared.CLOCK_MONOTONIC;
+
+fwd shared.EPERM;
+fwd shared.ENOENT;
+fwd shared.ESRCH;
+fwd shared.EINTR;
+fwd shared.EIO;
+fwd shared.ENXIO;
+fwd shared.E2BIG;
+fwd shared.EBADF;
+fwd shared.ECHILD;
+fwd shared.EAGAIN;
+fwd shared.ENOMEM;
+fwd shared.EACCES;
+fwd shared.EFAULT;
+fwd shared.EBUSY;
+fwd shared.EEXIST;
+fwd shared.ENODEV;
+fwd shared.ENOTDIR;
+fwd shared.EISDIR;
+fwd shared.EINVAL;
+fwd shared.ENFILE;
+fwd shared.EMFILE;
+fwd shared.ETXTBSY;
+fwd shared.ENOSPC;
+fwd shared.EROFS;
+fwd shared.EPIPE;
+fwd shared.ENOTEMPTY;
+fwd shared.ENOTSUP;
+
+fwd shared.EINTR_MAX_RETRIES;
+
+# feature detection
+fwd shared.has_numa;
+fwd shared.has_huge_pages;
+
+# syscall wrappers
+fwd shared.syscall0;
+fwd shared.syscall1;
+fwd shared.syscall2;
+fwd shared.syscall3;
+fwd shared.syscall4;
+fwd shared.syscall5;
+fwd shared.syscall6;
+
+# memory
+fwd shared.allocate;
+fwd shared.deallocate;
+fwd shared.reallocate;
+fwd shared.heap_region_base;
+fwd shared.heap_region_extend;
+fwd shared.protect;
+fwd shared.lock;
+fwd shared.unlock;
+fwd shared.advise;
+fwd shared.allocate_huge;
+fwd shared.numa_node_count;
+fwd shared.numa_current_node;
+fwd shared.numa_allocate;
+fwd shared.numa_move;
+fwd shared.map_file;
+fwd shared.sync_file;
+
+# environment
+fwd shared._envp;
+fwd shared.environ;
+
+# filesystem
+fwd shared.read;
+fwd shared.write;
+fwd shared.open;
+fwd shared.close;
+fwd shared.stat;
+fwd shared.stat_path;
+fwd shared.unlink;
+fwd shared.rename;
+fwd shared.symlink;
+fwd shared.make_dir;
+fwd shared.read_dir;
+fwd shared.access;
+fwd shared.seek;
+
+# process
+fwd shared.terminate;
+fwd shared.abort;
+fwd shared.spawn;
+fwd shared.spawn_redirected;
+fwd shared.getpid;
+fwd shared.pipe;
+fwd shared.sleep;
+fwd shared.getcwd;
+fwd shared.getenv;
+fwd shared.fork;
+fwd shared.vfork;
+fwd shared.exec;
+fwd shared.wait;
+fwd shared.wait_pid;
+fwd shared.has_exited;
+fwd shared.exit_code;
+fwd shared.was_signaled;
+fwd shared.term_signal;
+fwd shared.was_stopped;
+fwd shared.stop_signal;
+fwd shared.was_continued;
+
+# sockets
+fwd shared.AF_INET;
+fwd shared.SOCK_STREAM;
+fwd shared.SOCK_DGRAM;
+fwd shared.SOL_SOCKET;
+fwd shared.SO_REUSEADDR;
+fwd shared.SHUT_RD;
+fwd shared.SHUT_WR;
+fwd shared.SHUT_RDWR;
+fwd shared.SOCKADDR_IN_SIZE;
+fwd shared.sock_addr_init;
+fwd shared.sock_addr_read;
+fwd shared.sock_send;
+fwd shared.sock_recv;
+fwd shared.sock_close;
+fwd shared.sock_create;
+fwd shared.sock_bind;
+fwd shared.sock_listen;
+fwd shared.sock_accept;
+fwd shared.sock_connect;
+fwd shared.sock_sendto;
+fwd shared.sock_recvfrom;
+fwd shared.sock_shutdown;
+fwd shared.sock_setopt;
+
+# dns
+fwd shared.DNS_HOSTS_PATH;
+fwd shared.dns_nameserver;
+
+# random
+fwd shared.random_fill;
+
+# threads
+fwd shared.thread_wait;
+fwd shared.thread_wake;
+
+# time
+fwd shared.clock_gettime;
+
+# errno
+fwd shared.error_message;

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -108,10 +108,13 @@ pub fun thread_spawn(f: fun(), done_ptr: *i64, stack_base: usize, stack_size: us
 
     # parent/child discrimination must stay in registers: under CLONE_VM the
     # child's frame pointer still addresses the parent frame, so a shared stack
-    # local would race (both sides writing the same slot — see issue #195). the
-    # child branches straight to the trampoline off its own stack; the parent
-    # falls through and stores the tid. clone arg order on aarch64 is
-    # (flags, stack, ptid, tls, ctid); all but flags/stack are zero here.
+    # local would race (both sides writing the same slot — see issue #195). a
+    # conditional branch can target only a numeric local label on aarch64, not a
+    # symbol (there is no imm19 symbol reloc), so the parent (x0 != 0) skips via
+    # cbnz to local label 1, and the child (x0 == 0) falls through to an
+    # unconditional `b` to the trampoline symbol (CALL26; never returns). clone
+    # arg order on aarch64 is (flags, stack, ptid, tls, ctid); all but
+    # flags/stack are zero here.
     asm aarch64 { dmb ish }
     asm aarch64 {
         mov x0, {flags}
@@ -121,7 +124,9 @@ pub fun thread_spawn(f: fun(), done_ptr: *i64, stack_base: usize, stack_size: us
         mov x4, 0
         mov x8, 220           # SYS_clone
         svc 0
-        cbz x0, _std_thread_trampoline
+        cbnz x0, 1f           # parent (tid != 0): skip the child dispatch
+        b _std_thread_trampoline   # child (x0 == 0): branch to trampoline (no return)
+    1:
         str x0, {result}      # parent: tid, or negative errno on failure
     }
 

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -267,7 +267,15 @@ pub val O_CREAT:     i32 = 64;
 pub val O_EXCL:      i32 = 128;
 pub val O_TRUNC:     i32 = 512;
 pub val O_APPEND:    i32 = 1024;
-pub val O_DIRECTORY: i32 = 65536;
+
+# O_DIRECTORY differs by arch: x86_64 = 0x10000, aarch64 (asm-generic) = 0x4000.
+# 0x10000 means O_DIRECT on aarch64, so the value must be arch-gated.
+$if ($mach.target.arch == $mach.arch.x86_64) {
+pub val O_DIRECTORY: i32 = 0x10000;
+}
+$or ($mach.target.arch == $mach.arch.aarch64) {
+pub val O_DIRECTORY: i32 = 0x4000;
+}
 
 pub val AT_FDCWD:            i32 = -100;
 pub val AT_SYMLINK_NOFOLLOW: i32 = 0x0100;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -332,7 +332,7 @@ pub fun syscall0(n: usize) i64 {
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         asm aarch64 {
-            mov x8, {n}
+            ldr x8, {n}
             svc 0
             str x0, {out}
         }
@@ -357,8 +357,8 @@ pub fun syscall1(n: usize, a0: usize) i64 {
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         asm aarch64 {
-            mov x8, {n}
-            mov x0, {a0}
+            ldr x8, {n}
+            ldr x0, {a0}
             svc 0
             str x0, {out}
         }
@@ -385,9 +385,9 @@ pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         asm aarch64 {
-            mov x8, {n}
-            mov x0, {a0}
-            mov x1, {a1}
+            ldr x8, {n}
+            ldr x0, {a0}
+            ldr x1, {a1}
             svc 0
             str x0, {out}
         }
@@ -416,10 +416,10 @@ pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         asm aarch64 {
-            mov x8, {n}
-            mov x0, {a0}
-            mov x1, {a1}
-            mov x2, {a2}
+            ldr x8, {n}
+            ldr x0, {a0}
+            ldr x1, {a1}
+            ldr x2, {a2}
             svc 0
             str x0, {out}
         }
@@ -450,11 +450,11 @@ pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         asm aarch64 {
-            mov x8, {n}
-            mov x0, {a0}
-            mov x1, {a1}
-            mov x2, {a2}
-            mov x3, {a3}
+            ldr x8, {n}
+            ldr x0, {a0}
+            ldr x1, {a1}
+            ldr x2, {a2}
+            ldr x3, {a3}
             svc 0
             str x0, {out}
         }
@@ -487,12 +487,12 @@ pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         asm aarch64 {
-            mov x8, {n}
-            mov x0, {a0}
-            mov x1, {a1}
-            mov x2, {a2}
-            mov x3, {a3}
-            mov x4, {a4}
+            ldr x8, {n}
+            ldr x0, {a0}
+            ldr x1, {a1}
+            ldr x2, {a2}
+            ldr x3, {a3}
+            ldr x4, {a4}
             svc 0
             str x0, {out}
         }
@@ -527,13 +527,13 @@ pub fun syscall6(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         asm aarch64 {
-            mov x8, {n}
-            mov x0, {a0}
-            mov x1, {a1}
-            mov x2, {a2}
-            mov x3, {a3}
-            mov x4, {a4}
-            mov x5, {a5}
+            ldr x8, {n}
+            ldr x0, {a0}
+            ldr x1, {a1}
+            ldr x2, {a2}
+            ldr x3, {a3}
+            ldr x4, {a4}
+            ldr x5, {a5}
             svc 0
             str x0, {out}
         }

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -998,7 +998,13 @@ pub fun environ() **u8 {
 # code: exit code
 pub fun terminate(code: i64) {
     syscall1(SYS_EXIT_GROUP, code::usize);
-    asm x86_64 { hlt }
+    # exit_group never returns; trap loudly if it somehow does.
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        asm x86_64 { hlt }
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        asm aarch64 { brk 0 }
+    }
 }
 
 # abort: abort the process immediately with exit code 255.

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -17,6 +17,10 @@ $if ($mach.target.os != $mach.os.linux) {
     $error("std.system.os.linux.shared: requires linux target");
 }
 
+# syscall numbers are architecture-specific: x86_64 has its own table, while
+# aarch64 uses the generic asm-generic/unistd table. the aarch64 table also
+# lacks fork/vfork/symlink/dup2 entirely — clone, symlinkat, and dup3 stand in
+# (see the fork, vfork, symlink, and spawn_redirected wrappers below).
 $if ($mach.target.arch == $mach.arch.x86_64) {
     val SYS_READ:          usize = 0;
     val SYS_WRITE:         usize = 1;
@@ -68,84 +72,169 @@ $if ($mach.target.arch == $mach.arch.x86_64) {
     val SYS_GETCPU:        usize = 309;
     val SYS_CLOSE_RANGE:   usize = 436;
     val SYS_DUP2:          usize = 33;
+}
+$or ($mach.target.arch == $mach.arch.aarch64) {
+    val SYS_READ:          usize = 63;
+    val SYS_WRITE:         usize = 64;
+    val SYS_CLOSE:         usize = 57;
+    val SYS_FSTAT:         usize = 80;
+    val SYS_LSEEK:         usize = 62;
+    val SYS_MMAP:          usize = 222;
+    val SYS_MPROTECT:      usize = 226;
+    val SYS_MUNMAP:        usize = 215;
+    val SYS_BRK:           usize = 214;
+    val SYS_MREMAP:        usize = 216;
+    val SYS_MSYNC:         usize = 227;
+    val SYS_MADVISE:       usize = 233;
+    val SYS_NANOSLEEP:     usize = 101;
+    val SYS_GETPID:        usize = 172;
+    val SYS_CLONE:         usize = 220;
+    val SYS_EXECVE:        usize = 221;
+    val SYS_EXIT:          usize = 93;
+    val SYS_EXIT_GROUP:    usize = 94;
+    val SYS_WAIT4:         usize = 260;
+    val SYS_PIPE2:         usize = 59;
+    val SYS_GETCWD:        usize = 17;
+    val SYS_MLOCK:         usize = 228;
+    val SYS_MUNLOCK:       usize = 229;
+    val SYS_GETDENTS64:    usize = 61;
+    val SYS_CLOCK_GETTIME: usize = 113;
+    val SYS_MBIND:         usize = 235;
+    val SYS_GET_MEMPOLICY: usize = 236;
+    val SYS_OPENAT:        usize = 56;
+    val SYS_MKDIRAT:       usize = 34;
+    val SYS_NEWFSTATAT:    usize = 79;
+    val SYS_UNLINKAT:      usize = 35;
+    val SYS_RENAMEAT:      usize = 38;
+    val SYS_FACCESSAT:     usize = 48;
+    val SYS_SYMLINKAT:     usize = 36;
+    pub val SYS_FUTEX:     usize = 98;
+    val SYS_SENDTO:        usize = 206;
+    val SYS_RECVFROM:      usize = 207;
+    val SYS_SHUTDOWN:      usize = 210;
+    val SYS_BIND:          usize = 200;
+    val SYS_LISTEN:        usize = 201;
+    val SYS_SETSOCKOPT:    usize = 208;
+    val SYS_SOCKET:        usize = 198;
+    val SYS_CONNECT:       usize = 203;
+    val SYS_ACCEPT:        usize = 202;
+    val SYS_GETRANDOM:     usize = 278;
+    val SYS_GETCPU:        usize = 168;
+    val SYS_CLOSE_RANGE:   usize = 436;
+    val SYS_DUP3:          usize = 24;
 
-    pub val FUTEX_WAIT: usize = 0;
-    pub val FUTEX_WAKE: usize = 1;
-
-    pub val CLONE_VM:      usize = 0x00000100;
-    pub val CLONE_FS:      usize = 0x00000200;
-    pub val CLONE_FILES:   usize = 0x00000400;
-    pub val CLONE_SIGHAND: usize = 0x00000800;
-    pub val CLONE_THREAD:  usize = 0x00010000;
-    pub val CLONE_SYSVSEM: usize = 0x00040000;
-
-    val MREMAP_MAYMOVE: usize = 1;
-
-    val PROT_NONE:  i32 = 0;
-    val PROT_READ:  i32 = 1;
-    val PROT_WRITE: i32 = 2;
-    val PROT_EXEC:  i32 = 4;
-
-    val MAP_SHARED:     i32 = 1;
-    val MAP_PRIVATE:    i32 = 2;
-    val MAP_FIXED:      i32 = 16;
-    val MAP_ANONYMOUS:  i32 = 32;
-    val MAP_HUGETLB:    i32 = 0x40000;
-    val MAP_HUGE_SHIFT: i32 = 26;
-
-    val MS_ASYNC:      i32 = 1;
-    val MS_INVALIDATE: i32 = 2;
-    val MS_SYNC:       i32 = 4;
-
-    val MADV_NORMAL:     i32 = 0;
-    val MADV_RANDOM:     i32 = 1;
-    val MADV_SEQUENTIAL: i32 = 2;
-    val MADV_WILLNEED:   i32 = 3;
-    val MADV_DONTNEED:   i32 = 4;
-
-    val MPOL_DEFAULT:        usize = 0;
-    val MPOL_PREFERRED:      usize = 1;
-    val MPOL_BIND:           usize = 2;
-    val MPOL_INTERLEAVE:     usize = 3;
-    val MPOL_MF_MOVE:        usize = 2;
-    val MPOL_F_MEMS_ALLOWED: usize = 4;
-
-    val SEEK_SET: i32 = 0;
-    val SEEK_CUR: i32 = 1;
-    val SEEK_END: i32 = 2;
-
-    val ENOSYS: i64 = -38;
+    # aarch64 lacks fork/vfork syscalls; both are expressed via clone.
+    val SIGCHLD:      usize = 17;
+    val CLONE_VFORK:  usize = 0x00004000;
 }
 $or {
     $error("std.system.os.linux.shared: unsupported architecture");
 }
 
+# constants identical across linux architectures (asm-generic matches x86_64
+# for these), declared once at module scope.
+pub val FUTEX_WAIT: usize = 0;
+pub val FUTEX_WAKE: usize = 1;
+
+pub val CLONE_VM:      usize = 0x00000100;
+pub val CLONE_FS:      usize = 0x00000200;
+pub val CLONE_FILES:   usize = 0x00000400;
+pub val CLONE_SIGHAND: usize = 0x00000800;
+pub val CLONE_THREAD:  usize = 0x00010000;
+pub val CLONE_SYSVSEM: usize = 0x00040000;
+
+val MREMAP_MAYMOVE: usize = 1;
+
+val PROT_NONE:  i32 = 0;
+val PROT_READ:  i32 = 1;
+val PROT_WRITE: i32 = 2;
+val PROT_EXEC:  i32 = 4;
+
+val MAP_SHARED:     i32 = 1;
+val MAP_PRIVATE:    i32 = 2;
+val MAP_FIXED:      i32 = 16;
+val MAP_ANONYMOUS:  i32 = 32;
+val MAP_HUGETLB:    i32 = 0x40000;
+val MAP_HUGE_SHIFT: i32 = 26;
+
+val MS_ASYNC:      i32 = 1;
+val MS_INVALIDATE: i32 = 2;
+val MS_SYNC:       i32 = 4;
+
+val MADV_NORMAL:     i32 = 0;
+val MADV_RANDOM:     i32 = 1;
+val MADV_SEQUENTIAL: i32 = 2;
+val MADV_WILLNEED:   i32 = 3;
+val MADV_DONTNEED:   i32 = 4;
+
+val MPOL_DEFAULT:        usize = 0;
+val MPOL_PREFERRED:      usize = 1;
+val MPOL_BIND:           usize = 2;
+val MPOL_INTERLEAVE:     usize = 3;
+val MPOL_MF_MOVE:        usize = 2;
+val MPOL_F_MEMS_ALLOWED: usize = 4;
+
+val SEEK_SET: i32 = 0;
+val SEEK_CUR: i32 = 1;
+val SEEK_END: i32 = 2;
+
+val ENOSYS: i64 = -38;
+
 use os_shared: std.system.os.shared;
 
 # kernel ABI types
 
-# stat_t: linux stat structure for file metadata.
-pub rec stat_t {
-    st_dev:        u64;
-    st_ino:        u64;
-    st_nlink:      u64;
-    st_mode:       u32;
-    st_uid:        u32;
-    st_gid:        u32;
-    pad0:          i32;
-    st_rdev:       u64;
-    st_size:       i64;
-    st_blksize:    i64;
-    st_blocks:     i64;
-    st_atime:      i64;
-    st_atime_nsec: i64;
-    st_mtime:      i64;
-    st_mtime_nsec: i64;
-    st_ctime:      i64;
-    st_ctime_nsec: i64;
-    _reserved0:    i64;
-    _reserved1:    i64;
-    _reserved2:    i64;
+# stat_t: linux stat structure for file metadata. the kernel struct differs
+# by architecture: x86_64 has its own layout, while aarch64 uses the
+# asm-generic layout (st_mode/st_nlink order swapped, narrower nlink/blksize).
+# the field names are identical so consumers are arch-agnostic.
+$if ($mach.target.arch == $mach.arch.x86_64) {
+    pub rec stat_t {
+        st_dev:        u64;
+        st_ino:        u64;
+        st_nlink:      u64;
+        st_mode:       u32;
+        st_uid:        u32;
+        st_gid:        u32;
+        pad0:          i32;
+        st_rdev:       u64;
+        st_size:       i64;
+        st_blksize:    i64;
+        st_blocks:     i64;
+        st_atime:      i64;
+        st_atime_nsec: i64;
+        st_mtime:      i64;
+        st_mtime_nsec: i64;
+        st_ctime:      i64;
+        st_ctime_nsec: i64;
+        _reserved0:    i64;
+        _reserved1:    i64;
+        _reserved2:    i64;
+    }
+}
+$or ($mach.target.arch == $mach.arch.aarch64) {
+    pub rec stat_t {
+        st_dev:        u64;
+        st_ino:        u64;
+        st_mode:       u32;
+        st_nlink:      u32;
+        st_uid:        u32;
+        st_gid:        u32;
+        st_rdev:       u64;
+        _pad1:         u64;
+        st_size:       i64;
+        st_blksize:    i32;
+        _pad2:         i32;
+        st_blocks:     i64;
+        st_atime:      i64;
+        st_atime_nsec: i64;
+        st_mtime:      i64;
+        st_mtime_nsec: i64;
+        st_ctime:      i64;
+        st_ctime_nsec: i64;
+        _unused4:      u32;
+        _unused5:      u32;
+    }
 }
 
 # timespec: time specification with seconds and nanoseconds.
@@ -234,10 +323,19 @@ pub val EINTR_MAX_RETRIES: usize = 8;
 # ret: syscall result (negative on error)
 pub fun syscall0(n: usize) i64 {
     var out: i64;
-    asm x86_64 {
-        mov rax, {n}
-        syscall
-        mov {out}, rax
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, {n}
+            syscall
+            mov {out}, rax
+        }
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            mov x8, {n}
+            svc 0
+            str x0, {out}
+        }
     }
     ret out;
 }
@@ -249,11 +347,21 @@ pub fun syscall0(n: usize) i64 {
 # ret: syscall result (negative on error)
 pub fun syscall1(n: usize, a0: usize) i64 {
     var out: i64;
-    asm x86_64 {
-        mov rax, {n}
-        mov rdi, {a0}
-        syscall
-        mov {out}, rax
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, {n}
+            mov rdi, {a0}
+            syscall
+            mov {out}, rax
+        }
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            mov x8, {n}
+            mov x0, {a0}
+            svc 0
+            str x0, {out}
+        }
     }
     ret out;
 }
@@ -266,12 +374,23 @@ pub fun syscall1(n: usize, a0: usize) i64 {
 # ret: syscall result (negative on error)
 pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
     var out: i64;
-    asm x86_64 {
-        mov rax, {n}
-        mov rdi, {a0}
-        mov rsi, {a1}
-        syscall
-        mov {out}, rax
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, {n}
+            mov rdi, {a0}
+            mov rsi, {a1}
+            syscall
+            mov {out}, rax
+        }
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            mov x8, {n}
+            mov x0, {a0}
+            mov x1, {a1}
+            svc 0
+            str x0, {out}
+        }
     }
     ret out;
 }
@@ -285,13 +404,25 @@ pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
 # ret: syscall result (negative on error)
 pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
     var out: i64;
-    asm x86_64 {
-        mov rax, {n}
-        mov rdi, {a0}
-        mov rsi, {a1}
-        mov rdx, {a2}
-        syscall
-        mov {out}, rax
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, {n}
+            mov rdi, {a0}
+            mov rsi, {a1}
+            mov rdx, {a2}
+            syscall
+            mov {out}, rax
+        }
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            mov x8, {n}
+            mov x0, {a0}
+            mov x1, {a1}
+            mov x2, {a2}
+            svc 0
+            str x0, {out}
+        }
     }
     ret out;
 }
@@ -306,14 +437,27 @@ pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
 # ret: syscall result (negative on error)
 pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
     var out: i64;
-    asm x86_64 {
-        mov rax, {n}
-        mov rdi, {a0}
-        mov rsi, {a1}
-        mov rdx, {a2}
-        mov r10, {a3}
-        syscall
-        mov {out}, rax
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, {n}
+            mov rdi, {a0}
+            mov rsi, {a1}
+            mov rdx, {a2}
+            mov r10, {a3}
+            syscall
+            mov {out}, rax
+        }
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            mov x8, {n}
+            mov x0, {a0}
+            mov x1, {a1}
+            mov x2, {a2}
+            mov x3, {a3}
+            svc 0
+            str x0, {out}
+        }
     }
     ret out;
 }
@@ -329,15 +473,29 @@ pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
 # ret: syscall result (negative on error)
 pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize) i64 {
     var out: i64;
-    asm x86_64 {
-        mov rax, {n}
-        mov rdi, {a0}
-        mov rsi, {a1}
-        mov rdx, {a2}
-        mov r10, {a3}
-        mov r8, {a4}
-        syscall
-        mov {out}, rax
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, {n}
+            mov rdi, {a0}
+            mov rsi, {a1}
+            mov rdx, {a2}
+            mov r10, {a3}
+            mov r8, {a4}
+            syscall
+            mov {out}, rax
+        }
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            mov x8, {n}
+            mov x0, {a0}
+            mov x1, {a1}
+            mov x2, {a2}
+            mov x3, {a3}
+            mov x4, {a4}
+            svc 0
+            str x0, {out}
+        }
     }
     ret out;
 }
@@ -354,16 +512,31 @@ pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
 # ret: syscall result (negative on error)
 pub fun syscall6(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) i64 {
     var out: i64;
-    asm x86_64 {
-        mov rax, {n}
-        mov rdi, {a0}
-        mov rsi, {a1}
-        mov rdx, {a2}
-        mov r10, {a3}
-        mov r8, {a4}
-        mov r9, {a5}
-        syscall
-        mov {out}, rax
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, {n}
+            mov rdi, {a0}
+            mov rsi, {a1}
+            mov rdx, {a2}
+            mov r10, {a3}
+            mov r8, {a4}
+            mov r9, {a5}
+            syscall
+            mov {out}, rax
+        }
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            mov x8, {n}
+            mov x0, {a0}
+            mov x1, {a1}
+            mov x2, {a2}
+            mov x3, {a3}
+            mov x4, {a4}
+            mov x5, {a5}
+            svc 0
+            str x0, {out}
+        }
     }
     ret out;
 }
@@ -755,7 +928,13 @@ pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
 # linkpath: path of the link to create
 # ret:      0 on success, or negative errno
 pub fun symlink(target: *u8, linkpath: *u8) i64 {
-    ret syscall2(SYS_SYMLINK, target::usize, linkpath::usize);
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        ret syscall2(SYS_SYMLINK, target::usize, linkpath::usize);
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        # aarch64 has no symlink syscall; symlinkat against AT_FDCWD is equivalent.
+        ret syscall3(SYS_SYMLINKAT, target::usize, AT_FDCWD::isize::usize, linkpath::usize);
+    }
 }
 
 # mkdirat: create a directory relative to a directory fd.
@@ -831,14 +1010,30 @@ pub fun abort() {
 # ---
 # ret: in parent: child PID (>0), in child: 0, on error: negative errno
 pub fun fork() i64 {
-    ret syscall0(SYS_FORK);
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        ret syscall0(SYS_FORK);
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        # aarch64 has no fork syscall; clone with SIGCHLD and no child stack
+        # (child runs on a copy-on-write image of the parent stack) is fork.
+        ret syscall5(SYS_CLONE, SIGCHLD, 0, 0, 0, 0);
+    }
 }
 
 # vfork: create child process sharing memory with parent.
 # ---
 # ret: in parent: child PID (>0), in child: 0, on error: negative errno
 pub fun vfork() i64 {
-    ret syscall0(SYS_VFORK);
+    $if ($mach.target.arch == $mach.arch.x86_64) {
+        ret syscall0(SYS_VFORK);
+    }
+    $or ($mach.target.arch == $mach.arch.aarch64) {
+        # aarch64 has no vfork syscall; clone with CLONE_VM|CLONE_VFORK|SIGCHLD
+        # and no child stack matches vfork semantics (parent suspended, child
+        # shares the address space until exec/_exit). same caller contract as
+        # the x86_64 vfork: the child must only exec or _exit.
+        ret syscall5(SYS_CLONE, CLONE_VM | CLONE_VFORK | SIGCHLD, 0, 0, 0, 0);
+    }
 }
 
 # execve: replace the current process image with a new program.
@@ -941,14 +1136,29 @@ pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, s
         ret pid;
     }
     if (pid == 0) {
-        if (stdin_fd != -1 && syscall2(SYS_DUP2, stdin_fd::isize::usize, STDIN_FD::isize::usize) < 0) {
-            syscall1(SYS_EXIT_GROUP, 126);
+        # aarch64 has no dup2 syscall; dup3 with flags 0 is equivalent (it
+        # differs only in rejecting oldfd == newfd, which redirect fds never are).
+        $if ($mach.target.arch == $mach.arch.x86_64) {
+            if (stdin_fd != -1 && syscall2(SYS_DUP2, stdin_fd::isize::usize, STDIN_FD::isize::usize) < 0) {
+                syscall1(SYS_EXIT_GROUP, 126);
+            }
+            if (stdout_fd != -1 && syscall2(SYS_DUP2, stdout_fd::isize::usize, STDOUT_FD::isize::usize) < 0) {
+                syscall1(SYS_EXIT_GROUP, 126);
+            }
+            if (stderr_fd != -1 && syscall2(SYS_DUP2, stderr_fd::isize::usize, STDERR_FD::isize::usize) < 0) {
+                syscall1(SYS_EXIT_GROUP, 126);
+            }
         }
-        if (stdout_fd != -1 && syscall2(SYS_DUP2, stdout_fd::isize::usize, STDOUT_FD::isize::usize) < 0) {
-            syscall1(SYS_EXIT_GROUP, 126);
-        }
-        if (stderr_fd != -1 && syscall2(SYS_DUP2, stderr_fd::isize::usize, STDERR_FD::isize::usize) < 0) {
-            syscall1(SYS_EXIT_GROUP, 126);
+        $or ($mach.target.arch == $mach.arch.aarch64) {
+            if (stdin_fd != -1 && syscall3(SYS_DUP3, stdin_fd::isize::usize, STDIN_FD::isize::usize, 0) < 0) {
+                syscall1(SYS_EXIT_GROUP, 126);
+            }
+            if (stdout_fd != -1 && syscall3(SYS_DUP3, stdout_fd::isize::usize, STDOUT_FD::isize::usize, 0) < 0) {
+                syscall1(SYS_EXIT_GROUP, 126);
+            }
+            if (stderr_fd != -1 && syscall3(SYS_DUP3, stderr_fd::isize::usize, STDERR_FD::isize::usize, 0) < 0) {
+                syscall1(SYS_EXIT_GROUP, 126);
+            }
         }
         close_inherited_fds();
         exec(pathname, argv, envp);

--- a/src/system/panic.mach
+++ b/src/system/panic.mach
@@ -41,6 +41,9 @@ pub fun panic(msg: *u8) {
                 svc 0x80
             }
         }
+        $or {
+            $error("std.system.panic: unsupported darwin architecture");
+        }
     }
 
     $if ($mach.target.arch == $mach.arch.x86_64) {
@@ -48,5 +51,8 @@ pub fun panic(msg: *u8) {
     }
     $or ($mach.target.arch == $mach.arch.aarch64) {
         asm aarch64 { brk 0 }
+    }
+    $or {
+        $error("std.system.panic: unsupported architecture");
     }
 }

--- a/src/system/panic.mach
+++ b/src/system/panic.mach
@@ -27,8 +27,8 @@ pub fun panic(msg: *u8) {
             asm aarch64 {
                 mov x8, 64    # SYS_write (linux aarch64)
                 mov x0, 2     # fd = stderr
-                mov x1, {msg}
-                mov x2, {len}
+                ldr x1, {msg}
+                ldr x2, {len}
                 svc 0
             }
         }
@@ -50,8 +50,8 @@ pub fun panic(msg: *u8) {
             asm aarch64 {
                 mov x16, 4    # SYS_write (darwin aarch64)
                 mov x0, 2     # fd = stderr
-                mov x1, {msg}
-                mov x2, {len}
+                ldr x1, {msg}
+                ldr x2, {len}
                 svc 0x80
             }
         }

--- a/src/system/panic.mach
+++ b/src/system/panic.mach
@@ -14,12 +14,26 @@ pub fun panic(msg: *u8) {
     for (msg[len] != 0) { len = len + 1; }
 
     $if ($mach.target.os == $mach.os.linux) {
-        asm x86_64 {
-            mov eax, 1        # SYS_write
-            mov edi, 2        # fd = stderr
-            mov rsi, {msg}
-            mov rdx, {len}
-            syscall
+        $if ($mach.target.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 1        # SYS_write
+                mov edi, 2        # fd = stderr
+                mov rsi, {msg}
+                mov rdx, {len}
+                syscall
+            }
+        }
+        $or ($mach.target.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x8, 64    # SYS_write (linux aarch64)
+                mov x0, 2     # fd = stderr
+                mov x1, {msg}
+                mov x2, {len}
+                svc 0
+            }
+        }
+        $or {
+            $error("std.system.panic: unsupported linux architecture");
         }
     }
     $or {


### PR DESCRIPTION
Integration merge for the v1.6.0 release. Brings the mach-std aarch64 runtime (OS layer, _start, atomics, panic) + the toml f64 regression tests onto main, so octalide/mach's `dep.mach-std ref="branch/main"` resolves to a runtime-bearing std. Part of the coordinated mach v1.6.0 cut.