### PR TITLE
feat: rewrite format/print onto comptime packs; add float formatting; re-enable aarch64 (#282)

### DIFF
--- a/src/format.mach
+++ b/src/format.mach
@@ -1,6 +1,17 @@
 # formatting primitives.
 #
 # writes formatted data to any io.Writer without allocation.
+#
+# format strings fill `{}` holes from the arguments in order, each rendered by
+# its type: signed/unsigned integers (any width) in decimal, str as text, ptr as
+# 0x-hex, f64 as the shortest round-trippable decimal. bool and char share u8's
+# representation, so they render as their numeric value — a bool prints 1 or 0;
+# reach for the `{:c}` spec to render an integer's low byte as a character.
+#
+# a hole may carry a spec after `:` — `x`/`X` for lower/upper hex, `c` for a
+# low-byte char, a decimal minimum width, and a leading `0` to zero-pad rather
+# than space-pad (e.g. `{:x}`, `{:c}`, `{:5}`, `{:08x}`). `{{` and `}}` emit
+# literal braces. a hole/argument count mismatch is an error in either direction.
 
 use std.types.bool.bool;
 use std.types.bool.true;

--- a/src/format.mach
+++ b/src/format.mach
@@ -735,20 +735,25 @@ pub fun vformat(w: *writer.Writer, fmt: str, va: ...) Result[usize, str] {
         if (is_err[Spec, str](spr)) { ret err[usize, str](unwrap_err[Spec, str](spr)); }
         var sp: Spec = unwrap_ok[Spec, str](spr);
 
+        # type-directed dispatch: a `$type_of` gate folds at lowering (#1472), so
+        # every arm is type-checked under each concrete arg type and only the
+        # selected arm executes. each arm casts arg to its own type — an identity
+        # cast in the taken arm; the rest are pruned before they run. unsupported
+        # types fall through to a runtime ERR_BAD_FORMAT.
         var fr: Result[usize, str];
-        $if      ($type_of(arg) == str) { fr = fmt_str_field(w, arg, ?sp); }
-        $or ($type_of(arg) == ptr) { fr = fmt_ptr_field(w, arg, ?sp); }
-        $or ($type_of(arg) == f64) { fr = fmt_f64_field(w, arg, ?sp); }
+        $if      ($type_of(arg) == str) { fr = fmt_str_field(w, (arg::usize)::str, ?sp); }
+        $or ($type_of(arg) == ptr) { fr = fmt_ptr_field(w, (arg::usize)::ptr, ?sp); }
+        $or ($type_of(arg) == f64) { fr = fmt_f64_field(w, arg::f64, ?sp); }
         $or ($type_of(arg) == f32) { fr = fmt_f64_field(w, arg::f64, ?sp); }
-        $or ($type_of(arg) == i64) { fr = fmt_i64(w, arg, ?sp); }
+        $or ($type_of(arg) == i64) { fr = fmt_i64(w, arg::i64, ?sp); }
         $or ($type_of(arg) == i32) { fr = fmt_i64(w, arg::i64, ?sp); }
         $or ($type_of(arg) == i16) { fr = fmt_i64(w, arg::i64, ?sp); }
         $or ($type_of(arg) == i8)  { fr = fmt_i64(w, arg::i64, ?sp); }
-        $or ($type_of(arg) == u64) { fr = fmt_u64(w, arg, ?sp); }
+        $or ($type_of(arg) == u64) { fr = fmt_u64(w, arg::u64, ?sp); }
         $or ($type_of(arg) == u32) { fr = fmt_u64(w, arg::u64, ?sp); }
         $or ($type_of(arg) == u16) { fr = fmt_u64(w, arg::u64, ?sp); }
         $or ($type_of(arg) == u8)  { fr = fmt_u64(w, arg::u64, ?sp); }
-        $or { $error("std.format: no formatter for this argument type"); }
+        $or { fr = err[usize, str](ERR_BAD_FORMAT); }
         if (is_err[usize, str](fr)) { ret fr; }
         total = total + unwrap_ok[usize, str](fr);
     }
@@ -882,5 +887,122 @@ test "write_f64: golden extremes (exact bits)" {
     if (!golden_bits_eq(1, "5e-324")) { ret 1; }
     if (!golden_bits_eq(0x54B249AD2594C37D, "1e100")) { ret 1; }
     if (!golden_bits_eq(0x4341C37937E08000, "10000000000000000")) { ret 1; }
+    ret 0;
+}
+
+# fmt_capture: vformat a pack into storage (null-terminated); returns the Result.
+# behavioral tests assert the captured bytes and the returned true byte count.
+fun fmt_capture(storage: *u8, cap: usize, fmt: str, va: ...) Result[usize, str] {
+    var tb: TestBuf;
+    tb.data = storage;
+    tb.len = 0;
+    tb.cap = cap;
+    var w: writer.Writer;
+    w.ctx = (?tb)::ptr;
+    w.fn_write = testbuf_write;
+    val r: Result[usize, str] = vformat(?w, fmt, va...);
+    storage[tb.len] = 0;
+    ret r;
+}
+
+# a heterogeneous format covering every dispatch arm (signed/unsigned int, str,
+# f64, char via {:c}, bool, ptr) in one runtime scan; bool and char share u8's
+# representation, so bool formats as its numeric value and {:c} renders a byte.
+test "format: mixed types -> exact bytes" {
+    var s:  [128]u8;
+    var pz: ptr = nil;
+    val r: Result[usize, str] = fmt_capture(?s[0], 128,
+        "i={} u={} s={} f={} c={:c} b={} p={}",
+        -42::i64, 7::u64, "hi", 3.5::f64, 65::u8, true, pz);
+    if (is_err[usize, str](r)) { ret 1; }
+    val want: str = "i=-42 u=7 s=hi f=3.5 c=A b=1 p=0x0";
+    if (!str_equals(?s[0], want)) { ret 2; }
+    # the count is the true bytes written, not the format-scan position.
+    if (unwrap_ok[usize, str](r) != str_len(want)) { ret 3; }
+    ret 0;
+}
+
+test "format: hex, width and zero-pad specs" {
+    var s: [64]u8;
+    var r: Result[usize, str];
+
+    r = fmt_capture(?s[0], 64, "{:x}", 255::u64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "ff")) { ret 1; }
+
+    r = fmt_capture(?s[0], 64, "{:X}", 255::u64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "FF")) { ret 2; }
+
+    r = fmt_capture(?s[0], 64, "{:08x}", 0xABCD::u64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "0000abcd")) { ret 3; }
+
+    r = fmt_capture(?s[0], 64, "[{:5}]", 42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[   42]")) { ret 4; }
+
+    r = fmt_capture(?s[0], 64, "[{:05}]", 42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[00042]")) { ret 5; }
+
+    # zero-pad keeps the sign ahead of the fill.
+    r = fmt_capture(?s[0], 64, "[{:05}]", -42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[-0042]")) { ret 6; }
+
+    # strings space-pad regardless of the zero flag.
+    r = fmt_capture(?s[0], 64, "[{:5}]", "hi");
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[   hi]")) { ret 7; }
+    ret 0;
+}
+
+test "format: literal brace escapes" {
+    var s: [64]u8;
+    var r: Result[usize, str];
+
+    r = fmt_capture(?s[0], 64, "{{}}");
+    if (is_err[usize, str](r) || !str_equals(?s[0], "{}")) { ret 1; }
+
+    r = fmt_capture(?s[0], 64, "a{{{}}}b", 9::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "a{9}b")) { ret 2; }
+    ret 0;
+}
+
+test "format: arg/hole mismatch and bad-format errors" {
+    var s: [64]u8;
+    var r: Result[usize, str];
+
+    # more arguments than holes.
+    r = fmt_capture(?s[0], 64, "{}", 1::i64, 2::i64);
+    if (!is_err[usize, str](r)) { ret 1; }
+    if (!str_equals(unwrap_err[usize, str](r), ERR_FEW_HOLES)) { ret 2; }
+
+    # more holes than arguments.
+    r = fmt_capture(?s[0], 64, "{} {}", 1::i64);
+    if (!is_err[usize, str](r)) { ret 3; }
+    if (!str_equals(unwrap_err[usize, str](r), ERR_MANY_HOLES)) { ret 4; }
+
+    # an unmatched literal brace.
+    r = fmt_capture(?s[0], 64, "oops }", 1::i64);
+    if (!is_err[usize, str](r)) { ret 5; }
+    if (!str_equals(unwrap_err[usize, str](r), ERR_BAD_FORMAT)) { ret 6; }
+
+    # a malformed hole spec.
+    r = fmt_capture(?s[0], 64, "{:q}", 1::i64);
+    if (!is_err[usize, str](r)) { ret 7; }
+    if (!str_equals(unwrap_err[usize, str](r), ERR_BAD_FORMAT)) { ret 8; }
+    ret 0;
+}
+
+# exercises the whole-pack forward through the `format` wrapper into vformat.
+test "format: forwards whole pack through format wrapper" {
+    var s:  [64]u8;
+    var tb: TestBuf;
+    tb.data = ?s[0];
+    tb.len  = 0;
+    tb.cap  = 64;
+    var w: writer.Writer;
+    w.ctx = (?tb)::ptr;
+    w.fn_write = testbuf_write;
+
+    val r: Result[usize, str] = format(?w, "{}-{}", 1::i64, 2::i64);
+    s[tb.len] = 0;
+    if (is_err[usize, str](r)) { ret 1; }
+    if (!str_equals(?s[0], "1-2")) { ret 2; }
     ret 0;
 }

--- a/src/format.mach
+++ b/src/format.mach
@@ -11,6 +11,7 @@ use std.types.result.ok;
 use std.types.result.err;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
 use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_equals;
@@ -455,216 +456,321 @@ pub fun write_f64(w: *writer.Writer, n: f64) Result[usize, str] {
 }
 
 pub val ERR_BAD_FORMAT: str = "bad format";
+pub val ERR_FEW_HOLES:  str = "more arguments than format holes";
+pub val ERR_MANY_HOLES: str = "more format holes than arguments";
 
-# aarch64 varargs is deferred to v1.6.x (#276): gate the variadic surface so
-# the rest of std cross-compiles. the write_* primitives above stay available.
-$if ($mach.target.arch != $mach.arch.aarch64) {
-
-# vformat: format variadic arguments into a writer.
-#
-# format specifiers: %% (literal %), %s (string), %d (signed i64),
-# %u (unsigned u64), %x/%X (hex), %c (char), %p (pointer).
+# Spec: a parsed `{...}` hole spec.
 # ---
-# w:      target writer
-# format: format string
-# ap:     pointer to va_list
-# ret:    total bytes written, or an error message
-pub fun vformat(w: *writer.Writer, format: str, ap: *va_list, ...) Result[usize, str] {
-    if (w == nil || ap == nil) {
-        ret err[usize, str](ERR_BAD_FORMAT);
-    }
+# hex:   render an integer in hexadecimal
+# upper: uppercase hex digits when hex
+# chr:   render an integer's low byte as a character
+# zero:  pad to width with '0' instead of ' '
+# width: minimum field width in bytes
+rec Spec {
+    hex:   bool;
+    upper: bool;
+    chr:   bool;
+    zero:  bool;
+    width: usize;
+}
 
-    var total: usize = 0;
+# Span: a fixed-capacity buffer writer used to size a field before padding.
+rec Span {
+    buf: *u8;
+    len: usize;
+    cap: usize;
+}
+
+# span_write: Writer callback appending bytes into a Span up to its capacity.
+fun span_write(ctx: ptr, p: *u8, len: usize) Result[usize, str] {
+    val s: *Span = ctx::*Span;
     var i: usize = 0;
-
-    for (format[i] != 0) {
-        if (format[i] != '%') {
-            val r: Result[usize, str] = write_byte(w, format[i]);
-            if (is_err[usize, str](r)) { ret r; }
-            total = total + unwrap_ok[usize, str](r);
-            i = i + 1;
-            cnt;
-        }
-
-        i = i + 1;
-        val c: u8 = format[i];
-        if (c == 0) {
-            ret err[usize, str](ERR_BAD_FORMAT);
-        }
-
-        var r: Result[usize, str];
-
-        if (c == '%') {
-            r = write_byte(w, '%');
-        }
-        or (c == 's') {
-            r = write_str(w, va_arg[str](ap));
-        }
-        or (c == 'd') {
-            r = write_i64(w, va_arg[i64](ap));
-        }
-        or (c == 'u') {
-            r = write_u64(w, va_arg[u64](ap));
-        }
-        or (c == 'x') {
-            r = write_hex_u64(w, va_arg[u64](ap), false);
-        }
-        or (c == 'X') {
-            r = write_hex_u64(w, va_arg[u64](ap), true);
-        }
-        or (c == 'c') {
-            r = write_byte(w, va_arg[u8](ap));
-        }
-        or (c == 'p') {
-            r = write_ptr(w, va_arg[ptr](ap));
-        }
-        or {
-            ret err[usize, str](ERR_BAD_FORMAT);
-        }
-
-        if (is_err[usize, str](r)) { ret r; }
-        total = total + unwrap_ok[usize, str](r);
+    for (i < len) {
+        if (s.len >= s.cap) { ret err[usize, str](ERR_BAD_FORMAT); }
+        s.buf[s.len] = p[i];
+        s.len = s.len + 1;
         i = i + 1;
     }
+    ret ok[usize, str](len);
+}
+
+# parse_spec: parse a `{...}` hole, advancing *ip past the closing brace.
+# ---
+# precondition: fmt[*ip] == '{' opening a real hole (callers handle `{{`).
+# grammar: '{' [ ':' [ '0' ] [ width ] [ 'x' | 'X' | 'c' ] ] '}'
+# ip:  in/out format cursor
+# ret: the parsed spec, or ERR_BAD_FORMAT on a malformed hole
+fun parse_spec(fmt: str, ip: *usize) Result[Spec, str] {
+    var i: usize = @ip + 1;
+    var sp: Spec = Spec{ hex: false, upper: false, chr: false, zero: false, width: 0 };
+
+    if (fmt[i] == '}') {
+        @ip = i + 1;
+        ret ok[Spec, str](sp);
+    }
+    if (fmt[i] != ':') {
+        ret err[Spec, str](ERR_BAD_FORMAT);
+    }
+    i = i + 1;
+
+    if (fmt[i] == '0') {
+        sp.zero = true;
+        i = i + 1;
+    }
+    for (fmt[i] >= '0' && fmt[i] <= '9') {
+        sp.width = sp.width * 10 + (fmt[i] - '0')::usize;
+        i = i + 1;
+    }
+
+    if (fmt[i] == 'x') {
+        sp.hex = true;
+        i = i + 1;
+    }
+    or (fmt[i] == 'X') {
+        sp.hex = true;
+        sp.upper = true;
+        i = i + 1;
+    }
+    or (fmt[i] == 'c') {
+        sp.chr = true;
+        i = i + 1;
+    }
+
+    if (fmt[i] != '}') {
+        ret err[Spec, str](ERR_BAD_FORMAT);
+    }
+    @ip = i + 1;
+    ret ok[Spec, str](sp);
+}
+
+# emit_pad: write n copies of byte b to w.
+fun emit_pad(w: *writer.Writer, b: u8, n: usize) Result[usize, str] {
+    var i: usize = 0;
+    for (i < n) {
+        val r: Result[usize, str] = write_byte(w, b);
+        if (is_err[usize, str](r)) { ret r; }
+        i = i + 1;
+    }
+    ret ok[usize, str](n);
+}
+
+# emit_field: write a rendered field with width padding per spec.
+# ---
+# right-aligned; a leading '-' stays ahead of '0' padding.
+# ret: total bytes written (>= len), or an error
+fun emit_field(w: *writer.Writer, buf: *u8, len: usize, sp: *Spec) Result[usize, str] {
+    if (sp.width <= len) {
+        ret write_bytes(w, buf, len);
+    }
+    val pad: usize = sp.width - len;
+
+    if (sp.zero && len > 0 && buf[0] == '-') {
+        val r1: Result[usize, str] = write_byte(w, '-');
+        if (is_err[usize, str](r1)) { ret r1; }
+        val r2: Result[usize, str] = emit_pad(w, '0', pad);
+        if (is_err[usize, str](r2)) { ret r2; }
+        val r3: Result[usize, str] = write_bytes(w, (buf::usize + 1)::*u8, len - 1);
+        if (is_err[usize, str](r3)) { ret r3; }
+        ret ok[usize, str](sp.width);
+    }
+
+    var fill: u8 = ' ';
+    if (sp.zero) { fill = '0'; }
+    val rp: Result[usize, str] = emit_pad(w, fill, pad);
+    if (is_err[usize, str](rp)) { ret rp; }
+    val rb: Result[usize, str] = write_bytes(w, buf, len);
+    if (is_err[usize, str](rb)) { ret rb; }
+    ret ok[usize, str](sp.width);
+}
+
+# emit_literal: write literal text up to the next hole, honoring `{{`/`}}`.
+# ---
+# advances *ip and adds written bytes to *tp.
+# ret: ok(true) stopped at a hole-open `{`; ok(false) reached end of string;
+#      err on an unmatched `}` or a write failure
+fun emit_literal(w: *writer.Writer, fmt: str, ip: *usize, tp: *usize) Result[bool, str] {
+    var i: usize = @ip;
+    for (fmt[i] != 0) {
+        if (fmt[i] == '{') {
+            if (fmt[i + 1] == '{') {
+                val r: Result[usize, str] = write_byte(w, '{');
+                if (is_err[usize, str](r)) { @ip = i; ret err[bool, str](unwrap_err[usize, str](r)); }
+                @tp = @tp + unwrap_ok[usize, str](r);
+                i = i + 2;
+                cnt;
+            }
+            @ip = i;
+            ret ok[bool, str](true);
+        }
+        if (fmt[i] == '}') {
+            if (fmt[i + 1] == '}') {
+                val r: Result[usize, str] = write_byte(w, '}');
+                if (is_err[usize, str](r)) { @ip = i; ret err[bool, str](unwrap_err[usize, str](r)); }
+                @tp = @tp + unwrap_ok[usize, str](r);
+                i = i + 2;
+                cnt;
+            }
+            @ip = i;
+            ret err[bool, str](ERR_BAD_FORMAT);
+        }
+        val r: Result[usize, str] = write_byte(w, fmt[i]);
+        if (is_err[usize, str](r)) { @ip = i; ret err[bool, str](unwrap_err[usize, str](r)); }
+        @tp = @tp + unwrap_ok[usize, str](r);
+        i = i + 1;
+    }
+    @ip = i;
+    ret ok[bool, str](false);
+}
+
+# fmt_i64: format a signed integer per spec (decimal, hex of the two's-complement
+# bits, or low-byte char) with width padding.
+fun fmt_i64(w: *writer.Writer, v: i64, sp: *Spec) Result[usize, str] {
+    var scratch: [64]u8;
+    var s: Span = Span{ buf: ?scratch[0], len: 0, cap: 64 };
+    var bw: writer.Writer;
+    bw.ctx = (?s)::ptr;
+    bw.fn_write = span_write;
+
+    var r: Result[usize, str];
+    if (sp.chr) {
+        r = write_byte(?bw, v::u8);
+    }
+    or (sp.hex) {
+        r = write_hex_u64(?bw, v::u64, sp.upper);
+    }
+    or {
+        r = write_i64(?bw, v);
+    }
+    if (is_err[usize, str](r)) { ret r; }
+    ret emit_field(w, ?scratch[0], s.len, sp);
+}
+
+# fmt_u64: format an unsigned integer per spec (decimal, hex, or low-byte char)
+# with width padding.
+fun fmt_u64(w: *writer.Writer, v: u64, sp: *Spec) Result[usize, str] {
+    var scratch: [64]u8;
+    var s: Span = Span{ buf: ?scratch[0], len: 0, cap: 64 };
+    var bw: writer.Writer;
+    bw.ctx = (?s)::ptr;
+    bw.fn_write = span_write;
+
+    var r: Result[usize, str];
+    if (sp.chr) {
+        r = write_byte(?bw, v::u8);
+    }
+    or (sp.hex) {
+        r = write_hex_u64(?bw, v, sp.upper);
+    }
+    or {
+        r = write_u64(?bw, v);
+    }
+    if (is_err[usize, str](r)) { ret r; }
+    ret emit_field(w, ?scratch[0], s.len, sp);
+}
+
+# fmt_f64_field: format a float in shortest round-trip decimal with width padding.
+fun fmt_f64_field(w: *writer.Writer, v: f64, sp: *Spec) Result[usize, str] {
+    var scratch: [64]u8;
+    var s: Span = Span{ buf: ?scratch[0], len: 0, cap: 64 };
+    var bw: writer.Writer;
+    bw.ctx = (?s)::ptr;
+    bw.fn_write = span_write;
+
+    val r: Result[usize, str] = write_f64(?bw, v);
+    if (is_err[usize, str](r)) { ret r; }
+    ret emit_field(w, ?scratch[0], s.len, sp);
+}
+
+# fmt_ptr_field: format a pointer as 0x-prefixed hex with width padding.
+fun fmt_ptr_field(w: *writer.Writer, p: ptr, sp: *Spec) Result[usize, str] {
+    var scratch: [64]u8;
+    var s: Span = Span{ buf: ?scratch[0], len: 0, cap: 64 };
+    var bw: writer.Writer;
+    bw.ctx = (?s)::ptr;
+    bw.fn_write = span_write;
+
+    val r: Result[usize, str] = write_ptr(?bw, p);
+    if (is_err[usize, str](r)) { ret r; }
+    ret emit_field(w, ?scratch[0], s.len, sp);
+}
+
+# fmt_str_field: write a string with width padding (space-padded, right-aligned).
+fun fmt_str_field(w: *writer.Writer, sv: str, sp: *Spec) Result[usize, str] {
+    var n: usize = 0;
+    if (sv != nil) { n = str_len(sv); }
+    if (sp.width <= n) {
+        ret write_str(w, sv);
+    }
+    val rp: Result[usize, str] = emit_pad(w, ' ', sp.width - n);
+    if (is_err[usize, str](rp)) { ret rp; }
+    val rs: Result[usize, str] = write_str(w, sv);
+    if (is_err[usize, str](rs)) { ret rs; }
+    ret ok[usize, str](sp.width);
+}
+
+# vformat: format a comptime-variadic pack into a writer (v1.7 packs).
+#
+# holes are type-directed `{}` matched to args in order: signed/unsigned int ->
+# decimal, str -> text, ptr -> 0xHEX, f64 -> shortest round-trip decimal. specs:
+# `{:x}`/`{:X}` hex, `{:c}` low-byte char, `{:N}`/`{:0N}` minimum width. `{{` and
+# `}}` are literal-brace escapes. the arg sequence is comptime-unrolled and
+# monomorphized per call; the format scan stays at runtime.
+# ---
+# w:   target writer
+# fmt: format string
+# va:  comptime variadic argument pack
+# ret: total bytes written, or an error message
+pub fun vformat(w: *writer.Writer, fmt: str, va: ...) Result[usize, str] {
+    if (w == nil) { ret err[usize, str](ERR_BAD_FORMAT); }
+
+    var i: usize = 0;
+    var total: usize = 0;
+
+    $each arg in va {
+        val lit: Result[bool, str] = emit_literal(w, fmt, ?i, ?total);
+        if (is_err[bool, str](lit)) { ret err[usize, str](unwrap_err[bool, str](lit)); }
+        if (!unwrap_ok[bool, str](lit)) { ret err[usize, str](ERR_FEW_HOLES); }
+
+        val spr: Result[Spec, str] = parse_spec(fmt, ?i);
+        if (is_err[Spec, str](spr)) { ret err[usize, str](unwrap_err[Spec, str](spr)); }
+        var sp: Spec = unwrap_ok[Spec, str](spr);
+
+        var fr: Result[usize, str];
+        $if      ($type_of(arg) == str) { fr = fmt_str_field(w, arg, ?sp); }
+        $or ($type_of(arg) == ptr) { fr = fmt_ptr_field(w, arg, ?sp); }
+        $or ($type_of(arg) == f64) { fr = fmt_f64_field(w, arg, ?sp); }
+        $or ($type_of(arg) == f32) { fr = fmt_f64_field(w, arg::f64, ?sp); }
+        $or ($type_of(arg) == i64) { fr = fmt_i64(w, arg, ?sp); }
+        $or ($type_of(arg) == i32) { fr = fmt_i64(w, arg::i64, ?sp); }
+        $or ($type_of(arg) == i16) { fr = fmt_i64(w, arg::i64, ?sp); }
+        $or ($type_of(arg) == i8)  { fr = fmt_i64(w, arg::i64, ?sp); }
+        $or ($type_of(arg) == u64) { fr = fmt_u64(w, arg, ?sp); }
+        $or ($type_of(arg) == u32) { fr = fmt_u64(w, arg::u64, ?sp); }
+        $or ($type_of(arg) == u16) { fr = fmt_u64(w, arg::u64, ?sp); }
+        $or ($type_of(arg) == u8)  { fr = fmt_u64(w, arg::u64, ?sp); }
+        $or { $error("std.format: no formatter for this argument type"); }
+        if (is_err[usize, str](fr)) { ret fr; }
+        total = total + unwrap_ok[usize, str](fr);
+    }
+
+    val tail: Result[bool, str] = emit_literal(w, fmt, ?i, ?total);
+    if (is_err[bool, str](tail)) { ret err[usize, str](unwrap_err[bool, str](tail)); }
+    if (unwrap_ok[bool, str](tail)) { ret err[usize, str](ERR_MANY_HOLES); }
 
     ret ok[usize, str](total);
 }
 
-# format: format arguments into a writer.
+# format: format a comptime-variadic pack into a writer.
 #
-# convenience wrapper that manages va_list internally.
+# thin wrapper that forwards the whole pack to vformat.
 # ---
-# w:      target writer
-# format: format string
-# ret:    total bytes written, or an error message
-pub fun format(w: *writer.Writer, format: str, ...) Result[usize, str] {
-    var ap: va_list;
-    va_start(?ap);
-    val r: Result[usize, str] = vformat(w, format, ?ap);
-    va_end(?ap);
-    ret r;
+# w:   target writer
+# fmt: format string
+# va:  comptime variadic argument pack
+# ret: total bytes written, or an error message
+pub fun format(w: *writer.Writer, fmt: str, va: ...) Result[usize, str] {
+    ret vformat(w, fmt, va...);
 }
-
-# variadic-codegen regression coverage.
-#
-# these guard the SysV variadic lowering against two miscompiles that silently
-# re-break (mach issues #1135 / #1136): the va_list overflow cursor must skip an
-# empty-aggregate vararg, and the AL-guarded FP-register save must see the caller's
-# vector-register count survive the prologue. plus baseline va_arg smoke cases.
-
-# an empty (size-0) aggregate, passed through varargs to exercise the overflow
-# cursor advance for a zero-byte slot.
-rec VaEmpty {}
-
-# a <=16B aggregate (two GP eightbytes) and a >16B aggregate (passed by reference),
-# to cover the non-empty by-value and by-reference va_arg overflow paths alongside
-# the empty case.
-rec VaSmall { x: i64; y: i64; }
-rec VaBig   { a: i64; b: i64; c: i64; }
-
-# va_empty_then_i64: six fixed i64 params consume all six SysV GP argument
-# registers, so gp_offset == 48 on entry to the varargs and both the empty struct
-# and the i64 land in the overflow area. returns the i64 vararg; the empty slot
-# must be skipped (advanced by one eightbyte) or the i64 re-reads the empty slot.
-fun va_empty_then_i64(a: i64, b: i64, c: i64, d: i64, e: i64, f: i64, ...) i64 {
-    var ap: va_list;
-    va_start(?ap);
-    val _e: VaEmpty = va_arg[VaEmpty](?ap);
-    val n: i64 = va_arg[i64](?ap);
-    va_end(?ap);
-    ret n;
-}
-
-# va_mixed_aggregates: empty + small + scalar + big-by-ref + scalar, all forced
-# into the overflow area, returns their checksum to prove every cursor advance.
-fun va_mixed_aggregates(a: i64, b: i64, c: i64, d: i64, e: i64, f: i64, ...) i64 {
-    var ap: va_list;
-    va_start(?ap);
-    val _e: VaEmpty = va_arg[VaEmpty](?ap);
-    val s:  VaSmall = va_arg[VaSmall](?ap);
-    val n1: i64     = va_arg[i64](?ap);
-    val g:  VaBig   = va_arg[VaBig](?ap);
-    val n2: i64     = va_arg[i64](?ap);
-    va_end(?ap);
-    ret s.x + s.y + n1 + g.a + g.b + g.c + n2;
-}
-
-# va_one_gp_then_f64: one named GP param then an f64 vararg. the prologue captures
-# p0 before the AL-guarded FP-register save; if a capture vreg is colored to the
-# vector-count register (RAX) the save's `test al,al` reads the wrong count. when
-# p0's low byte is zero (p0 == 256) a clobbered AL would be zero and skip the FP
-# save, so va_arg[f64] would read garbage.
-fun va_one_gp_then_f64(p0: i64, ...) i64 {
-    var ap: va_list;
-    va_start(?ap);
-    val x: f64 = va_arg[f64](?ap);
-    va_end(?ap);
-    ret p0 + x::i64;
-}
-
-# va_i64: a baseline integer vararg smoke case.
-fun va_i64(n: i64, ...) i64 {
-    var ap: va_list;
-    va_start(?ap);
-    val v: i64 = va_arg[i64](?ap);
-    va_end(?ap);
-    ret v;
-}
-
-# va_str: a baseline string vararg smoke case (str is a 16-byte aggregate).
-fun va_str(n: i64, ...) str {
-    var ap: va_list;
-    va_start(?ap);
-    val s: str = va_arg[str](?ap);
-    va_end(?ap);
-    ret s;
-}
-
-# va_f64: a baseline float vararg smoke case (lands in a vector register).
-fun va_f64(n: i64, ...) f64 {
-    var ap: va_list;
-    va_start(?ap);
-    val v: f64 = va_arg[f64](?ap);
-    va_end(?ap);
-    ret v;
-}
-
-test "variadic: empty-aggregate overflow cursor skips the empty slot" {
-    if (va_empty_then_i64(1, 2, 3, 4, 5, 6, VaEmpty{}, 4242) != 4242) { ret 1; }
-    ret 0;
-}
-
-test "variadic: mixed empty/small/big/scalar overflow varargs" {
-    val s: VaSmall = VaSmall{ x: 11, y: 22 };
-    val g: VaBig   = VaBig{ a: 100, b: 200, c: 300 };
-    val want: i64  = 11 + 22 + 7 + 100 + 200 + 300 + 9000;
-    if (va_mixed_aggregates(1, 2, 3, 4, 5, 6, VaEmpty{}, s, 7, g, 9000) != want) { ret 1; }
-    ret 0;
-}
-
-test "variadic: FP-save AL guard survives a zero-low-byte GP param" {
-    # p0 == 256 -> low byte 0: a clobbered AL would skip the FP save.
-    if (va_one_gp_then_f64(256, 3.0) != 259) { ret 1; }
-    # a non-zero-low-byte control case.
-    if (va_one_gp_then_f64(1, 7.0) != 8) { ret 1; }
-    ret 0;
-}
-
-test "variadic: baseline i64 vararg" {
-    if (va_i64(0, 1234567) != 1234567) { ret 1; }
-    ret 0;
-}
-
-test "variadic: baseline str vararg" {
-    if (!str_equals(va_str(0, "hello"), "hello")) { ret 1; }
-    ret 0;
-}
-
-test "variadic: baseline f64 vararg" {
-    if (va_f64(0, 1234.0)::i64 != 1234) { ret 1; }
-    ret 0;
-}
-}  # end $if (arch != aarch64) — varargs deferred to v1.6.x (#276)
 
 # test-only buffer-backed writer used to capture write_f64 output.
 rec TestBuf {

--- a/src/format.mach
+++ b/src/format.mach
@@ -15,6 +15,7 @@ use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_equals;
 use writer: std.io.writer;
+use mem: std.memory;
 
 # write_bytes: write raw bytes to a writer.
 # ---
@@ -320,6 +321,319 @@ fun big_sub(a: *Big, b: *Big) {
     big_norm(a);
 }
 
+# bitlen_u64: number of significant bits in v (0 when v == 0).
+fun bitlen_u64(v: u64) usize {
+    var n: usize = 0;
+    var x: u64 = v;
+    for (x > 0) {
+        n = n + 1;
+        x = x >> 1;
+    }
+    ret n;
+}
+
+# big_mul_pow10: b = b * 10^k.
+fun big_mul_pow10(b: *Big, k: usize) {
+    var rem: usize = k;
+    for (rem >= 9) {
+        big_mul_small(b, 1000000000);
+        rem = rem - 9;
+    }
+    var p: u32 = 1;
+    var i: usize = 0;
+    for (i < rem) {
+        p = p * 10;
+        i = i + 1;
+    }
+    if (p > 1) {
+        big_mul_small(b, p);
+    }
+}
+
+# dragon4: shortest round-trippable decimal digits of v = f * 2^e (f != 0).
+# writes digit values 0..9 into buf, the count into out_n, and the decimal
+# exponent into out_decExp such that v = 0.<buf digits> * 10^out_decExp. exact
+# bignum arithmetic, round-to-nearest-even — no magic tables.
+fun dragon4(f: u64, e: i64, buf: *u8, out_n: *usize, out_decExp: *i64) {
+    var R: Big;
+    var S: Big;
+    var Mp: Big;
+    var Mm: Big;
+    big_from_u64(?R, f);
+    if (e >= 0) {
+        if (f != 0x10000000000000) {
+            big_shl(?R, (e + 1)::usize);
+            big_from_u64(?S, 2);
+            big_from_u64(?Mp, 1);
+            big_shl(?Mp, e::usize);
+            big_from_u64(?Mm, 1);
+            big_shl(?Mm, e::usize);
+        }
+        or {
+            big_shl(?R, (e + 2)::usize);
+            big_from_u64(?S, 4);
+            big_from_u64(?Mp, 1);
+            big_shl(?Mp, (e + 1)::usize);
+            big_from_u64(?Mm, 1);
+            big_shl(?Mm, e::usize);
+        }
+    }
+    or {
+        if (e == -1074 || f != 0x10000000000000) {
+            big_shl(?R, 1);
+            big_from_u64(?S, 1);
+            big_shl(?S, (1 - e)::usize);
+            big_from_u64(?Mp, 1);
+            big_from_u64(?Mm, 1);
+        }
+        or {
+            big_shl(?R, 2);
+            big_from_u64(?S, 1);
+            big_shl(?S, (2 - e)::usize);
+            big_from_u64(?Mp, 2);
+            big_from_u64(?Mm, 1);
+        }
+    }
+
+    # estimate the decimal exponent, then scale so R/S lands in [0.1, 1).
+    val binexp: i64 = e + bitlen_u64(f)::i64 - 1;
+    var k: i64 = (binexp * 1233) / 4096 + 1;
+    if (k >= 0) {
+        big_mul_pow10(?S, k::usize);
+    }
+    or {
+        big_mul_pow10(?R, (0 - k)::usize);
+        big_mul_pow10(?Mp, (0 - k)::usize);
+        big_mul_pow10(?Mm, (0 - k)::usize);
+    }
+    for (big_cmp(?R, ?S) >= 0) {
+        big_mul_small(?S, 10);
+        k = k + 1;
+    }
+    var r10: Big;
+    big_copy(?r10, ?R);
+    big_mul_small(?r10, 10);
+    for (big_cmp(?r10, ?S) < 0) {
+        big_mul_small(?R, 10);
+        big_mul_small(?Mp, 10);
+        big_mul_small(?Mm, 10);
+        k = k - 1;
+        big_copy(?r10, ?R);
+        big_mul_small(?r10, 10);
+    }
+
+    val even: bool = (f & 1) == 0;
+    var nd: usize = 0;
+    var tmp: Big;
+    var done: bool = false;
+    for (!done) {
+        big_mul_small(?R, 10);
+        big_mul_small(?Mp, 10);
+        big_mul_small(?Mm, 10);
+        var d: i64 = 0;
+        for (big_cmp(?R, ?S) >= 0) {
+            big_sub(?R, ?S);
+            d = d + 1;
+        }
+        var low: bool = false;
+        if (even) { low = big_cmp(?R, ?Mm) <= 0; }
+        or { low = big_cmp(?R, ?Mm) < 0; }
+        big_copy(?tmp, ?R);
+        big_add(?tmp, ?Mp);
+        var high: bool = false;
+        if (even) { high = big_cmp(?tmp, ?S) >= 0; }
+        or { high = big_cmp(?tmp, ?S) > 0; }
+
+        if (low || high) {
+            var up: bool = false;
+            if (high && !low) { up = true; }
+            or (low && !high) { up = false; }
+            or {
+                big_copy(?tmp, ?R);
+                big_shl(?tmp, 1);
+                val c: i64 = big_cmp(?tmp, ?S);
+                if (c > 0) { up = true; }
+                or (c < 0) { up = false; }
+                or { up = (d & 1) == 1; }
+            }
+            if (up) { d = d + 1; }
+            done = true;
+        }
+        buf[nd] = d::u8;
+        nd = nd + 1;
+    }
+
+    # propagate a round-up carry (terminating digit may have become 10).
+    if (buf[nd - 1] == 10) {
+        buf[nd - 1] = 0;
+        var carry: bool = true;
+        var i: usize = nd - 1;
+        for (carry && i > 0) {
+            buf[i - 1] = buf[i - 1] + 1;
+            if (buf[i - 1] == 10) {
+                buf[i - 1] = 0;
+                i = i - 1;
+            }
+            or {
+                carry = false;
+            }
+        }
+        if (carry) {
+            var j: usize = nd;
+            for (j > 0) {
+                buf[j] = buf[j - 1];
+                j = j - 1;
+            }
+            buf[0] = 1;
+            nd = nd + 1;
+            k = k + 1;
+        }
+    }
+    # trim trailing zeros (can appear after a round-up carry).
+    for (nd > 1 && buf[nd - 1] == 0) {
+        nd = nd - 1;
+    }
+
+    @out_n = nd;
+    @out_decExp = k;
+}
+
+# write_f64: write a 64-bit float in shortest round-trippable decimal.
+# ---
+# w:   target writer
+# n:   value to format
+# ret: bytes written, or an error message
+pub fun write_f64(w: *writer.Writer, n: f64) Result[usize, str] {
+    var bits: u64;
+    mem.raw_copy(?bits, ?n, 8);
+    val sign: bool = (bits >> 63) != 0;
+    val exp_bits: u64 = (bits >> 52) & 0x7FF;
+    val frac: u64 = bits & 0xFFFFFFFFFFFFF;
+
+    if (exp_bits == 0x7FF) {
+        if (frac == 0) {
+            if (sign) { ret write_str(w, "-inf"); }
+            ret write_str(w, "inf");
+        }
+        ret write_str(w, "nan");
+    }
+    if (exp_bits == 0 && frac == 0) {
+        if (sign) { ret write_str(w, "-0"); }
+        ret write_str(w, "0");
+    }
+
+    var f: u64;
+    var e: i64;
+    if (exp_bits == 0) {
+        f = frac;
+        e = -1074;
+    }
+    or {
+        f = frac | 0x10000000000000;
+        e = exp_bits::i64 - 1075;
+    }
+
+    var dig: [32]u8;
+    var nd: usize = 0;
+    var decExp: i64 = 0;
+    dragon4(f, e, ?dig[0], ?nd, ?decExp);
+
+    var out: [48]u8;
+    var olen: usize = 0;
+    if (sign) { out[olen] = '-'; olen = olen + 1; }
+
+    if (decExp > 17 || decExp < -3) {
+        out[olen] = dig[0] + '0';
+        olen = olen + 1;
+        if (nd > 1) {
+            out[olen] = '.';
+            olen = olen + 1;
+            var i: usize = 1;
+            for (i < nd) {
+                out[olen] = dig[i] + '0';
+                olen = olen + 1;
+                i = i + 1;
+            }
+        }
+        out[olen] = 'e';
+        olen = olen + 1;
+        var ex: i64 = decExp - 1;
+        if (ex < 0) {
+            out[olen] = '-';
+            olen = olen + 1;
+            ex = 0 - ex;
+        }
+        var eb: [8]u8;
+        var en: usize = 0;
+        if (ex == 0) {
+            eb[0] = '0';
+            en = 1;
+        }
+        or {
+            for (ex > 0) {
+                eb[en] = (ex % 10)::u8 + '0';
+                ex = ex / 10;
+                en = en + 1;
+            }
+        }
+        var j: usize = en;
+        for (j > 0) {
+            j = j - 1;
+            out[olen] = eb[j];
+            olen = olen + 1;
+        }
+    }
+    or (decExp <= 0) {
+        out[olen] = '0';
+        olen = olen + 1;
+        out[olen] = '.';
+        olen = olen + 1;
+        var z: i64 = 0 - decExp;
+        for (z > 0) {
+            out[olen] = '0';
+            olen = olen + 1;
+            z = z - 1;
+        }
+        var i: usize = 0;
+        for (i < nd) {
+            out[olen] = dig[i] + '0';
+            olen = olen + 1;
+            i = i + 1;
+        }
+    }
+    or (decExp::usize >= nd) {
+        var i: usize = 0;
+        for (i < nd) {
+            out[olen] = dig[i] + '0';
+            olen = olen + 1;
+            i = i + 1;
+        }
+        var z: i64 = decExp - nd::i64;
+        for (z > 0) {
+            out[olen] = '0';
+            olen = olen + 1;
+            z = z - 1;
+        }
+    }
+    or {
+        var i: usize = 0;
+        for (i < decExp::usize) {
+            out[olen] = dig[i] + '0';
+            olen = olen + 1;
+            i = i + 1;
+        }
+        out[olen] = '.';
+        olen = olen + 1;
+        for (i < nd) {
+            out[olen] = dig[i] + '0';
+            olen = olen + 1;
+            i = i + 1;
+        }
+    }
+
+    ret write_bytes(w, ?out[0], olen);
+}
+
 pub val ERR_BAD_FORMAT: str = "bad format";
 
 # aarch64 varargs is deferred to v1.6.x (#276): gate the variadic surface so
@@ -571,5 +885,118 @@ test "bignum: add / sub / cmp" {
     if (big_cmp(?a, ?b) != 1) { ret 1; }
     if (big_cmp(?b, ?a) != -1) { ret 1; }
     if (big_cmp(?a, ?a) != 0) { ret 1; }
+    ret 0;
+}
+
+# test-only buffer-backed writer used to capture write_f64 output.
+rec TestBuf {
+    data: *u8;
+    len:  usize;
+    cap:  usize;
+}
+
+fun testbuf_write(ctx: ptr, p: *u8, len: usize) Result[usize, str] {
+    val tb: *TestBuf = ctx::*TestBuf;
+    var i: usize = 0;
+    for (i < len) {
+        if (tb.len >= tb.cap) { ret err[usize, str]("testbuf overflow"); }
+        tb.data[tb.len] = p[i];
+        tb.len = tb.len + 1;
+        i = i + 1;
+    }
+    ret ok[usize, str](len);
+}
+
+# f64_into: format n into storage (null-terminated); returns the byte length.
+fun f64_into(n: f64, storage: *u8, cap: usize) usize {
+    var tb: TestBuf;
+    tb.data = storage;
+    tb.len = 0;
+    tb.cap = cap;
+    var w: writer.Writer;
+    w.ctx = (?tb)::ptr;
+    w.fn_write = testbuf_write;
+    val r: Result[usize, str] = write_f64(?w, n);
+    if (is_err[usize, str](r)) { storage[0] = 0; ret 0; }
+    storage[tb.len] = 0;
+    ret tb.len;
+}
+
+# golden_eq: format n and compare to the expected shortest decimal.
+fun golden_eq(n: f64, want: str) bool {
+    var s: [64]u8;
+    f64_into(n, ?s[0], 64);
+    ret str_equals(?s[0], want);
+}
+
+# golden_bits_eq: format the f64 with the given bit pattern and compare.
+fun golden_bits_eq(bits: u64, want: str) bool {
+    var n: f64;
+    mem.raw_copy(?n, ?bits, 8);
+    ret golden_eq(n, want);
+}
+
+test "write_f64: golden values" {
+    var s: [64]u8;
+    f64_into(0.0, ?s[0], 64);
+    if (!str_equals(?s[0], "0")) { ret 1; }
+    f64_into(1.0, ?s[0], 64);
+    if (!str_equals(?s[0], "1")) { ret 1; }
+    f64_into(1.5, ?s[0], 64);
+    if (!str_equals(?s[0], "1.5")) { ret 1; }
+    f64_into(0.5, ?s[0], 64);
+    if (!str_equals(?s[0], "0.5")) { ret 1; }
+    f64_into(100.0, ?s[0], 64);
+    if (!str_equals(?s[0], "100")) { ret 1; }
+    f64_into(0.1, ?s[0], 64);
+    if (!str_equals(?s[0], "0.1")) { ret 1; }
+    f64_into(-2.5, ?s[0], 64);
+    if (!str_equals(?s[0], "-2.5")) { ret 1; }
+    ret 0;
+}
+
+test "write_f64: special values" {
+    var s: [64]u8;
+    var x: f64;
+    var bits: u64;
+    bits = 0x8000000000000000;
+    mem.raw_copy(?x, ?bits, 8);
+    f64_into(x, ?s[0], 64);
+    if (!str_equals(?s[0], "-0")) { ret 1; }
+    bits = 0x7FF0000000000000;
+    mem.raw_copy(?x, ?bits, 8);
+    f64_into(x, ?s[0], 64);
+    if (!str_equals(?s[0], "inf")) { ret 1; }
+    bits = 0xFFF0000000000000;
+    mem.raw_copy(?x, ?bits, 8);
+    f64_into(x, ?s[0], 64);
+    if (!str_equals(?s[0], "-inf")) { ret 1; }
+    bits = 0x7FF8000000000000;
+    mem.raw_copy(?x, ?bits, 8);
+    f64_into(x, ?s[0], 64);
+    if (!str_equals(?s[0], "nan")) { ret 1; }
+    ret 0;
+}
+
+test "write_f64: golden notation" {
+    if (!golden_eq(3.141592653589793, "3.141592653589793")) { ret 1; }
+    if (!golden_eq(2.718281828459045, "2.718281828459045")) { ret 1; }
+    if (!golden_eq(1.0e10, "10000000000")) { ret 1; }
+    if (!golden_eq(1.0e-10, "1e-10")) { ret 1; }
+    if (!golden_eq(123456.789, "123456.789")) { ret 1; }
+    if (!golden_eq(1.0e20, "1e20")) { ret 1; }
+    if (!golden_eq(1.0e21, "1e21")) { ret 1; }
+    ret 0;
+}
+
+# extremes use exact bit patterns so they don't depend on the precision of the
+# compiler's float-literal lexer (which is not correctly-rounded for large
+# exponents — tracked separately from this formatter).
+test "write_f64: golden extremes (exact bits)" {
+    if (!golden_bits_eq(0x7FEFFFFFFFFFFFFF, "1.7976931348623157e308")) { ret 1; }
+    if (!golden_bits_eq(0x0010000000000000, "2.2250738585072014e-308")) { ret 1; }
+    if (!golden_bits_eq(1, "5e-324")) { ret 1; }
+    if (!golden_bits_eq(0x54B249AD2594C37D, "1e100")) { ret 1; }
+    if (!golden_bits_eq(0x4341C37937E08000, "10000000000000000")) { ret 1; }
     ret 0;
 }

--- a/src/format.mach
+++ b/src/format.mach
@@ -157,6 +157,169 @@ pub fun write_ptr(w: *writer.Writer, p: ptr) Result[usize, str] {
     ret ok[usize, str](unwrap_ok[usize, str](r1) + unwrap_ok[usize, str](r2));
 }
 
+# fixed-capacity big integer used by the dragon4 float formatter. limbs are
+# little-endian 32-bit; n counts active limbs (n == 0 is zero, no leading-zero
+# limbs). 128 limbs (4096 bits) comfortably covers every f64 (<= ~1100 bits).
+rec Big {
+    n: usize;
+    d: [128]u32;
+}
+
+# big_zero: set b to zero.
+fun big_zero(b: *Big) {
+    b.n = 0;
+}
+
+# big_norm: drop leading-zero limbs so n is exact.
+fun big_norm(b: *Big) {
+    for (b.n > 0 && b.d[b.n - 1] == 0) {
+        b.n = b.n - 1;
+    }
+}
+
+# big_from_u64: set b to v.
+fun big_from_u64(b: *Big, v: u64) {
+    b.d[0] = (v & 0xFFFFFFFF)::u32;
+    b.d[1] = (v >> 32)::u32;
+    b.n = 2;
+    big_norm(b);
+}
+
+# big_is_zero: true iff b == 0.
+fun big_is_zero(b: *Big) bool {
+    ret b.n == 0;
+}
+
+# big_to_u64: low 64 bits of b (exact when b < 2^64). used by tests.
+fun big_to_u64(b: *Big) u64 {
+    if (b.n == 0) { ret 0; }
+    if (b.n == 1) { ret b.d[0]::u64; }
+    ret b.d[0]::u64 | (b.d[1]::u64 << 32);
+}
+
+# big_copy: dst = src.
+fun big_copy(dst: *Big, src: *Big) {
+    dst.n = src.n;
+    var i: usize = 0;
+    for (i < src.n) {
+        dst.d[i] = src.d[i];
+        i = i + 1;
+    }
+}
+
+# big_cmp: -1 if a < b, 0 if equal, 1 if a > b.
+fun big_cmp(a: *Big, b: *Big) i64 {
+    if (a.n != b.n) {
+        if (a.n < b.n) { ret -1; }
+        ret 1;
+    }
+    var i: usize = a.n;
+    for (i > 0) {
+        i = i - 1;
+        if (a.d[i] != b.d[i]) {
+            if (a.d[i] < b.d[i]) { ret -1; }
+            ret 1;
+        }
+    }
+    ret 0;
+}
+
+# big_mul_small: b = b * m.
+fun big_mul_small(b: *Big, m: u32) {
+    if (b.n == 0 || m == 0) { big_zero(b); ret; }
+    var carry: u64 = 0;
+    var i: usize = 0;
+    for (i < b.n) {
+        val cur: u64 = b.d[i]::u64 * m::u64 + carry;
+        b.d[i] = (cur & 0xFFFFFFFF)::u32;
+        carry = cur >> 32;
+        i = i + 1;
+    }
+    if (carry > 0) {
+        b.d[b.n] = (carry & 0xFFFFFFFF)::u32;
+        b.n = b.n + 1;
+    }
+}
+
+# big_shl: b = b << bits (multiply by 2^bits).
+fun big_shl(b: *Big, bits: usize) {
+    if (b.n == 0 || bits == 0) { ret; }
+    val limb_shift: usize = bits / 32;
+    val bit_shift: usize = bits % 32;
+    if (bit_shift > 0) {
+        var carry: u64 = 0;
+        var i: usize = 0;
+        for (i < b.n) {
+            val v: u64 = (b.d[i]::u64 << bit_shift) | carry;
+            b.d[i] = (v & 0xFFFFFFFF)::u32;
+            carry = v >> 32;
+            i = i + 1;
+        }
+        if (carry > 0) {
+            b.d[b.n] = (carry & 0xFFFFFFFF)::u32;
+            b.n = b.n + 1;
+        }
+    }
+    if (limb_shift > 0) {
+        var i: usize = b.n;
+        for (i > 0) {
+            i = i - 1;
+            b.d[i + limb_shift] = b.d[i];
+        }
+        var j: usize = 0;
+        for (j < limb_shift) {
+            b.d[j] = 0;
+            j = j + 1;
+        }
+        b.n = b.n + limb_shift;
+    }
+}
+
+# big_add: a = a + b.
+fun big_add(a: *Big, b: *Big) {
+    var maxn: usize = a.n;
+    if (b.n > maxn) { maxn = b.n; }
+    var carry: u64 = 0;
+    var i: usize = 0;
+    for (i < maxn) {
+        var av: u64 = 0;
+        if (i < a.n) { av = a.d[i]::u64; }
+        var bv: u64 = 0;
+        if (i < b.n) { bv = b.d[i]::u64; }
+        val s: u64 = av + bv + carry;
+        a.d[i] = (s & 0xFFFFFFFF)::u32;
+        carry = s >> 32;
+        i = i + 1;
+    }
+    a.n = maxn;
+    if (carry > 0) {
+        a.d[a.n] = (carry & 0xFFFFFFFF)::u32;
+        a.n = a.n + 1;
+    }
+    big_norm(a);
+}
+
+# big_sub: a = a - b, requires a >= b.
+fun big_sub(a: *Big, b: *Big) {
+    var borrow: i64 = 0;
+    var i: usize = 0;
+    for (i < a.n) {
+        var bv: i64 = 0;
+        if (i < b.n) { bv = b.d[i]::i64; }
+        var t: i64 = a.d[i]::i64 - bv - borrow;
+        if (t < 0) {
+            t = t + 0x100000000;
+            borrow = 1;
+        }
+        or {
+            borrow = 0;
+        }
+        a.d[i] = t::u32;
+        i = i + 1;
+    }
+    big_norm(a);
+}
+
 pub val ERR_BAD_FORMAT: str = "bad format";
 
 # aarch64 varargs is deferred to v1.6.x (#276): gate the variadic surface so
@@ -368,3 +531,45 @@ test "variadic: baseline f64 vararg" {
     ret 0;
 }
 }  # end $if (arch != aarch64) — varargs deferred to v1.6.x (#276)
+
+test "bignum: from_u64 / to_u64 roundtrip" {
+    var a: Big;
+    big_from_u64(?a, 0);
+    if (!big_is_zero(?a)) { ret 1; }
+    big_from_u64(?a, 123456789);
+    if (big_to_u64(?a) != 123456789) { ret 1; }
+    big_from_u64(?a, 0xFFFFFFFFFF);
+    if (big_to_u64(?a) != 0xFFFFFFFFFF) { ret 1; }
+    ret 0;
+}
+
+test "bignum: mul_small and shl" {
+    var a: Big;
+    big_from_u64(?a, 123);
+    big_mul_small(?a, 10);
+    if (big_to_u64(?a) != 1230) { ret 1; }
+    big_from_u64(?a, 1);
+    big_shl(?a, 40);
+    if (big_to_u64(?a) != 0x10000000000) { ret 1; }
+    big_from_u64(?a, 0xFFFFFFFF);
+    big_mul_small(?a, 16);
+    if (big_to_u64(?a) != 0xFFFFFFFF0) { ret 1; }
+    ret 0;
+}
+
+test "bignum: add / sub / cmp" {
+    var a: Big;
+    var b: Big;
+    big_from_u64(?a, 0xFFFFFFFF);
+    big_from_u64(?b, 1);
+    big_add(?a, ?b);
+    if (big_to_u64(?a) != 0x100000000) { ret 1; }
+    big_sub(?a, ?b);
+    if (big_to_u64(?a) != 0xFFFFFFFF) { ret 1; }
+    big_from_u64(?a, 1000);
+    big_from_u64(?b, 999);
+    if (big_cmp(?a, ?b) != 1) { ret 1; }
+    if (big_cmp(?b, ?a) != -1) { ret 1; }
+    if (big_cmp(?a, ?a) != 0) { ret 1; }
+    ret 0;
+}

--- a/src/format.mach
+++ b/src/format.mach
@@ -16,6 +16,7 @@ use std.types.string.str_len;
 use std.types.string.str_equals;
 use writer: std.io.writer;
 use mem: std.memory;
+use bn: std.math.bignum;
 
 # write_bytes: write raw bytes to a writer.
 # ---
@@ -158,169 +159,6 @@ pub fun write_ptr(w: *writer.Writer, p: ptr) Result[usize, str] {
     ret ok[usize, str](unwrap_ok[usize, str](r1) + unwrap_ok[usize, str](r2));
 }
 
-# fixed-capacity big integer used by the dragon4 float formatter. limbs are
-# little-endian 32-bit; n counts active limbs (n == 0 is zero, no leading-zero
-# limbs). 128 limbs (4096 bits) comfortably covers every f64 (<= ~1100 bits).
-rec Big {
-    n: usize;
-    d: [128]u32;
-}
-
-# big_zero: set b to zero.
-fun big_zero(b: *Big) {
-    b.n = 0;
-}
-
-# big_norm: drop leading-zero limbs so n is exact.
-fun big_norm(b: *Big) {
-    for (b.n > 0 && b.d[b.n - 1] == 0) {
-        b.n = b.n - 1;
-    }
-}
-
-# big_from_u64: set b to v.
-fun big_from_u64(b: *Big, v: u64) {
-    b.d[0] = (v & 0xFFFFFFFF)::u32;
-    b.d[1] = (v >> 32)::u32;
-    b.n = 2;
-    big_norm(b);
-}
-
-# big_is_zero: true iff b == 0.
-fun big_is_zero(b: *Big) bool {
-    ret b.n == 0;
-}
-
-# big_to_u64: low 64 bits of b (exact when b < 2^64). used by tests.
-fun big_to_u64(b: *Big) u64 {
-    if (b.n == 0) { ret 0; }
-    if (b.n == 1) { ret b.d[0]::u64; }
-    ret b.d[0]::u64 | (b.d[1]::u64 << 32);
-}
-
-# big_copy: dst = src.
-fun big_copy(dst: *Big, src: *Big) {
-    dst.n = src.n;
-    var i: usize = 0;
-    for (i < src.n) {
-        dst.d[i] = src.d[i];
-        i = i + 1;
-    }
-}
-
-# big_cmp: -1 if a < b, 0 if equal, 1 if a > b.
-fun big_cmp(a: *Big, b: *Big) i64 {
-    if (a.n != b.n) {
-        if (a.n < b.n) { ret -1; }
-        ret 1;
-    }
-    var i: usize = a.n;
-    for (i > 0) {
-        i = i - 1;
-        if (a.d[i] != b.d[i]) {
-            if (a.d[i] < b.d[i]) { ret -1; }
-            ret 1;
-        }
-    }
-    ret 0;
-}
-
-# big_mul_small: b = b * m.
-fun big_mul_small(b: *Big, m: u32) {
-    if (b.n == 0 || m == 0) { big_zero(b); ret; }
-    var carry: u64 = 0;
-    var i: usize = 0;
-    for (i < b.n) {
-        val cur: u64 = b.d[i]::u64 * m::u64 + carry;
-        b.d[i] = (cur & 0xFFFFFFFF)::u32;
-        carry = cur >> 32;
-        i = i + 1;
-    }
-    if (carry > 0) {
-        b.d[b.n] = (carry & 0xFFFFFFFF)::u32;
-        b.n = b.n + 1;
-    }
-}
-
-# big_shl: b = b << bits (multiply by 2^bits).
-fun big_shl(b: *Big, bits: usize) {
-    if (b.n == 0 || bits == 0) { ret; }
-    val limb_shift: usize = bits / 32;
-    val bit_shift: usize = bits % 32;
-    if (bit_shift > 0) {
-        var carry: u64 = 0;
-        var i: usize = 0;
-        for (i < b.n) {
-            val v: u64 = (b.d[i]::u64 << bit_shift) | carry;
-            b.d[i] = (v & 0xFFFFFFFF)::u32;
-            carry = v >> 32;
-            i = i + 1;
-        }
-        if (carry > 0) {
-            b.d[b.n] = (carry & 0xFFFFFFFF)::u32;
-            b.n = b.n + 1;
-        }
-    }
-    if (limb_shift > 0) {
-        var i: usize = b.n;
-        for (i > 0) {
-            i = i - 1;
-            b.d[i + limb_shift] = b.d[i];
-        }
-        var j: usize = 0;
-        for (j < limb_shift) {
-            b.d[j] = 0;
-            j = j + 1;
-        }
-        b.n = b.n + limb_shift;
-    }
-}
-
-# big_add: a = a + b.
-fun big_add(a: *Big, b: *Big) {
-    var maxn: usize = a.n;
-    if (b.n > maxn) { maxn = b.n; }
-    var carry: u64 = 0;
-    var i: usize = 0;
-    for (i < maxn) {
-        var av: u64 = 0;
-        if (i < a.n) { av = a.d[i]::u64; }
-        var bv: u64 = 0;
-        if (i < b.n) { bv = b.d[i]::u64; }
-        val s: u64 = av + bv + carry;
-        a.d[i] = (s & 0xFFFFFFFF)::u32;
-        carry = s >> 32;
-        i = i + 1;
-    }
-    a.n = maxn;
-    if (carry > 0) {
-        a.d[a.n] = (carry & 0xFFFFFFFF)::u32;
-        a.n = a.n + 1;
-    }
-    big_norm(a);
-}
-
-# big_sub: a = a - b, requires a >= b.
-fun big_sub(a: *Big, b: *Big) {
-    var borrow: i64 = 0;
-    var i: usize = 0;
-    for (i < a.n) {
-        var bv: i64 = 0;
-        if (i < b.n) { bv = b.d[i]::i64; }
-        var t: i64 = a.d[i]::i64 - bv - borrow;
-        if (t < 0) {
-            t = t + 0x100000000;
-            borrow = 1;
-        }
-        or {
-            borrow = 0;
-        }
-        a.d[i] = t::u32;
-        i = i + 1;
-    }
-    big_norm(a);
-}
-
 # bitlen_u64: number of significant bits in v (0 when v == 0).
 fun bitlen_u64(v: u64) usize {
     var n: usize = 0;
@@ -332,66 +170,48 @@ fun bitlen_u64(v: u64) usize {
     ret n;
 }
 
-# big_mul_pow10: b = b * 10^k.
-fun big_mul_pow10(b: *Big, k: usize) {
-    var rem: usize = k;
-    for (rem >= 9) {
-        big_mul_small(b, 1000000000);
-        rem = rem - 9;
-    }
-    var p: u32 = 1;
-    var i: usize = 0;
-    for (i < rem) {
-        p = p * 10;
-        i = i + 1;
-    }
-    if (p > 1) {
-        big_mul_small(b, p);
-    }
-}
-
 # dragon4: shortest round-trippable decimal digits of v = f * 2^e (f != 0).
 # writes digit values 0..9 into buf, the count into out_n, and the decimal
 # exponent into out_decExp such that v = 0.<buf digits> * 10^out_decExp. exact
 # bignum arithmetic, round-to-nearest-even — no magic tables.
 fun dragon4(f: u64, e: i64, buf: *u8, out_n: *usize, out_decExp: *i64) {
-    var R: Big;
-    var S: Big;
-    var Mp: Big;
-    var Mm: Big;
-    big_from_u64(?R, f);
+    var R: bn.Big;
+    var S: bn.Big;
+    var Mp: bn.Big;
+    var Mm: bn.Big;
+    bn.from_u64(?R, f);
     if (e >= 0) {
         if (f != 0x10000000000000) {
-            big_shl(?R, (e + 1)::usize);
-            big_from_u64(?S, 2);
-            big_from_u64(?Mp, 1);
-            big_shl(?Mp, e::usize);
-            big_from_u64(?Mm, 1);
-            big_shl(?Mm, e::usize);
+            bn.shl(?R, (e + 1)::usize);
+            bn.from_u64(?S, 2);
+            bn.from_u64(?Mp, 1);
+            bn.shl(?Mp, e::usize);
+            bn.from_u64(?Mm, 1);
+            bn.shl(?Mm, e::usize);
         }
         or {
-            big_shl(?R, (e + 2)::usize);
-            big_from_u64(?S, 4);
-            big_from_u64(?Mp, 1);
-            big_shl(?Mp, (e + 1)::usize);
-            big_from_u64(?Mm, 1);
-            big_shl(?Mm, e::usize);
+            bn.shl(?R, (e + 2)::usize);
+            bn.from_u64(?S, 4);
+            bn.from_u64(?Mp, 1);
+            bn.shl(?Mp, (e + 1)::usize);
+            bn.from_u64(?Mm, 1);
+            bn.shl(?Mm, e::usize);
         }
     }
     or {
         if (e == -1074 || f != 0x10000000000000) {
-            big_shl(?R, 1);
-            big_from_u64(?S, 1);
-            big_shl(?S, (1 - e)::usize);
-            big_from_u64(?Mp, 1);
-            big_from_u64(?Mm, 1);
+            bn.shl(?R, 1);
+            bn.from_u64(?S, 1);
+            bn.shl(?S, (1 - e)::usize);
+            bn.from_u64(?Mp, 1);
+            bn.from_u64(?Mm, 1);
         }
         or {
-            big_shl(?R, 2);
-            big_from_u64(?S, 1);
-            big_shl(?S, (2 - e)::usize);
-            big_from_u64(?Mp, 2);
-            big_from_u64(?Mm, 1);
+            bn.shl(?R, 2);
+            bn.from_u64(?S, 1);
+            bn.shl(?S, (2 - e)::usize);
+            bn.from_u64(?Mp, 2);
+            bn.from_u64(?Mm, 1);
         }
     }
 
@@ -399,59 +219,59 @@ fun dragon4(f: u64, e: i64, buf: *u8, out_n: *usize, out_decExp: *i64) {
     val binexp: i64 = e + bitlen_u64(f)::i64 - 1;
     var k: i64 = (binexp * 1233) / 4096 + 1;
     if (k >= 0) {
-        big_mul_pow10(?S, k::usize);
+        bn.mul_pow10(?S, k::usize);
     }
     or {
-        big_mul_pow10(?R, (0 - k)::usize);
-        big_mul_pow10(?Mp, (0 - k)::usize);
-        big_mul_pow10(?Mm, (0 - k)::usize);
+        bn.mul_pow10(?R, (0 - k)::usize);
+        bn.mul_pow10(?Mp, (0 - k)::usize);
+        bn.mul_pow10(?Mm, (0 - k)::usize);
     }
-    for (big_cmp(?R, ?S) >= 0) {
-        big_mul_small(?S, 10);
+    for (bn.cmp(?R, ?S) >= 0) {
+        bn.mul_small(?S, 10);
         k = k + 1;
     }
-    var r10: Big;
-    big_copy(?r10, ?R);
-    big_mul_small(?r10, 10);
-    for (big_cmp(?r10, ?S) < 0) {
-        big_mul_small(?R, 10);
-        big_mul_small(?Mp, 10);
-        big_mul_small(?Mm, 10);
+    var r10: bn.Big;
+    bn.copy(?r10, ?R);
+    bn.mul_small(?r10, 10);
+    for (bn.cmp(?r10, ?S) < 0) {
+        bn.mul_small(?R, 10);
+        bn.mul_small(?Mp, 10);
+        bn.mul_small(?Mm, 10);
         k = k - 1;
-        big_copy(?r10, ?R);
-        big_mul_small(?r10, 10);
+        bn.copy(?r10, ?R);
+        bn.mul_small(?r10, 10);
     }
 
     val even: bool = (f & 1) == 0;
     var nd: usize = 0;
-    var tmp: Big;
+    var tmp: bn.Big;
     var done: bool = false;
     for (!done) {
-        big_mul_small(?R, 10);
-        big_mul_small(?Mp, 10);
-        big_mul_small(?Mm, 10);
+        bn.mul_small(?R, 10);
+        bn.mul_small(?Mp, 10);
+        bn.mul_small(?Mm, 10);
         var d: i64 = 0;
-        for (big_cmp(?R, ?S) >= 0) {
-            big_sub(?R, ?S);
+        for (bn.cmp(?R, ?S) >= 0) {
+            bn.sub(?R, ?S);
             d = d + 1;
         }
         var low: bool = false;
-        if (even) { low = big_cmp(?R, ?Mm) <= 0; }
-        or { low = big_cmp(?R, ?Mm) < 0; }
-        big_copy(?tmp, ?R);
-        big_add(?tmp, ?Mp);
+        if (even) { low = bn.cmp(?R, ?Mm) <= 0; }
+        or { low = bn.cmp(?R, ?Mm) < 0; }
+        bn.copy(?tmp, ?R);
+        bn.add(?tmp, ?Mp);
         var high: bool = false;
-        if (even) { high = big_cmp(?tmp, ?S) >= 0; }
-        or { high = big_cmp(?tmp, ?S) > 0; }
+        if (even) { high = bn.cmp(?tmp, ?S) >= 0; }
+        or { high = bn.cmp(?tmp, ?S) > 0; }
 
         if (low || high) {
             var up: bool = false;
             if (high && !low) { up = true; }
             or (low && !high) { up = false; }
             or {
-                big_copy(?tmp, ?R);
-                big_shl(?tmp, 1);
-                val c: i64 = big_cmp(?tmp, ?S);
+                bn.copy(?tmp, ?R);
+                bn.shl(?tmp, 1);
+                val c: i64 = bn.cmp(?tmp, ?S);
                 if (c > 0) { up = true; }
                 or (c < 0) { up = false; }
                 or { up = (d & 1) == 1; }
@@ -845,48 +665,6 @@ test "variadic: baseline f64 vararg" {
     ret 0;
 }
 }  # end $if (arch != aarch64) — varargs deferred to v1.6.x (#276)
-
-test "bignum: from_u64 / to_u64 roundtrip" {
-    var a: Big;
-    big_from_u64(?a, 0);
-    if (!big_is_zero(?a)) { ret 1; }
-    big_from_u64(?a, 123456789);
-    if (big_to_u64(?a) != 123456789) { ret 1; }
-    big_from_u64(?a, 0xFFFFFFFFFF);
-    if (big_to_u64(?a) != 0xFFFFFFFFFF) { ret 1; }
-    ret 0;
-}
-
-test "bignum: mul_small and shl" {
-    var a: Big;
-    big_from_u64(?a, 123);
-    big_mul_small(?a, 10);
-    if (big_to_u64(?a) != 1230) { ret 1; }
-    big_from_u64(?a, 1);
-    big_shl(?a, 40);
-    if (big_to_u64(?a) != 0x10000000000) { ret 1; }
-    big_from_u64(?a, 0xFFFFFFFF);
-    big_mul_small(?a, 16);
-    if (big_to_u64(?a) != 0xFFFFFFFF0) { ret 1; }
-    ret 0;
-}
-
-test "bignum: add / sub / cmp" {
-    var a: Big;
-    var b: Big;
-    big_from_u64(?a, 0xFFFFFFFF);
-    big_from_u64(?b, 1);
-    big_add(?a, ?b);
-    if (big_to_u64(?a) != 0x100000000) { ret 1; }
-    big_sub(?a, ?b);
-    if (big_to_u64(?a) != 0xFFFFFFFF) { ret 1; }
-    big_from_u64(?a, 1000);
-    big_from_u64(?b, 999);
-    if (big_cmp(?a, ?b) != 1) { ret 1; }
-    if (big_cmp(?b, ?a) != -1) { ret 1; }
-    if (big_cmp(?a, ?a) != 0) { ret 1; }
-    ret 0;
-}
 
 # test-only buffer-backed writer used to capture write_f64 output.
 rec TestBuf {

--- a/src/print.mach
+++ b/src/print.mach
@@ -95,54 +95,38 @@ pub fun eu64(n: u64) Result[usize, str] {
     ret f.write_u64(?w, n);
 }
 
-# aarch64 varargs is deferred to v1.6.x (#276): gate the variadic print API
-# so the rest of std cross-compiles. non-varargs print/println/u64 stay.
-$if ($mach.target.arch != $mach.arch.aarch64) {
-
 # formatted output to stdout.
 # ---
-# format: format string (see std.format.vformat for specifiers)
-# ret:    bytes written, or an error
-pub fun printf(format: str, ...) Result[usize, str] {
+# fmt: format string (see std.format.vformat for hole syntax)
+# va:  comptime variadic argument pack
+# ret: bytes written, or an error
+pub fun printf(fmt: str, va: ...) Result[usize, str] {
     var w: writer.Writer;
     stdout_writer(?w);
-
-    var ap: va_list;
-    va_start(?ap);
-    val r: Result[usize, str] = f.vformat(?w, format, ?ap);
-    va_end(?ap);
-
-    ret r;
+    ret f.vformat(?w, fmt, va...);
 }
 
 # formatted output to stderr.
 # ---
-# format: format string (see std.format.vformat for specifiers)
-# ret:    bytes written, or an error
-pub fun eprintf(format: str, ...) Result[usize, str] {
+# fmt: format string (see std.format.vformat for hole syntax)
+# va:  comptime variadic argument pack
+# ret: bytes written, or an error
+pub fun eprintf(fmt: str, va: ...) Result[usize, str] {
     var w: writer.Writer;
     stderr_writer(?w);
-
-    var ap: va_list;
-    va_start(?ap);
-    val r: Result[usize, str] = f.vformat(?w, format, ?ap);
-    va_end(?ap);
-
-    ret r;
+    ret f.vformat(?w, fmt, va...);
 }
 
 # formatted output to stdout followed by a newline.
 # ---
-# format: format string (see std.format.vformat for specifiers)
-# ret:    bytes written, or an error
-pub fun printlnf(format: str, ...) Result[usize, str] {
+# fmt: format string (see std.format.vformat for hole syntax)
+# va:  comptime variadic argument pack
+# ret: bytes written, or an error
+pub fun printlnf(fmt: str, va: ...) Result[usize, str] {
     var w: writer.Writer;
     stdout_writer(?w);
 
-    var ap: va_list;
-    va_start(?ap);
-    val r1: Result[usize, str] = f.vformat(?w, format, ?ap);
-    va_end(?ap);
+    val r1: Result[usize, str] = f.vformat(?w, fmt, va...);
     if (is_err[usize, str](r1)) { ret r1; }
 
     val r2: Result[usize, str] = f.write_newline(?w);
@@ -153,16 +137,14 @@ pub fun printlnf(format: str, ...) Result[usize, str] {
 
 # formatted output to stderr followed by a newline.
 # ---
-# format: format string (see std.format.vformat for specifiers)
-# ret:    bytes written, or an error
-pub fun eprintlnf(format: str, ...) Result[usize, str] {
+# fmt: format string (see std.format.vformat for hole syntax)
+# va:  comptime variadic argument pack
+# ret: bytes written, or an error
+pub fun eprintlnf(fmt: str, va: ...) Result[usize, str] {
     var w: writer.Writer;
     stderr_writer(?w);
 
-    var ap: va_list;
-    va_start(?ap);
-    val r1: Result[usize, str] = f.vformat(?w, format, ?ap);
-    va_end(?ap);
+    val r1: Result[usize, str] = f.vformat(?w, fmt, va...);
     if (is_err[usize, str](r1)) { ret r1; }
 
     val r2: Result[usize, str] = f.write_newline(?w);
@@ -170,4 +152,3 @@ pub fun eprintlnf(format: str, ...) Result[usize, str] {
 
     ret ok[usize, str](unwrap_ok[usize, str](r1) + unwrap_ok[usize, str](r2));
 }
-}  # end $if (arch != aarch64) — varargs deferred to v1.6.x (#276)

--- a/src/print.mach
+++ b/src/print.mach
@@ -152,3 +152,12 @@ pub fun eprintlnf(fmt: str, va: ...) Result[usize, str] {
 
     ret ok[usize, str](unwrap_ok[usize, str](r1) + unwrap_ok[usize, str](r2));
 }
+
+# smoke: a pack-tailed printf forwards its (empty) pack to vformat end-to-end on
+# every target, writing nothing for an empty format.
+test "printf: forwards pack to stdout" {
+    val r: Result[usize, str] = printf("");
+    if (is_err[usize, str](r)) { ret 1; }
+    if (unwrap_ok[usize, str](r) != 0) { ret 2; }
+    ret 0;
+}


### PR DESCRIPTION
Closes #282.

v1.7 rewrite of std's variadic formatting onto comptime packs, plus float formatting (octalide-ruled in-scope) and re-enabling aarch64 variadic formatting.

## Status: DRAFT / WIP — landing in tested layers

**Done**
- [x] `write_f64` groundwork: fixed 128-limb u32 bignum (`from_u64`/`cmp`/`shl`/`mul_small`/`add`/`sub`) + unit tests. Compiler-independent; builds under mach 1.6.0.

**Pending (blocked on compiler features)**
- [ ] dragon4 digit generation + `write_f64` (round-trippable, shortest; no magic constants) + round-trip/golden/random tests — compiler-independent, lands next.
- [ ] `vformat`/`format`/`printf`/… rewrite onto `va: ...` + `$each` + `$type_of` per §5 (blocked on mach #1474/#1475/#1472), with the agreed correctness fixes (real Result-threading + true byte count, `{{`/`}}` escapes, `{:x}`/width hole-parser, more-holes-than-args detection, ERR_FEW_HOLES/ERR_MANY_HOLES).
- [ ] Delete the `$if (arch != aarch64)` gates → aarch64 variadic formatting on every target.
- [ ] Replace the SysV-mechanism va_arg regression tests with portable behavioral format tests (run on every target incl. qemu-aarch64).

## Hole syntax
`{}` type-directed (with `{:x}`/`{:X}`/width specs); `{{`/`}}` escapes. (`%` dropped — redundant under `$type_of` dispatch.)

## Float algorithm
dragon4 + a small fixed bignum (exact, shortest, round-trippable) — chosen over Grisu2 because it has zero magic constants (every line verifiable), directly serving the "silently-wrong floats are worse than none" bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)