### PR TITLE
ci: install mach from versioned release artifact (#289)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,16 @@ jobs:
           submodules: true
 
       - name: Install mach
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          curl -fsSL "https://github.com/octalide/mach/releases/latest/download/mach" -o /usr/local/bin/mach
+          mkdir -p /tmp/machdl
+          gh release download --repo octalide/mach \
+            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
+          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
+          cp /tmp/machdl/mach /usr/local/bin/mach
           chmod +x /usr/local/bin/mach
+          mach info
 
       - name: Build
         run: mach build .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,16 @@ jobs:
           submodules: true
 
       - name: Install mach
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          curl -fsSL "https://github.com/octalide/mach/releases/latest/download/mach" -o /usr/local/bin/mach
+          mkdir -p /tmp/machdl
+          gh release download --repo octalide/mach \
+            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
+          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
+          cp /tmp/machdl/mach /usr/local/bin/mach
           chmod +x /usr/local/bin/mach
+          mach info
 
       - name: Build
         run: mach build .


### PR DESCRIPTION
Closes #289.

The `Install mach` step in `ci.yml` and `release.yml` curled the flat unversioned `mach` release asset, which was removed in the v1.6.0 release-artifact cleanup (releases now ship only `mach-<ver>-<arch>-<os>.tar.gz` + `SHA256SUMS`). It 404'd, so **every** CI/release run died at install (~6s) before building — this broke all mach-std CI, including #288.

## Fix
Resolve the latest mach release with `gh release download` (no tag = latest), fetch the versioned `mach-*-x86_64-linux.tar.gz`, extract the `mach` binary (it sits at the tarball root), install to `/usr/local/bin/mach`, and verify with `mach info`. Applied to both workflows. Self-resolving across future versions (matches the "scripts resolve latest version" release convention).

Verified the download+extract+run locally against the v1.6.0 tarball. This PR's own CI exercises the fixed install path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)