### PR TITLE
std: migrate to v1.7 comptime namespaces + decorators (collapse)

### DIFF
--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -177,7 +177,7 @@ pub fun exit(code: i64) {
 # the exec contract is platform-neutral, but the test programs are not;
 # the $if blocks confine the differences to program paths, argv shapes,
 # and echo's line ending (cmd appends CRLF where posix echo appends LF).
-$if ($mach.target.os == $mach.os.windows) {
+$if ($mach.build.os == $mach.os.windows) {
     var comspec_buf: [260]u8;
 
     # %ComSpec% names the command interpreter; fall back to the canonical

--- a/src/runtime.mach
+++ b/src/runtime.mach
@@ -16,13 +16,13 @@
 #
 # note: `use std.runtime;` is required to link the entrypoint into the binary.
 
-$if ($mach.target.os == $mach.os.linux) {
+$if ($mach.build.os == $mach.os.linux) {
     use std.runtime.linux;
 }
-$or ($mach.target.os == $mach.os.darwin) {
+$or ($mach.build.os == $mach.os.darwin) {
     use std.runtime.darwin;
 }
-$or ($mach.target.os == $mach.os.windows) {
+$or ($mach.build.os == $mach.os.windows) {
     use std.runtime.windows;
 }
 $or {

--- a/src/runtime.mach
+++ b/src/runtime.mach
@@ -5,7 +5,7 @@
 #
 #   use std.runtime;
 #
-#   $main.symbol = "main";
+#   `symbol("main")`
 #   fun main(argc: i64, argv: **u8) i64 {
 #       ret 0;
 #   }

--- a/src/runtime/darwin.mach
+++ b/src/runtime/darwin.mach
@@ -1,11 +1,11 @@
-$if ($mach.target.os != $mach.os.darwin) {
+$if ($mach.build.os != $mach.os.darwin) {
     $error("std.runtime.darwin: requires darwin target");
 }
 
-$if ($mach.target.arch == $mach.arch.aarch64) {
+$if ($mach.build.arch == $mach.arch.aarch64) {
     use std.runtime.darwin.aarch64;
 }
-$or ($mach.target.arch == $mach.arch.x86_64) {
+$or ($mach.build.arch == $mach.arch.x86_64) {
     use std.runtime.darwin.x86_64;
 }
 $or {

--- a/src/runtime/darwin/aarch64.mach
+++ b/src/runtime/darwin/aarch64.mach
@@ -18,11 +18,11 @@
 #   $main.symbol = "main";
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 
-$if ($mach.target.os != $mach.os.darwin) {
+$if ($mach.build.os != $mach.os.darwin) {
     $error("std.runtime.darwin.aarch64: requires darwin target");
 }
 
-$if ($mach.target.arch != $mach.arch.aarch64) {
+$if ($mach.build.arch != $mach.arch.aarch64) {
     $error("std.runtime.darwin.aarch64: requires aarch64 target");
 }
 

--- a/src/runtime/darwin/aarch64.mach
+++ b/src/runtime/darwin/aarch64.mach
@@ -15,7 +15,7 @@
 #   4. exits via sys_exit with the return code from main
 #
 # user code must define:
-#   $main.symbol = "main";
+#   `symbol("main")`
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 
 $if ($mach.build.os != $mach.os.darwin) {
@@ -32,12 +32,12 @@ var _rt_argc: i64 = 0;
 var _rt_argv: u64 = 0;
 var _rt_envp: u64 = 0;
 
-$_rt_init.symbol = "_rt_init";
+`symbol("_rt_init")`
 fun _rt_init() {
     os._envp = _rt_envp;
 }
 
-$_start.symbol = "start";
+`symbol("start")`
 pub fun _start() {
     asm aarch64 {
         ldr x0, [sp]      # argc -> x0 (1st argument)

--- a/src/runtime/darwin/x86_64.mach
+++ b/src/runtime/darwin/x86_64.mach
@@ -18,11 +18,11 @@
 #   $main.symbol = "main";
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 
-$if ($mach.target.os != $mach.os.darwin) {
+$if ($mach.build.os != $mach.os.darwin) {
     $error("std.runtime.darwin.x86_64: requires darwin target");
 }
 
-$if ($mach.target.arch != $mach.arch.x86_64) {
+$if ($mach.build.arch != $mach.arch.x86_64) {
     $error("std.runtime.darwin.x86_64: requires x86_64 target");
 }
 

--- a/src/runtime/darwin/x86_64.mach
+++ b/src/runtime/darwin/x86_64.mach
@@ -15,7 +15,7 @@
 #   4. exits via sys_exit with the return code from main
 #
 # user code must define:
-#   $main.symbol = "main";
+#   `symbol("main")`
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 
 $if ($mach.build.os != $mach.os.darwin) {
@@ -32,12 +32,12 @@ var _rt_argc: i64 = 0;
 var _rt_argv: u64 = 0;
 var _rt_envp: u64 = 0;
 
-$_rt_init.symbol = "_rt_init";
+`symbol("_rt_init")`
 fun _rt_init() {
     os._envp = _rt_envp;
 }
 
-$_start.symbol = "start";
+`symbol("start")`
 pub fun _start() {
     asm x86_64 {
         mov rax, rsp      # rax = initial stack pointer

--- a/src/runtime/linux.mach
+++ b/src/runtime/linux.mach
@@ -1,7 +1,7 @@
-$if ($mach.target.arch == $mach.arch.x86_64) {
+$if ($mach.build.arch == $mach.arch.x86_64) {
     use std.runtime.linux.x86_64;
 }
-$or ($mach.target.arch == $mach.arch.aarch64) {
+$or ($mach.build.arch == $mach.arch.aarch64) {
     use std.runtime.linux.aarch64;
 }
 $or {

--- a/src/runtime/linux/aarch64.mach
+++ b/src/runtime/linux/aarch64.mach
@@ -19,7 +19,7 @@
 #      threads; SYS_exit would leave non-main threads alive)
 #
 # user code must define:
-#   $main.symbol = "main";
+#   `symbol("main")`
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 #
 # VERIFICATION STATUS — written ahead of the mach aarch64 backend; two
@@ -37,19 +37,19 @@
 
 use os: std.system.os.linux.aarch64;
 
-$_rt_argc.symbol = "_rt_argc";
+`symbol("_rt_argc")`
 var _rt_argc: i64 = 0;
-$_rt_argv.symbol = "_rt_argv";
+`symbol("_rt_argv")`
 var _rt_argv: u64 = 0;
-$_rt_envp.symbol = "_rt_envp";
+`symbol("_rt_envp")`
 var _rt_envp: u64 = 0;
 
-$_rt_init.symbol = "_rt_init";
+`symbol("_rt_init")`
 fun _rt_init() {
     os._envp = _rt_envp;
 }
 
-$_start.symbol = "_start";
+`symbol("_start")`
 pub fun _start() {
     asm aarch64 {
         mov x9, sp            # x9 = initial stack pointer (argc at [x9])

--- a/src/runtime/linux/x86_64.mach
+++ b/src/runtime/linux/x86_64.mach
@@ -20,24 +20,24 @@
 #      alive, hanging the process after main returns)
 #
 # user code must define:
-#   $main.symbol = "main";
+#   `symbol("main")`
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 
 use os: std.system.os.linux.x86_64;
 
-$_rt_argc.symbol = "_rt_argc";
+`symbol("_rt_argc")`
 var _rt_argc: i64 = 0;
-$_rt_argv.symbol = "_rt_argv";
+`symbol("_rt_argv")`
 var _rt_argv: u64 = 0;
-$_rt_envp.symbol = "_rt_envp";
+`symbol("_rt_envp")`
 var _rt_envp: u64 = 0;
 
-$_rt_init.symbol = "_rt_init";
+`symbol("_rt_init")`
 fun _rt_init() {
     os._envp = _rt_envp;
 }
 
-$_start.symbol = "_start";
+`symbol("_start")`
 pub fun _start() {
     asm x86_64 {
         mov rax, rsp      # rax = initial stack pointer

--- a/src/runtime/windows.mach
+++ b/src/runtime/windows.mach
@@ -1,8 +1,8 @@
-$if ($mach.target.os != $mach.os.windows) {
+$if ($mach.build.os != $mach.os.windows) {
     $error("std.runtime.windows: requires windows target");
 }
 
-$if ($mach.target.arch == $mach.arch.x86_64) {
+$if ($mach.build.arch == $mach.arch.x86_64) {
     use std.runtime.windows.x86_64;
 }
 $or {

--- a/src/runtime/windows/x86_64.mach
+++ b/src/runtime/windows/x86_64.mach
@@ -15,11 +15,11 @@
 
 use std.types.size.usize;
 
-$if ($mach.target.os != $mach.os.windows) {
+$if ($mach.build.os != $mach.os.windows) {
     $error("std.runtime.windows.x86_64: requires windows target");
 }
 
-$if ($mach.target.arch != $mach.arch.x86_64) {
+$if ($mach.build.arch != $mach.arch.x86_64) {
     $error("std.runtime.windows.x86_64: requires x86_64 target");
 }
 

--- a/src/runtime/windows/x86_64.mach
+++ b/src/runtime/windows/x86_64.mach
@@ -10,7 +10,7 @@
 #   4. exits via ExitProcess with the return code from main
 #
 # user code must define:
-#   $main.symbol = "main";
+#   `symbol("main")`
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 
 use std.types.size.usize;
@@ -32,16 +32,16 @@ val MAX_ARGS: usize = 256;
 val MAX_CMDLINE: usize = 32768;
 
 # the entrypoint references these by literal name from inline asm (`[argc]`,
-# `[argv_ptrs]`, `call parse_cmdline`), so each carries a `.symbol` override to
+# `[argv_ptrs]`, `call parse_cmdline`), so each carries a `symbol` decorator to
 # keep its link name verbatim rather than mangled — mirroring the linux runtime's
 # `_rt_*` symbols.
 var cmdline_buf: [32768]u8;
-$argv_ptrs.symbol = "argv_ptrs";
+`symbol("argv_ptrs")`
 var argv_ptrs: [256]usize;
-$argc.symbol = "argc";
+`symbol("argc")`
 var argc: i64 = 0;
 
-$_start.symbol = "mainCRTStartup";
+`symbol("mainCRTStartup")`
 pub fun _start() {
     asm x86_64 {
         and rsp, -16      # align stack to 16 bytes
@@ -66,7 +66,7 @@ pub fun _start() {
 # copies the command line into cmdline_buf, splits on whitespace,
 # handles double-quote grouping (quotes are stripped from the result).
 # populates argv_ptrs and argc.
-$parse_cmdline.symbol = "parse_cmdline";
+`symbol("parse_cmdline")`
 fun parse_cmdline(cmdline: *u8) {
     if (cmdline == nil) {
         argc = 0;

--- a/src/sync/atomic.mach
+++ b/src/sync/atomic.mach
@@ -2,7 +2,7 @@
 #
 # all operations have sequential-consistency ordering, implemented with
 # real per-arch instruction sequences selected at comptime on
-# $mach.target.arch:
+# $mach.build.arch:
 #   - x86_64: the ISA's TSO model makes plain aligned MOV ordered for
 #     load/store; LOCK XADD / XCHG / CMPXCHG carry an implicit full barrier
 #     for the read-modify-write ops; MFENCE is the standalone full barrier;
@@ -21,7 +21,7 @@ use std.types.bool.false;
 # ret: loaded value
 pub fun load(ptr: *i64) i64 {
     var result: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         # aligned MOV is ordered under x86-TSO; gives seq-cst load semantics
         # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
@@ -30,7 +30,7 @@ pub fun load(ptr: *i64) i64 {
             mov {result}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         # load-acquire pairs with STLR stores for seq-cst ordering
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
@@ -50,7 +50,7 @@ pub fun load(ptr: *i64) i64 {
 # ptr: address to store to
 # v:   value to store
 pub fun store(ptr: *i64, v: i64) {
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         # XCHG to memory carries an implicit LOCK, giving a seq-cst store
         # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
@@ -59,7 +59,7 @@ pub fun store(ptr: *i64, v: i64) {
             xchg [rcx], rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         # store-release pairs with LDAR loads for seq-cst ordering
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
@@ -84,7 +84,7 @@ pub fun store(ptr: *i64, v: i64) {
 pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
     var old: i64 = 0;
     val exp: i64 = @expected;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         # LOCK CMPXCHG: RAX holds the comparand and receives the prior value
         # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
@@ -95,7 +95,7 @@ pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
             mov {old}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         # LDAXR/STLXR retry loop; trailing DMB ISH gives full seq-cst order
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
@@ -128,7 +128,7 @@ pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
 # ret: previous value
 pub fun fetch_add(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         # LOCK XADD returns the prior value in the source register
         # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
@@ -138,7 +138,7 @@ pub fun fetch_add(ptr: *i64, v: i64) i64 {
             mov {old}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         # LDAXR/STLXR add loop; trailing DMB ISH gives full seq-cst order
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
@@ -166,7 +166,7 @@ pub fun fetch_add(ptr: *i64, v: i64) i64 {
 # ret: previous value
 pub fun fetch_sub(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         # negate then LOCK XADD; returns the prior value
         # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
@@ -177,7 +177,7 @@ pub fun fetch_sub(ptr: *i64, v: i64) i64 {
             mov {old}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         # LDAXR/STLXR sub loop; trailing DMB ISH gives full seq-cst order
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
@@ -205,7 +205,7 @@ pub fun fetch_sub(ptr: *i64, v: i64) i64 {
 # ret: previous value
 pub fun exchange(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         # XCHG with memory carries an implicit LOCK (full barrier)
         # {ptr} binds to a stack slot, so stage the address in rcx first
         asm x86_64 {
@@ -215,7 +215,7 @@ pub fun exchange(ptr: *i64, v: i64) i64 {
             mov {old}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         # LDAXR/STLXR swap loop; trailing DMB ISH gives full seq-cst order
         # {ptr} binds to a stack slot, so stage the address in x12 first
         asm aarch64 {
@@ -237,12 +237,12 @@ pub fun exchange(ptr: *i64, v: i64) i64 {
 
 # full memory barrier.
 pub fun fence() {
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mfence
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             dmb ish
         }
@@ -254,12 +254,12 @@ pub fun fence() {
 
 # cpu yield hint for spin loops.
 pub fun spin_hint() {
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             pause
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             yield
         }

--- a/src/sync/thread.mach
+++ b/src/sync/thread.mach
@@ -87,7 +87,7 @@ pub fun is_done(t: *Thread) bool {
 
 use atomic_mod: std.sync.atomic;
 
-$if ($mach.target.os == $mach.os.windows) {
+$if ($mach.build.os == $mach.os.windows) {
     use win: std.system.os.windows;
 }
 
@@ -108,7 +108,7 @@ test "thread: Thread record initializes" {
 }
 
 test "thread: spawn and join" {
-    $if ($mach.target.os == $mach.os.windows) {
+    $if ($mach.build.os == $mach.os.windows) {
         # WaitOnAddress/WakeByAddressSingle are correctly pinned to the synch
         # apiset (#253), and wine resolves it (apiset -> kernelbase/ntdll) — but
         # mach v1.5.0 omits the import call-thunk for the last PE import
@@ -127,7 +127,7 @@ test "thread: spawn and join" {
 }
 
 test "thread: is_done after join" {
-    $if ($mach.target.os == $mach.os.windows) {
+    $if ($mach.build.os == $mach.os.windows) {
         # see "thread: spawn and join" above — the synch-apiset wait path faults
         # under wine on mach#1388's missing last-descriptor thunk. skip under wine.
         if (win.running_under_wine()) { ret 0; }

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -10,13 +10,13 @@ use std.types.string.str_len;
 
 use shared: std.system.os.shared;
 
-$if ($mach.target.os == $mach.os.linux) {
+$if ($mach.build.os == $mach.os.linux) {
     use impl: std.system.os.linux;
 }
-$or ($mach.target.os == $mach.os.darwin) {
+$or ($mach.build.os == $mach.os.darwin) {
     use impl: std.system.os.darwin;
 }
-$or ($mach.target.os == $mach.os.windows) {
+$or ($mach.build.os == $mach.os.windows) {
     use impl: std.system.os.windows;
 }
 $or {
@@ -208,7 +208,7 @@ fwd impl.thread_wake;
 # cap: buffer capacity in bytes
 # ret: full length of the path, or negative on error
 pub fun temp_dir(buf: *u8, cap: usize) i64 {
-    $if ($mach.target.os == $mach.os.windows) {
+    $if ($mach.build.os == $mach.os.windows) {
         ret impl.temp_dir(buf, cap);
     }
     $or {
@@ -218,7 +218,7 @@ pub fun temp_dir(buf: *u8, cap: usize) i64 {
     }
 }
 
-$if ($mach.target.os != $mach.os.windows) {
+$if ($mach.build.os != $mach.os.windows) {
     val TEMP_DIR_DEFAULT: str = "/tmp";
 
     # copy the posix fallback temp directory into buf under the temp_dir

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -4,14 +4,14 @@
 # consumers who need darwin-specific functionality import this module
 # directly rather than going through std.system.os.
 
-$if ($mach.target.os != $mach.os.darwin) {
+$if ($mach.build.os != $mach.os.darwin) {
     $error("std.system.os.darwin: requires darwin target");
 }
 
-$if ($mach.target.arch == $mach.arch.aarch64) {
+$if ($mach.build.arch == $mach.arch.aarch64) {
     use impl: std.system.os.darwin.aarch64;
 }
-$or ($mach.target.arch == $mach.arch.x86_64) {
+$or ($mach.build.arch == $mach.arch.x86_64) {
     use impl: std.system.os.darwin.x86_64;
 }
 $or {

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -7,11 +7,11 @@ use std.types.size.usize;
 
 use shared: std.system.os.darwin.shared;
 
-$if ($mach.target.os != $mach.os.darwin) {
+$if ($mach.build.os != $mach.os.darwin) {
     $error("std.system.os.darwin.aarch64: requires darwin target");
 }
 
-$if ($mach.target.arch != $mach.arch.aarch64) {
+$if ($mach.build.arch != $mach.arch.aarch64) {
     $error("std.system.os.darwin.aarch64: requires aarch64 target");
 }
 

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -14,7 +14,7 @@ use std.types.string.str_len;
 use std.types.string.str_starts_with;
 use atomic: std.sync.atomic;
 
-$if ($mach.target.os != $mach.os.darwin) {
+$if ($mach.build.os != $mach.os.darwin) {
     $error("std.system.os.darwin.shared: requires darwin target");
 }
 
@@ -232,7 +232,7 @@ pub val EINTR_MAX_RETRIES: usize = 8;
 pub fun syscall0(n: usize) i64 {
     var out: i64 = 0;
     var fail: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, 0x2000000
             or rax, {n}
@@ -243,7 +243,7 @@ pub fun syscall0(n: usize) i64 {
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             mov x16, {n}
             svc 0x80
@@ -259,7 +259,7 @@ pub fun syscall0(n: usize) i64 {
 pub fun syscall1(n: usize, a0: usize) i64 {
     var out: i64 = 0;
     var fail: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, 0x2000000
             or rax, {n}
@@ -271,7 +271,7 @@ pub fun syscall1(n: usize, a0: usize) i64 {
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             mov x16, {n}
             mov x0, {a0}
@@ -288,7 +288,7 @@ pub fun syscall1(n: usize, a0: usize) i64 {
 pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
     var out: i64 = 0;
     var fail: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, 0x2000000
             or rax, {n}
@@ -301,7 +301,7 @@ pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             mov x16, {n}
             mov x0, {a0}
@@ -319,7 +319,7 @@ pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
 pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
     var out: i64 = 0;
     var fail: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, 0x2000000
             or rax, {n}
@@ -333,7 +333,7 @@ pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             mov x16, {n}
             mov x0, {a0}
@@ -352,7 +352,7 @@ pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
 pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
     var out: i64 = 0;
     var fail: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, 0x2000000
             or rax, {n}
@@ -367,7 +367,7 @@ pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             mov x16, {n}
             mov x0, {a0}
@@ -387,7 +387,7 @@ pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
 pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize) i64 {
     var out: i64 = 0;
     var fail: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, 0x2000000
             or rax, {n}
@@ -403,7 +403,7 @@ pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             mov x16, {n}
             mov x0, {a0}
@@ -424,7 +424,7 @@ pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
 pub fun syscall6(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) i64 {
     var out: i64 = 0;
     var fail: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, 0x2000000
             or rax, {n}
@@ -441,7 +441,7 @@ pub fun syscall6(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             mov x16, {n}
             mov x0, {a0}
@@ -467,10 +467,10 @@ pub fun syscall6(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
 # code: exit code
 pub fun terminate(code: i64) {
     syscall1(SYS_EXIT, code::usize);
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 { hlt }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 { brk 0 }
     }
 }
@@ -728,7 +728,7 @@ pub fun fork() i64 {
     var out: i64 = 0;
     var fail: i64 = 0;
     var child: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, 0x2000000
             or rax, {n}
@@ -740,7 +740,7 @@ pub fun fork() i64 {
             mov {child}, rdx
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             mov x16, {n}
             svc 0x80
@@ -774,7 +774,7 @@ pub fun vfork() i64 {
     var out: i64 = 0;
     var fail: i64 = 0;
     var child: i64 = 0;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, 0x2000000
             or rax, {n}
@@ -786,7 +786,7 @@ pub fun vfork() i64 {
             mov {child}, rdx
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             mov x16, {n}
             svc 0x80

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -7,11 +7,11 @@ use std.types.size.usize;
 
 use shared: std.system.os.darwin.shared;
 
-$if ($mach.target.os != $mach.os.darwin) {
+$if ($mach.build.os != $mach.os.darwin) {
     $error("std.system.os.darwin.x86_64: requires darwin target");
 }
 
-$if ($mach.target.arch != $mach.arch.x86_64) {
+$if ($mach.build.arch != $mach.arch.x86_64) {
     $error("std.system.os.darwin.x86_64: requires x86_64 target");
 }
 

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -4,14 +4,14 @@
 # consumers who need linux-specific functionality import this module
 # directly rather than going through std.system.os.
 
-$if ($mach.target.os != $mach.os.linux) {
+$if ($mach.build.os != $mach.os.linux) {
     $error("std.system.os.linux: requires linux target");
 }
 
-$if ($mach.target.arch == $mach.arch.x86_64) {
+$if ($mach.build.arch == $mach.arch.x86_64) {
     use impl: std.system.os.linux.x86_64;
 }
-$or ($mach.target.arch == $mach.arch.aarch64) {
+$or ($mach.build.arch == $mach.arch.aarch64) {
     use impl: std.system.os.linux.aarch64;
 }
 $or {

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -46,7 +46,7 @@ val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAN
 # prologue (stp x29,x30,[sp,#-16]!; mov x29,sp) then places the four args at
 # [x29+16..x29+40]. NOTE: this offset assumes that frame-record convention and
 # must be confirmed against the mach aarch64 prologue under qemu.
-$thread_trampoline.symbol = "_std_thread_trampoline";
+`symbol("_std_thread_trampoline")`
 fun thread_trampoline() {
     var fn_addr: usize = 0;
     var done_addr: usize = 0;

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -18,11 +18,11 @@ use std.system.os.linux.shared.CLONE_SIGHAND;
 use std.system.os.linux.shared.CLONE_THREAD;
 use std.system.os.linux.shared.CLONE_SYSVSEM;
 
-$if ($mach.target.os != $mach.os.linux) {
+$if ($mach.build.os != $mach.os.linux) {
     $error("std.system.os.linux.aarch64: requires linux target");
 }
 
-$if ($mach.target.arch != $mach.arch.aarch64) {
+$if ($mach.build.arch != $mach.arch.aarch64) {
     $error("std.system.os.linux.aarch64: requires aarch64 target");
 }
 

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -13,7 +13,7 @@ use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_starts_with;
 
-$if ($mach.target.os != $mach.os.linux) {
+$if ($mach.build.os != $mach.os.linux) {
     $error("std.system.os.linux.shared: requires linux target");
 }
 
@@ -21,7 +21,7 @@ $if ($mach.target.os != $mach.os.linux) {
 # aarch64 uses the generic asm-generic/unistd table. the aarch64 table also
 # lacks fork/vfork/symlink/dup2 entirely — clone, symlinkat, and dup3 stand in
 # (see the fork, vfork, symlink, and spawn_redirected wrappers below).
-$if ($mach.target.arch == $mach.arch.x86_64) {
+$if ($mach.build.arch == $mach.arch.x86_64) {
     val SYS_READ:          usize = 0;
     val SYS_WRITE:         usize = 1;
     val SYS_CLOSE:         usize = 3;
@@ -73,7 +73,7 @@ $if ($mach.target.arch == $mach.arch.x86_64) {
     val SYS_CLOSE_RANGE:   usize = 436;
     val SYS_DUP2:          usize = 33;
 }
-$or ($mach.target.arch == $mach.arch.aarch64) {
+$or ($mach.build.arch == $mach.arch.aarch64) {
     val SYS_READ:          usize = 63;
     val SYS_WRITE:         usize = 64;
     val SYS_CLOSE:         usize = 57;
@@ -188,7 +188,7 @@ use os_shared: std.system.os.shared;
 # by architecture: x86_64 has its own layout, while aarch64 uses the
 # asm-generic layout (st_mode/st_nlink order swapped, narrower nlink/blksize).
 # the field names are identical so consumers are arch-agnostic.
-$if ($mach.target.arch == $mach.arch.x86_64) {
+$if ($mach.build.arch == $mach.arch.x86_64) {
     pub rec stat_t {
         st_dev:        u64;
         st_ino:        u64;
@@ -212,7 +212,7 @@ $if ($mach.target.arch == $mach.arch.x86_64) {
         _reserved2:    i64;
     }
 }
-$or ($mach.target.arch == $mach.arch.aarch64) {
+$or ($mach.build.arch == $mach.arch.aarch64) {
     pub rec stat_t {
         st_dev:        u64;
         st_ino:        u64;
@@ -270,10 +270,10 @@ pub val O_APPEND:    i32 = 1024;
 
 # O_DIRECTORY differs by arch: x86_64 = 0x10000, aarch64 (asm-generic) = 0x4000.
 # 0x10000 means O_DIRECT on aarch64, so the value must be arch-gated.
-$if ($mach.target.arch == $mach.arch.x86_64) {
+$if ($mach.build.arch == $mach.arch.x86_64) {
 pub val O_DIRECTORY: i32 = 0x10000;
 }
-$or ($mach.target.arch == $mach.arch.aarch64) {
+$or ($mach.build.arch == $mach.arch.aarch64) {
 pub val O_DIRECTORY: i32 = 0x4000;
 }
 
@@ -331,14 +331,14 @@ pub val EINTR_MAX_RETRIES: usize = 8;
 # ret: syscall result (negative on error)
 pub fun syscall0(n: usize) i64 {
     var out: i64;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, {n}
             syscall
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             ldr x8, {n}
             svc 0
@@ -355,7 +355,7 @@ pub fun syscall0(n: usize) i64 {
 # ret: syscall result (negative on error)
 pub fun syscall1(n: usize, a0: usize) i64 {
     var out: i64;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, {n}
             mov rdi, {a0}
@@ -363,7 +363,7 @@ pub fun syscall1(n: usize, a0: usize) i64 {
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             ldr x8, {n}
             ldr x0, {a0}
@@ -382,7 +382,7 @@ pub fun syscall1(n: usize, a0: usize) i64 {
 # ret: syscall result (negative on error)
 pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
     var out: i64;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, {n}
             mov rdi, {a0}
@@ -391,7 +391,7 @@ pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             ldr x8, {n}
             ldr x0, {a0}
@@ -412,7 +412,7 @@ pub fun syscall2(n: usize, a0: usize, a1: usize) i64 {
 # ret: syscall result (negative on error)
 pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
     var out: i64;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, {n}
             mov rdi, {a0}
@@ -422,7 +422,7 @@ pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             ldr x8, {n}
             ldr x0, {a0}
@@ -445,7 +445,7 @@ pub fun syscall3(n: usize, a0: usize, a1: usize, a2: usize) i64 {
 # ret: syscall result (negative on error)
 pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
     var out: i64;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, {n}
             mov rdi, {a0}
@@ -456,7 +456,7 @@ pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             ldr x8, {n}
             ldr x0, {a0}
@@ -481,7 +481,7 @@ pub fun syscall4(n: usize, a0: usize, a1: usize, a2: usize, a3: usize) i64 {
 # ret: syscall result (negative on error)
 pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize) i64 {
     var out: i64;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, {n}
             mov rdi, {a0}
@@ -493,7 +493,7 @@ pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             ldr x8, {n}
             ldr x0, {a0}
@@ -520,7 +520,7 @@ pub fun syscall5(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
 # ret: syscall result (negative on error)
 pub fun syscall6(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize, a5: usize) i64 {
     var out: i64;
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
             mov rax, {n}
             mov rdi, {a0}
@@ -533,7 +533,7 @@ pub fun syscall6(n: usize, a0: usize, a1: usize, a2: usize, a3: usize, a4: usize
             mov {out}, rax
         }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 {
             ldr x8, {n}
             ldr x0, {a0}
@@ -936,10 +936,10 @@ pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
 # linkpath: path of the link to create
 # ret:      0 on success, or negative errno
 pub fun symlink(target: *u8, linkpath: *u8) i64 {
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         ret syscall2(SYS_SYMLINK, target::usize, linkpath::usize);
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         # aarch64 has no symlink syscall; symlinkat against AT_FDCWD is equivalent.
         ret syscall3(SYS_SYMLINKAT, target::usize, AT_FDCWD::isize::usize, linkpath::usize);
     }
@@ -1007,10 +1007,10 @@ pub fun environ() **u8 {
 pub fun terminate(code: i64) {
     syscall1(SYS_EXIT_GROUP, code::usize);
     # exit_group never returns; trap loudly if it somehow does.
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 { hlt }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 { brk 0 }
     }
 }
@@ -1024,10 +1024,10 @@ pub fun abort() {
 # ---
 # ret: in parent: child PID (>0), in child: 0, on error: negative errno
 pub fun fork() i64 {
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         ret syscall0(SYS_FORK);
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         # aarch64 has no fork syscall; clone with SIGCHLD and no child stack
         # (child runs on a copy-on-write image of the parent stack) is fork.
         ret syscall5(SYS_CLONE, SIGCHLD, 0, 0, 0, 0);
@@ -1038,10 +1038,10 @@ pub fun fork() i64 {
 # ---
 # ret: in parent: child PID (>0), in child: 0, on error: negative errno
 pub fun vfork() i64 {
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         ret syscall0(SYS_VFORK);
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         # aarch64 has no vfork syscall; clone with CLONE_VM|CLONE_VFORK|SIGCHLD
         # and no child stack matches vfork semantics (parent suspended, child
         # shares the address space until exec/_exit). same caller contract as
@@ -1152,7 +1152,7 @@ pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, s
     if (pid == 0) {
         # aarch64 has no dup2 syscall; dup3 with flags 0 is equivalent (it
         # differs only in rejecting oldfd == newfd, which redirect fds never are).
-        $if ($mach.target.arch == $mach.arch.x86_64) {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
             if (stdin_fd != -1 && syscall2(SYS_DUP2, stdin_fd::isize::usize, STDIN_FD::isize::usize) < 0) {
                 syscall1(SYS_EXIT_GROUP, 126);
             }
@@ -1163,7 +1163,7 @@ pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, s
                 syscall1(SYS_EXIT_GROUP, 126);
             }
         }
-        $or ($mach.target.arch == $mach.arch.aarch64) {
+        $or ($mach.build.arch == $mach.arch.aarch64) {
             if (stdin_fd != -1 && syscall3(SYS_DUP3, stdin_fd::isize::usize, STDIN_FD::isize::usize, 0) < 0) {
                 syscall1(SYS_EXIT_GROUP, 126);
             }

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -18,11 +18,11 @@ use std.system.os.linux.shared.CLONE_SIGHAND;
 use std.system.os.linux.shared.CLONE_THREAD;
 use std.system.os.linux.shared.CLONE_SYSVSEM;
 
-$if ($mach.target.os != $mach.os.linux) {
+$if ($mach.build.os != $mach.os.linux) {
     $error("std.system.os.linux.x86_64: requires linux target");
 }
 
-$if ($mach.target.arch != $mach.arch.x86_64) {
+$if ($mach.build.arch != $mach.arch.x86_64) {
     $error("std.system.os.linux.x86_64: requires x86_64 target");
 }
 

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -39,7 +39,7 @@ val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAN
 # the symbol is pinned so the inline-asm branch can target it. at entry rsp
 # points at the argument block on the child stack, so after the prologue the
 # args sit at [rbp+8..rbp+32] exactly as if the trampoline had been called.
-$thread_trampoline.symbol = "_std_thread_trampoline";
+`symbol("_std_thread_trampoline")`
 fun thread_trampoline() {
     var fn_addr: usize = 0;
     var done_addr: usize = 0;

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -4,11 +4,11 @@
 # consumers who need windows-specific functionality import this module
 # directly rather than going through std.system.os.
 
-$if ($mach.target.os != $mach.os.windows) {
+$if ($mach.build.os != $mach.os.windows) {
     $error("std.system.os.windows: requires windows target");
 }
 
-$if ($mach.target.arch == $mach.arch.x86_64) {
+$if ($mach.build.arch == $mach.arch.x86_64) {
     use impl: std.system.os.windows.x86_64;
 }
 $or {

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -19,7 +19,7 @@ use std.types.string.str_len;
 use os_shared: std.system.os.shared;
 use atomic:    std.sync.atomic;
 
-$if ($mach.target.os != $mach.os.windows) {
+$if ($mach.build.os != $mach.os.windows) {
     $error("std.system.os.windows.shared: requires windows target");
 }
 

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -3,8 +3,8 @@
 # windows has no stable syscall interface. all OS interaction goes through
 # kernel32.dll and ntdll.dll via ext fun declarations, plus ws2_32.dll for
 # sockets, advapi32.dll for RtlGenRandom, and api-ms-win-core-synch-l1-2-0.dll
-# for the wait-on-address family; these are pinned with `$<sym>.library` so the
-# PE import directory attributes them to the right DLL rather than the first
+# for the wait-on-address family; these are pinned with a `library` decorator so
+# the PE import directory attributes them to the right DLL rather than the first
 # dependency. a HANDLE-to-fd mapping table bridges the POSIX-style fd interface
 # used by os.mach.
 
@@ -212,7 +212,7 @@ ext fun FindNextFileA(p0: isize, p1: *u8) i32;
 ext fun FindClose(p0: isize) i32;
 ext fun GetFinalPathNameByHandleA(p0: isize, p1: *u8, p2: u32, p3: u32) u32;
 # CreateSymbolicLinkA is exported by kernel32.dll (the first dependency), so
-# an unqualified import binds correctly without a `$<sym>.library` pin (unlike
+# an unqualified import binds correctly without a `library` decorator (unlike
 # the synch-apiset functions of #253). it returns a BOOLEAN — a single byte.
 ext fun CreateSymbolicLinkA(p0: *u8, p1: *u8, p2: u32) u8;
 
@@ -224,60 +224,49 @@ ext fun CreateThread(p0: ptr, p1: usize, p2: usize, p3: ptr, p4: u32, p5: *u32) 
 
 # WaitOnAddress / WakeByAddressSingle live in the synch apiset DLL, not kernel32.
 # real windows' kernel32 does not export them (only wine's does), so without
-# `$<sym>.library` the import binds to kernel32 and the native loader rejects the
-# exe with STATUS_ENTRYPOINT_NOT_FOUND. pin them to the canonical apiset DLL. see
-# issue #253.
-$WaitOnAddress.library = "api-ms-win-core-synch-l1-2-0.dll";
+# the `library` decorator the import binds to kernel32 and the native loader
+# rejects the exe with STATUS_ENTRYPOINT_NOT_FOUND. pin them to the canonical
+# apiset DLL. see issue #253.
+`library("api-ms-win-core-synch-l1-2-0.dll")`
 ext fun WaitOnAddress(p0: ptr, p1: ptr, p2: usize, p3: u32) i32;
-$WakeByAddressSingle.library = "api-ms-win-core-synch-l1-2-0.dll";
+`library("api-ms-win-core-synch-l1-2-0.dll")`
 ext fun WakeByAddressSingle(p0: ptr);
 
-# Winsock2 API imports (ws2_32.dll). each is pinned to ws2_32.dll with
-# `$<sym>.library`; without it an `ext` import binds to the first dependency
+# Winsock2 API imports (ws2_32.dll). each is pinned to ws2_32.dll with a
+# `library` decorator; without it an `ext` import binds to the first dependency
 # (kernel32.dll) and aborts at call time on a real loader.
 
-$WSAStartup.library = "ws2_32.dll";
+`library("ws2_32.dll")`
 ext fun WSAStartup(p0: u16, p1: *u8) i32;
-$WSAGetLastError.library = "ws2_32.dll";
+`library("ws2_32.dll")`
 ext fun WSAGetLastError() i32;
-$ws2_socket.library = "ws2_32.dll";
-$ws2_socket.symbol  = "socket";
+`library("ws2_32.dll")` `symbol("socket")`
 ext fun ws2_socket(p0: i32, p1: i32, p2: i32) usize;
-$ws2_bind.library = "ws2_32.dll";
-$ws2_bind.symbol  = "bind";
+`library("ws2_32.dll")` `symbol("bind")`
 ext fun ws2_bind(p0: usize, p1: *u8, p2: i32) i32;
-$ws2_listen.library = "ws2_32.dll";
-$ws2_listen.symbol  = "listen";
+`library("ws2_32.dll")` `symbol("listen")`
 ext fun ws2_listen(p0: usize, p1: i32) i32;
-$ws2_accept.library = "ws2_32.dll";
-$ws2_accept.symbol  = "accept";
+`library("ws2_32.dll")` `symbol("accept")`
 ext fun ws2_accept(p0: usize, p1: *u8, p2: *i32) usize;
-$ws2_connect.library = "ws2_32.dll";
-$ws2_connect.symbol  = "connect";
+`library("ws2_32.dll")` `symbol("connect")`
 ext fun ws2_connect(p0: usize, p1: *u8, p2: i32) i32;
-$ws2_sendto.library = "ws2_32.dll";
-$ws2_sendto.symbol  = "sendto";
+`library("ws2_32.dll")` `symbol("sendto")`
 ext fun ws2_sendto(p0: usize, p1: *u8, p2: i32, p3: i32, p4: *u8, p5: i32) i32;
-$ws2_recvfrom.library = "ws2_32.dll";
-$ws2_recvfrom.symbol  = "recvfrom";
+`library("ws2_32.dll")` `symbol("recvfrom")`
 ext fun ws2_recvfrom(p0: usize, p1: *u8, p2: i32, p3: i32, p4: *u8, p5: *i32) i32;
-$ws2_shutdown.library = "ws2_32.dll";
-$ws2_shutdown.symbol  = "shutdown";
+`library("ws2_32.dll")` `symbol("shutdown")`
 ext fun ws2_shutdown(p0: usize, p1: i32) i32;
-$ws2_setsockopt.library = "ws2_32.dll";
-$ws2_setsockopt.symbol  = "setsockopt";
+`library("ws2_32.dll")` `symbol("setsockopt")`
 ext fun ws2_setsockopt(p0: usize, p1: i32, p2: i32, p3: *u8, p4: i32) i32;
-$ws2_send.library = "ws2_32.dll";
-$ws2_send.symbol  = "send";
+`library("ws2_32.dll")` `symbol("send")`
 ext fun ws2_send(p0: usize, p1: *u8, p2: i32, p3: i32) i32;
-$ws2_recv.library = "ws2_32.dll";
-$ws2_recv.symbol  = "recv";
+`library("ws2_32.dll")` `symbol("recv")`
 ext fun ws2_recv(p0: usize, p1: *u8, p2: i32, p3: i32) i32;
-$closesocket.library = "ws2_32.dll";
+`library("ws2_32.dll")`
 ext fun closesocket(p0: usize) i32;
 
 # advapi32.dll
-$SystemFunction036.library = "advapi32.dll";
+`library("advapi32.dll")`
 ext fun SystemFunction036(p0: *u8, p1: u32) i32;
 
 ext fun GetCurrentProcessId() u32;

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -6,11 +6,11 @@
 
 use shared: std.system.os.windows.shared;
 
-$if ($mach.target.os != $mach.os.windows) {
+$if ($mach.build.os != $mach.os.windows) {
     $error("std.system.os.windows.x86_64: requires windows target");
 }
 
-$if ($mach.target.arch != $mach.arch.x86_64) {
+$if ($mach.build.arch != $mach.arch.x86_64) {
     $error("std.system.os.windows.x86_64: requires x86_64 target");
 }
 

--- a/src/system/panic.mach
+++ b/src/system/panic.mach
@@ -13,8 +13,8 @@ pub fun panic(msg: *u8) {
     var len: usize = 0;
     for (msg[len] != 0) { len = len + 1; }
 
-    $if ($mach.target.os == $mach.os.linux) {
-        $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.os == $mach.os.linux) {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
             asm x86_64 {
                 mov eax, 1        # SYS_write
                 mov edi, 2        # fd = stderr
@@ -23,7 +23,7 @@ pub fun panic(msg: *u8) {
                 syscall
             }
         }
-        $or ($mach.target.arch == $mach.arch.aarch64) {
+        $or ($mach.build.arch == $mach.arch.aarch64) {
             asm aarch64 {
                 mov x8, 64    # SYS_write (linux aarch64)
                 mov x0, 2     # fd = stderr
@@ -37,7 +37,7 @@ pub fun panic(msg: *u8) {
         }
     }
     $or {
-        $if ($mach.target.arch == $mach.arch.x86_64) {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
             asm x86_64 {
                 mov eax, 0x2000004  # SYS_write (darwin)
                 mov edi, 2          # fd = stderr
@@ -46,7 +46,7 @@ pub fun panic(msg: *u8) {
                 syscall
             }
         }
-        $or ($mach.target.arch == $mach.arch.aarch64) {
+        $or ($mach.build.arch == $mach.arch.aarch64) {
             asm aarch64 {
                 mov x16, 4    # SYS_write (darwin aarch64)
                 mov x0, 2     # fd = stderr
@@ -60,10 +60,10 @@ pub fun panic(msg: *u8) {
         }
     }
 
-    $if ($mach.target.arch == $mach.arch.x86_64) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 { hlt }
     }
-    $or ($mach.target.arch == $mach.arch.aarch64) {
+    $or ($mach.build.arch == $mach.arch.aarch64) {
         asm aarch64 { brk 0 }
     }
     $or {

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -52,7 +52,7 @@ pub fun separator() u8 {
 #
 # windows accepts both '/' and '\'; posix treats only '/' as a separator.
 pub fun is_separator(c: u8) bool {
-    $if ($mach.target.os == $mach.os.windows) {
+    $if ($mach.build.os == $mach.os.windows) {
         ret c == separator() || c == '/';
     }
     $or {
@@ -67,7 +67,7 @@ pub fun is_separator(c: u8) bool {
 # and on all non-windows targets. callers use it so filename/parent/is_root
 # never split inside a volume or UNC root.
 fun root_len(p: Path) usize {
-    $if ($mach.target.os == $mach.os.windows) {
+    $if ($mach.build.os == $mach.os.windows) {
         if (is_empty(p)) { ret 0; }
         val len: usize = str_len(p);
 
@@ -107,7 +107,7 @@ pub fun is_abs(p: Path) bool {
     if (p == nil) { ret false; }
     if (is_separator(p[0])) { ret true; }
 
-    $if ($mach.target.os == $mach.os.windows) {
+    $if ($mach.build.os == $mach.os.windows) {
         if (char_is_alpha(p[0]) && p[1] == ':' && is_separator(p[2])) { ret true; }
     }
 
@@ -473,7 +473,7 @@ test "path: parent root" {
 
 # windows accepts '\' as a separator alongside '/'; these are guarded
 # because '\' is a legal filename byte on posix and parses differently.
-$if ($mach.target.os == $mach.os.windows) {
+$if ($mach.build.os == $mach.os.windows) {
     test "path: is_abs with backslash root" {
         if (!is_abs("\\foo")) { ret 1; }
         ret 0;

--- a/src/types/size.mach
+++ b/src/types/size.mach
@@ -2,15 +2,15 @@
 # ---
 # Defines usize and isize for the target pointer width. Defaults to 64-bit when unknown.
 
-$if ($mach.target.pointer_width == 2) {
+$if ($mach.build.pointer_width == 2) {
 	pub def usize: u16;
 	pub def isize: i16;
 }
-$or ($mach.target.pointer_width == 4) {
+$or ($mach.build.pointer_width == 4) {
 	pub def usize: u32;
 	pub def isize: i32;
 }
-$or ($mach.target.pointer_width == 8) {
+$or ($mach.build.pointer_width == 8) {
 	pub def usize: u64;
 	pub def isize: i64;
 }


### PR DESCRIPTION
Closes #283.

The v1.7 comptime collapse for std: replace every legacy spelling with the new one, repo-wide (new-only, legacy removed entirely).

- **Namespaces:** `$mach.target.*` reads → `$mach.build.*` (provenance-rooted build context; 127 sites, identical sub-keys).
- **Decorators:** `$<sym>.symbol = "..."` / `$<sym>.library = "..."` setters → leading ``symbol("...")`` / ``library("...")`` decorators. `mach.toml [os.*] libs` link set unchanged — the decorator only routes to it.
- `$assert`: zero std sites (no-op).

Builds + tests under the released v1.7.0 compiler, which parses the new spellings. Self-host is unaffected (compiler vendors a frozen pre-collapse std via DECOUPLE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)