### PR TITLE
release: mach-std 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.13.0] - 2026-06-19
+
+Process spawning no longer copies the parent's address space, so `mach test`
+and other fork-heavy programs stay robust on swapless `vm.overcommit_memory=0`
+hosts. Built with the mach 2.0.1 compiler.
+
+### Fixed
+
+- os: `spawn`/`spawn_redirected` (linux) now `clone(CLONE_VM|CLONE_VFORK|
+  SIGCHLD)` the child onto a private stack and a pinned trampoline instead of
+  `fork()`. Sharing the address space skips fork's copy-on-write commit
+  accounting, so spawn no longer fails with `ENOMEM` on a swapless
+  `vm.overcommit_memory=0` host (e.g. GitHub runners), and the fix benefits
+  every fork-heavy mach program. Verified on x86_64 and aarch64 (mach#1487).
+
+### Changed
+
+- allocator: the generic `deallocate[T]` now returns `Result[bool, str]` —
+  ok(true) on success (including the nil-pointer / count == 0 no-op), err on a
+  non-zero status — aligning it with `allocate`/`reallocate`. `deallocate_raw`
+  stays the raw i64 primitive; callers that inspected the status were updated
+  (#291).
+
+### Documented
+
+- format: documented that `f32` widens to `f64` and prints as that value (no
+  f32-specific shortest round-trip), with added tests for f32 widening, the
+  smaller integer widths (i8/i16/i32, u16/u32), and negative signed hex (#293).
+
 ## [0.12.0] - 2026-06-19
 
 The v1.7 collapse — every legacy comptime spelling is gone, replaced by the

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "std"
 name    = "Mach Standard Library"
-version = "0.12.0"
+version = "0.13.0"
 src     = "src"
 dep     = "dep"
 target  = "native"

--- a/src/allocator.mach
+++ b/src/allocator.mach
@@ -12,6 +12,8 @@ use std.types.result.unwrap_err;
 use std.types.option.Option;
 use std.types.option.is_none;
 use std.types.option.unwrap;
+use std.types.bool.bool;
+use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
@@ -154,15 +156,21 @@ pub fun reallocate[T](a: *Allocator, p: *T, old_count: usize, new_count: usize) 
     ret ok[*T, str](unwrap_ok[ptr, str](res_reallocate_raw)::*T);
 }
 
-# deallocate: deallocate memory previously returned by alloc/zalloc for count elements.
+# deallocate: deallocate memory previously returned by alloc/zalloc for count
+# elements.
 # ---
+# a:     Allocator to use for this operation
 # p:     pointer returned by alloc/zalloc (may be nil)
 # count: number of elements to deallocate
-# ret:   0 on success, or negative errno; no-op for nil pointer or count == 0.
-pub fun deallocate[T](a: *Allocator, p: *T, count: usize) i64 {
+# ret:   ok(true) on success (including the nil-pointer / count == 0 no-op), or
+#        err on a non-zero deallocator status, mirroring allocate/reallocate.
+pub fun deallocate[T](a: *Allocator, p: *T, count: usize) Result[bool, str] {
     if (p == nil || count == 0) {
-        ret 0;
+        ret ok[bool, str](true);
     }
 
-    ret deallocate_raw(a, p::ptr, $size_of(T) * count, $align_of(T));
+    if (deallocate_raw(a, p::ptr, $size_of(T) * count, $align_of(T)) != 0) {
+        ret err[bool, str]("deallocate failed");
+    }
+    ret ok[bool, str](true);
 }

--- a/src/allocator/arena.mach
+++ b/src/allocator/arena.mach
@@ -439,7 +439,7 @@ test "arena: free is noop for non-last allocation" {
     if (is_err[*i64, str](r2)) { ret 1; }
     val p2: *i64 = unwrap_ok[*i64, str](r2);
 
-    if (allo.deallocate[i64](?aa, p1, 2) < 0) { ret 1; }
+    if (is_err[bool, str](allo.deallocate[i64](?aa, p1, 2))) { ret 1; }
 
     p2[0] = 999;
     if (p2[0] != 999) { ret 1; }
@@ -464,7 +464,7 @@ test "arena: free last allocation rolls back" {
     if (is_err[*i64, str](r2)) { ret 1; }
     val p2: *i64 = unwrap_ok[*i64, str](r2);
 
-    if (allo.deallocate[i64](?aa, p2, 2) < 0) { ret 1; }
+    if (is_err[bool, str](allo.deallocate[i64](?aa, p2, 2))) { ret 1; }
 
     val r3: Result[*i64, str] = allo.allocate[i64](?aa, 2);
     if (is_err[*i64, str](r3)) { ret 1; }
@@ -590,5 +590,25 @@ test "arena: zero-cap arena grows on first alloc" {
     if (p1[0] != 42) { ret 1; }
 
     if (dnit(?ar) < 0) { ret 1; }
+    ret 0;
+}
+
+# generic deallocate now reports its outcome as a Result, aligning with
+# allocate/reallocate (issue #291): a real free, a nil pointer, and a zero
+# count all yield ok.
+test "allocator: generic deallocate returns ok" {
+    var pa: allo.Allocator;
+    page.make(?pa);
+
+    val r: Result[*i64, str] = allo.allocate[i64](?pa, 4);
+    if (is_err[*i64, str](r)) { ret 1; }
+    val p: *i64 = unwrap_ok[*i64, str](r);
+
+    # a real free succeeds.
+    if (is_err[bool, str](allo.deallocate[i64](?pa, p, 4))) { ret 1; }
+    # a nil pointer is a no-op that still reports ok.
+    if (is_err[bool, str](allo.deallocate[i64](?pa, nil::*i64, 4))) { ret 2; }
+    # a zero count is a no-op that still reports ok.
+    if (is_err[bool, str](allo.deallocate[i64](?pa, p, 0))) { ret 3; }
     ret 0;
 }

--- a/src/collections/bitset.mach
+++ b/src/collections/bitset.mach
@@ -64,11 +64,11 @@ pub fun dnit(bs: *Bitset) bool {
         bs.nbits = 0;
         ret true;
     }
-    val res: i64 = allocator.deallocate[u64](bs.alloc, bs.words, bs.nwords);
+    val freed: bool = !is_err[bool, str](allocator.deallocate[u64](bs.alloc, bs.words, bs.nwords));
     bs.words  = nil;
     bs.nbits  = 0;
     bs.nwords = 0;
-    ret res == 0;
+    ret freed;
 }
 
 # set: set the bit at the given index.

--- a/src/collections/deque.mach
+++ b/src/collections/deque.mach
@@ -49,15 +49,15 @@ pub fun dnit[T](dq: *Deque[T]) bool {
         ret true;
     }
 
-    val res: i64 = allo.deallocate[T](dq.alloc, dq.data, dq.cap);
-    if (res == 0) {
+    val freed: bool = is_ok[bool, str](allo.deallocate[T](dq.alloc, dq.data, dq.cap));
+    if (freed) {
         dq.data = nil;
         dq.len = 0;
         dq.head = 0;
         dq.cap = 0;
     }
 
-    ret res == 0;
+    ret freed;
 }
 
 # check if the deque is empty.

--- a/src/collections/heap.mach
+++ b/src/collections/heap.mach
@@ -49,14 +49,14 @@ pub fun dnit[T](h: *Heap[T]) bool {
         ret true;
     }
 
-    val res: i64 = allo.deallocate[T](h.alloc, h.data, h.cap);
-    if (res == 0) {
+    val freed: bool = is_ok[bool, str](allo.deallocate[T](h.alloc, h.data, h.cap));
+    if (freed) {
         h.data = nil;
         h.len = 0;
         h.cap = 0;
     }
 
-    ret res == 0;
+    ret freed;
 }
 
 # check if the heap is empty.

--- a/src/collections/map.mach
+++ b/src/collections/map.mach
@@ -86,9 +86,9 @@ pub fun dnit[K, V](m: *Map[K, V]) bool {
     }
 
     var ok: bool = true;
-    if (allocator.deallocate[K](m.alloc, m.keys, m.cap) < 0) { ok = false; }
-    if (allocator.deallocate[V](m.alloc, m.values, m.cap) < 0) { ok = false; }
-    if (allocator.deallocate[u8](m.alloc, m.states, m.cap) < 0) { ok = false; }
+    if (is_err[bool, str](allocator.deallocate[K](m.alloc, m.keys, m.cap))) { ok = false; }
+    if (is_err[bool, str](allocator.deallocate[V](m.alloc, m.values, m.cap))) { ok = false; }
+    if (is_err[bool, str](allocator.deallocate[u8](m.alloc, m.states, m.cap))) { ok = false; }
 
     m.keys       = nil;
     m.values     = nil;

--- a/src/collections/vector.mach
+++ b/src/collections/vector.mach
@@ -47,14 +47,14 @@ pub fun dnit[T](vec: *Vector[T]) bool {
         ret true;
     }
 
-    val res: i64 = allo.deallocate[T](vec.alloc, vec.data, vec.cap);
-    if (res == 0) {
+    val freed: bool = is_ok[bool, str](allo.deallocate[T](vec.alloc, vec.data, vec.cap));
+    if (freed) {
         vec.data = nil;
         vec.len = 0;
         vec.cap = 0;
     }
 
-    ret res == 0;
+    ret freed;
 }
 
 # is_empty: check if the vector is empty.

--- a/src/format.mach
+++ b/src/format.mach
@@ -4,7 +4,10 @@
 #
 # format strings fill `{}` holes from the arguments in order, each rendered by
 # its type: signed/unsigned integers (any width) in decimal, str as text, ptr as
-# 0x-hex, f64 as the shortest round-trippable decimal. bool and char share u8's
+# 0x-hex, f64 as the shortest round-trippable decimal. f32 widens to f64 (an
+# exact widening) and prints as that value, so it has no f32-specific shortest
+# round-trip — an inexact f32 shows the full f64 expansion of its widened value.
+# bool and char share u8's
 # representation, so they render as their numeric value — a bool prints 1 or 0;
 # reach for the `{:c}` spec to render an integer's low byte as a character.
 #
@@ -755,6 +758,7 @@ pub fun vformat(w: *writer.Writer, fmt: str, va: ...) Result[usize, str] {
         $if      ($type_of(arg) == str) { fr = fmt_str_field(w, (arg::usize)::str, ?sp); }
         $or ($type_of(arg) == ptr) { fr = fmt_ptr_field(w, (arg::usize)::ptr, ?sp); }
         $or ($type_of(arg) == f64) { fr = fmt_f64_field(w, arg::f64, ?sp); }
+        # f32 widens to f64 (exact) and prints as that value — no f32 shortest round-trip.
         $or ($type_of(arg) == f32) { fr = fmt_f64_field(w, arg::f64, ?sp); }
         $or ($type_of(arg) == i64) { fr = fmt_i64(w, arg::i64, ?sp); }
         $or ($type_of(arg) == i32) { fr = fmt_i64(w, arg::i64, ?sp); }
@@ -1015,5 +1019,71 @@ test "format: forwards whole pack through format wrapper" {
     s[tb.len] = 0;
     if (is_err[usize, str](r)) { ret 1; }
     if (!str_equals(?s[0], "1-2")) { ret 2; }
+    ret 0;
+}
+
+# f32 has no shortest-round-trip of its own: the f32 dispatch arm widens to f64
+# (exact) and formats that, so an f32 renders as its f64 value. an exactly
+# representable f32 is unaffected; an inexact one shows the full f64 expansion.
+test "format: f32 widens to f64" {
+    var s: [64]u8;
+    var r: Result[usize, str];
+
+    r = fmt_capture(?s[0], 64, "{}", 0.5::f32);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "0.5")) { ret 1; }
+
+    r = fmt_capture(?s[0], 64, "{}", 1.25::f32);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "1.25")) { ret 2; }
+
+    r = fmt_capture(?s[0], 64, "{}", 2.0::f32);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "2")) { ret 3; }
+
+    r = fmt_capture(?s[0], 64, "{}", (-3.5)::f32);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "-3.5")) { ret 4; }
+
+    # 0.1 is not exactly representable in f32; widening its value (bits
+    # 0x3DCCCCCD) to f64 yields the full expansion, not "0.1".
+    var x: f32;
+    var bits: u32 = 0x3DCCCCCD;
+    mem.raw_copy(?x, ?bits, 4);
+    r = fmt_capture(?s[0], 64, "{}", x);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "0.10000000149011612")) { ret 5; }
+    ret 0;
+}
+
+# every smaller integer width widens to i64/u64 and shares fmt_i64/fmt_u64; one
+# case per width class confirms the dispatch arms and the widening.
+test "format: smaller integer widths" {
+    var s: [64]u8;
+    var r: Result[usize, str];
+
+    r = fmt_capture(?s[0], 64, "{}", (-5)::i8);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "-5")) { ret 1; }
+
+    r = fmt_capture(?s[0], 64, "{}", (-300)::i16);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "-300")) { ret 2; }
+
+    r = fmt_capture(?s[0], 64, "{}", (-70000)::i32);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "-70000")) { ret 3; }
+
+    r = fmt_capture(?s[0], 64, "{}", 65535::u16);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "65535")) { ret 4; }
+
+    r = fmt_capture(?s[0], 64, "{}", 4000000000::u32);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "4000000000")) { ret 5; }
+    ret 0;
+}
+
+# signed hex renders the two's-complement bit pattern: the value casts through
+# i64 to u64, so {:x} of a negative i64 is its full 64-bit pattern.
+test "format: negative signed hex (two's complement)" {
+    var s: [64]u8;
+    var r: Result[usize, str];
+
+    r = fmt_capture(?s[0], 64, "{:x}", (-1)::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "ffffffffffffffff")) { ret 1; }
+
+    r = fmt_capture(?s[0], 64, "{:x}", (-42)::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "ffffffffffffffd6")) { ret 2; }
     ret 0;
 }

--- a/src/io/buffer.mach
+++ b/src/io/buffer.mach
@@ -59,13 +59,13 @@ pub fun wbuf_dnit(buf: *WriteBuf) bool {
         ret true;
     }
 
-    val res: i64 = allocator.deallocate[u8](buf.alloc, buf.data, buf.cap);
-    if (res == 0) {
+    val freed: bool = is_ok[bool, str](allocator.deallocate[u8](buf.alloc, buf.data, buf.cap));
+    if (freed) {
         buf.data = nil;
         buf.len = 0;
         buf.cap = 0;
     }
-    ret res == 0;
+    ret freed;
 }
 
 # wbuf_reserve: ensure capacity for additional bytes.

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -348,3 +348,21 @@ test "exec: capture reports full length on truncation" {
     if (cap_small[1] != 'e') { ret 1; }
     ret 0;
 }
+
+# fork-heavy regression (issue mach#1487): spawn now clones the child onto a
+# private stack with a shared address space (CLONE_VM|CLONE_VFORK) instead of
+# fork()ing, allocating and freeing that stack per call. exercise it across
+# many iterations to catch a leaked or corrupted child stack.
+test "exec: repeated spawns stay correct" {
+    var i: usize = 0;
+    for (i < 64) {
+        var argv: [4]usize = argv_ok();
+        val r: Result[ExitStatus, str] = run(prog_ok(), (?argv[0])::**u8, nil);
+        if (is_err[ExitStatus, str](r)) { ret 1; }
+        val s: ExitStatus = unwrap_ok[ExitStatus, str](r);
+        if (!exited(s)) { ret 1; }
+        if (code(s) != 0) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -122,10 +122,6 @@ $or ($mach.build.arch == $mach.arch.aarch64) {
     val SYS_GETCPU:        usize = 168;
     val SYS_CLOSE_RANGE:   usize = 436;
     val SYS_DUP3:          usize = 24;
-
-    # aarch64 lacks fork/vfork syscalls; both are expressed via clone.
-    val SIGCHLD:      usize = 17;
-    val CLONE_VFORK:  usize = 0x00004000;
 }
 $or {
     $error("std.system.os.linux.shared: unsupported architecture");
@@ -142,6 +138,12 @@ pub val CLONE_FILES:   usize = 0x00000400;
 pub val CLONE_SIGHAND: usize = 0x00000800;
 pub val CLONE_THREAD:  usize = 0x00010000;
 pub val CLONE_SYSVSEM: usize = 0x00040000;
+
+# clone-flag/signal values used by vfork and the spawn fast path. SIGCHLD in
+# the low byte makes the child a normal waitable process; CLONE_VFORK suspends
+# the parent until the child execs or exits. identical across linux arches.
+val CLONE_VFORK: usize = 0x00004000;
+val SIGCHLD:     usize = 17;
 
 val MREMAP_MAYMOVE: usize = 1;
 
@@ -1114,6 +1116,103 @@ fun close_inherited_fds() {
     }
 }
 
+# spawn child stack: a private, page-multiple stack handed to the clone child
+# so it never runs on the parent's stack. the child only redirects fds, closes
+# inherited fds, and execs, so a few pages are ample.
+val SPAWN_STACK_SIZE: usize = 16384;
+
+# clone flags for the spawn fast path: CLONE_VM shares the address space (no
+# COW, so the kernel never runs fork's overcommit commit-accounting and spawn
+# cannot ENOMEM on a swapless vm.overcommit_memory=0 host — issue mach#1487),
+# CLONE_VFORK suspends the parent until the child execs or exits, and SIGCHLD
+# makes the child a normal waitable process.
+val SPAWN_CLONE_FLAGS: usize = CLONE_VM | CLONE_VFORK | SIGCHLD;
+
+# child-stack bias: the trampoline is entered with sp = stack_top - bias and
+# reads its single ctx-pointer argument from that slot after the standard
+# prologue. x86_64 keeps sp ≡ 8 (mod 16) to mirror a post-call frame; aarch64
+# keeps sp 16-byte aligned.
+$if ($mach.build.arch == $mach.arch.x86_64) {
+    val SPAWN_SP_BIAS: usize = 24;
+}
+$or ($mach.build.arch == $mach.arch.aarch64) {
+    val SPAWN_SP_BIAS: usize = 16;
+}
+
+# spawn_ctx: arguments carried across the clone boundary to the trampoline.
+# lives in the parent's frame; CLONE_VFORK keeps the parent suspended (and this
+# struct alive and stable) until the child execs or exits.
+rec spawn_ctx {
+    pathname:  *u8;
+    argv:      **u8;
+    envp:      **u8;
+    stdin_fd:  i32;
+    stdout_fd: i32;
+    stderr_fd: i32;
+}
+
+# spawn_trampoline: child-side entry, reached by a direct jump/branch from the
+# child half of clone (see spawn_redirected) so it runs on the private child
+# stack and never touches the parent's frame. at entry sp points at the
+# ctx-pointer slot; after the standard prologue it sits at [rbp+8] (x86_64) /
+# [x29+16] (aarch64), matching thread_trampoline. the child only redirects fds,
+# closes inherited fds, and execs — all stack-safe under CLONE_VM — and never
+# returns: a successful exec replaces the image, any failure exits the child
+# (126 on a failed redirect, 127 on a failed exec).
+`symbol("_std_spawn_trampoline")`
+fun spawn_trampoline() {
+    var ctx_addr: usize = 0;
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, [rbp+8]
+            mov {ctx_addr}, rax
+        }
+    }
+    $or ($mach.build.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            ldr x0, [x29, 16]
+            str x0, {ctx_addr}
+        }
+    }
+    val ctx: *spawn_ctx = ctx_addr::*spawn_ctx;
+
+    # aarch64 has no dup2 syscall; dup3 with flags 0 is equivalent (it differs
+    # only in rejecting oldfd == newfd, which redirect fds never are).
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        if (ctx.stdin_fd != -1 && syscall2(SYS_DUP2, ctx.stdin_fd::isize::usize, STDIN_FD::isize::usize) < 0) {
+            syscall1(SYS_EXIT_GROUP, 126);
+        }
+        if (ctx.stdout_fd != -1 && syscall2(SYS_DUP2, ctx.stdout_fd::isize::usize, STDOUT_FD::isize::usize) < 0) {
+            syscall1(SYS_EXIT_GROUP, 126);
+        }
+        if (ctx.stderr_fd != -1 && syscall2(SYS_DUP2, ctx.stderr_fd::isize::usize, STDERR_FD::isize::usize) < 0) {
+            syscall1(SYS_EXIT_GROUP, 126);
+        }
+    }
+    $or ($mach.build.arch == $mach.arch.aarch64) {
+        if (ctx.stdin_fd != -1 && syscall3(SYS_DUP3, ctx.stdin_fd::isize::usize, STDIN_FD::isize::usize, 0) < 0) {
+            syscall1(SYS_EXIT_GROUP, 126);
+        }
+        if (ctx.stdout_fd != -1 && syscall3(SYS_DUP3, ctx.stdout_fd::isize::usize, STDOUT_FD::isize::usize, 0) < 0) {
+            syscall1(SYS_EXIT_GROUP, 126);
+        }
+        if (ctx.stderr_fd != -1 && syscall3(SYS_DUP3, ctx.stderr_fd::isize::usize, STDERR_FD::isize::usize, 0) < 0) {
+            syscall1(SYS_EXIT_GROUP, 126);
+        }
+    }
+    close_inherited_fds();
+    exec(ctx.pathname, ctx.argv, ctx.envp);
+    syscall1(SYS_EXIT_GROUP, 127);
+    # exec replaces the image and exit_group never returns; trap loudly rather
+    # than ret into a garbage frame on the child stack if the child falls through.
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        asm x86_64 { hlt }
+    }
+    $or ($mach.build.arch == $mach.arch.aarch64) {
+        asm aarch64 { brk 0 }
+    }
+}
+
 # spawn: create a child process running the given program.
 #
 # closes inherited file descriptors >= 3 in the child before exec to
@@ -1145,40 +1244,69 @@ pub fun spawn(pathname: *u8, argv: **u8, envp: **u8) i64 {
 # stderr_fd: descriptor to install as the child's stderr, or -1 to inherit
 # ret:       child PID on success, or negative errno
 pub fun spawn_redirected(pathname: *u8, argv: **u8, envp: **u8, stdin_fd: i32, stdout_fd: i32, stderr_fd: i32) i64 {
-    val pid: i64 = fork();
-    if (pid < 0) {
-        ret pid;
+    var ctx: spawn_ctx;
+    ctx.pathname  = pathname;
+    ctx.argv      = argv;
+    ctx.envp      = envp;
+    ctx.stdin_fd  = stdin_fd;
+    ctx.stdout_fd = stdout_fd;
+    ctx.stderr_fd = stderr_fd;
+
+    # a private child stack keeps the child off the parent's stack; CLONE_VM
+    # then shares the address space (no COW) so spawn never trips the fork
+    # overcommit-accounting ENOMEM, and CLONE_VFORK suspends the parent until
+    # the child execs or exits (issue mach#1487).
+    val stack_base: ptr = allocate(SPAWN_STACK_SIZE);
+    if (stack_base == nil) {
+        ret ENOMEM;
     }
-    if (pid == 0) {
-        # aarch64 has no dup2 syscall; dup3 with flags 0 is equivalent (it
-        # differs only in rejecting oldfd == newfd, which redirect fds never are).
-        $if ($mach.build.arch == $mach.arch.x86_64) {
-            if (stdin_fd != -1 && syscall2(SYS_DUP2, stdin_fd::isize::usize, STDIN_FD::isize::usize) < 0) {
-                syscall1(SYS_EXIT_GROUP, 126);
-            }
-            if (stdout_fd != -1 && syscall2(SYS_DUP2, stdout_fd::isize::usize, STDOUT_FD::isize::usize) < 0) {
-                syscall1(SYS_EXIT_GROUP, 126);
-            }
-            if (stderr_fd != -1 && syscall2(SYS_DUP2, stderr_fd::isize::usize, STDERR_FD::isize::usize) < 0) {
-                syscall1(SYS_EXIT_GROUP, 126);
-            }
+    val stack_top: usize = stack_base::usize + SPAWN_STACK_SIZE;
+    val child_sp:  usize = stack_top - SPAWN_SP_BIAS;
+    @(child_sp::*usize) = (?ctx)::usize;
+
+    var flags:     usize = SPAWN_CLONE_FLAGS;
+    var stack_ptr: usize = child_sp;
+    var result:    i64 = 0;
+
+    # parent/child discrimination stays in registers: the child returns from
+    # clone with sp = child_sp and branches straight to the trampoline (never
+    # returning here); the parent (pid != 0) falls through and stores the pid.
+    # CLONE_VFORK runs the child to exec/exit before the parent resumes, so the
+    # child is gone by the time result and the stack free below execute.
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        asm x86_64 { mfence }
+        asm x86_64 {
+            mov rdi, {flags}
+            mov rsi, {stack_ptr}
+            xor rdx, rdx
+            xor r10, r10
+            xor r8, r8
+            mov rax, 56           # SYS_clone
+            syscall
+            test rax, rax
+            jz _std_spawn_trampoline
+            mov {result}, rax     # parent: pid, or negative errno on failure
         }
-        $or ($mach.build.arch == $mach.arch.aarch64) {
-            if (stdin_fd != -1 && syscall3(SYS_DUP3, stdin_fd::isize::usize, STDIN_FD::isize::usize, 0) < 0) {
-                syscall1(SYS_EXIT_GROUP, 126);
-            }
-            if (stdout_fd != -1 && syscall3(SYS_DUP3, stdout_fd::isize::usize, STDOUT_FD::isize::usize, 0) < 0) {
-                syscall1(SYS_EXIT_GROUP, 126);
-            }
-            if (stderr_fd != -1 && syscall3(SYS_DUP3, stderr_fd::isize::usize, STDERR_FD::isize::usize, 0) < 0) {
-                syscall1(SYS_EXIT_GROUP, 126);
-            }
-        }
-        close_inherited_fds();
-        exec(pathname, argv, envp);
-        syscall1(SYS_EXIT_GROUP, 127);
     }
-    ret pid;
+    $or ($mach.build.arch == $mach.arch.aarch64) {
+        asm aarch64 { dmb ish }
+        asm aarch64 {
+            ldr x0, {flags}
+            ldr x1, {stack_ptr}
+            mov x2, 0
+            mov x3, 0
+            mov x4, 0
+            mov x8, 220           # SYS_clone
+            svc 0
+            cbnz x0, 1f           # parent (pid != 0): skip the child dispatch
+            b _std_spawn_trampoline    # child (x0 == 0): branch to trampoline (no return)
+        1:
+            str x0, {result}      # parent: pid, or negative errno on failure
+        }
+    }
+
+    deallocate(stack_base, SPAWN_STACK_SIZE);
+    ret result;
 }
 
 # getpid: return the current process ID.


### PR DESCRIPTION
Release integration merge of `dev` into `main` for **mach-std 0.13.0**.

- mach#1487 — robust clone-based process spawn (linux), verified x86_64 + aarch64.
- #291 — generic `deallocate[T]` returns `Result[bool, str]`.
- #293 — format f32 documentation + coverage tests.

Tagged `v0.13.0` after merge. `#285` ($fields derive) deferred — blocked by a mach 2.0.1 `$fields`-on-generic-param limitation.