### PR TITLE
release: mach-std v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.0] - 2026-06-19
+
+Migrate all decorator syntax from backtick form to `#[attr]`. Built with mach 2.3.0.
+
+### Changed
+
+- all: migrate decorators to `#[attr]` syntax (`symbol`, `library`) across runtime
+  entrypoints and system OS bindings.
+
 ## [0.13.0] - 2026-06-19
 
 Process spawning no longer copies the parent's address space, so `mach test`

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "std"
 name    = "Mach Standard Library"
-version = "0.13.0"
+version = "0.14.0"
 src     = "src"
 dep     = "dep"
 target  = "native"

--- a/src/runtime.mach
+++ b/src/runtime.mach
@@ -5,7 +5,7 @@
 #
 #   use std.runtime;
 #
-#   `symbol("main")`
+#   #[symbol("main")]
 #   fun main(argc: i64, argv: **u8) i64 {
 #       ret 0;
 #   }

--- a/src/runtime/darwin/aarch64.mach
+++ b/src/runtime/darwin/aarch64.mach
@@ -15,7 +15,7 @@
 #   4. exits via sys_exit with the return code from main
 #
 # user code must define:
-#   `symbol("main")`
+#   #[symbol("main")]
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 
 $if ($mach.build.os != $mach.os.darwin) {
@@ -32,12 +32,12 @@ var _rt_argc: i64 = 0;
 var _rt_argv: u64 = 0;
 var _rt_envp: u64 = 0;
 
-`symbol("_rt_init")`
+#[symbol("_rt_init")]
 fun _rt_init() {
     os._envp = _rt_envp;
 }
 
-`symbol("start")`
+#[symbol("start")]
 pub fun _start() {
     asm aarch64 {
         ldr x0, [sp]      # argc -> x0 (1st argument)

--- a/src/runtime/darwin/x86_64.mach
+++ b/src/runtime/darwin/x86_64.mach
@@ -15,7 +15,7 @@
 #   4. exits via sys_exit with the return code from main
 #
 # user code must define:
-#   `symbol("main")`
+#   #[symbol("main")]
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 
 $if ($mach.build.os != $mach.os.darwin) {
@@ -32,12 +32,12 @@ var _rt_argc: i64 = 0;
 var _rt_argv: u64 = 0;
 var _rt_envp: u64 = 0;
 
-`symbol("_rt_init")`
+#[symbol("_rt_init")]
 fun _rt_init() {
     os._envp = _rt_envp;
 }
 
-`symbol("start")`
+#[symbol("start")]
 pub fun _start() {
     asm x86_64 {
         mov rax, rsp      # rax = initial stack pointer

--- a/src/runtime/linux/aarch64.mach
+++ b/src/runtime/linux/aarch64.mach
@@ -19,7 +19,7 @@
 #      threads; SYS_exit would leave non-main threads alive)
 #
 # user code must define:
-#   `symbol("main")`
+#   #[symbol("main")]
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 #
 # VERIFICATION STATUS — written ahead of the mach aarch64 backend; two
@@ -37,19 +37,19 @@
 
 use os: std.system.os.linux.aarch64;
 
-`symbol("_rt_argc")`
+#[symbol("_rt_argc")]
 var _rt_argc: i64 = 0;
-`symbol("_rt_argv")`
+#[symbol("_rt_argv")]
 var _rt_argv: u64 = 0;
-`symbol("_rt_envp")`
+#[symbol("_rt_envp")]
 var _rt_envp: u64 = 0;
 
-`symbol("_rt_init")`
+#[symbol("_rt_init")]
 fun _rt_init() {
     os._envp = _rt_envp;
 }
 
-`symbol("_start")`
+#[symbol("_start")]
 pub fun _start() {
     asm aarch64 {
         mov x9, sp            # x9 = initial stack pointer (argc at [x9])

--- a/src/runtime/linux/x86_64.mach
+++ b/src/runtime/linux/x86_64.mach
@@ -20,24 +20,24 @@
 #      alive, hanging the process after main returns)
 #
 # user code must define:
-#   `symbol("main")`
+#   #[symbol("main")]
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 
 use os: std.system.os.linux.x86_64;
 
-`symbol("_rt_argc")`
+#[symbol("_rt_argc")]
 var _rt_argc: i64 = 0;
-`symbol("_rt_argv")`
+#[symbol("_rt_argv")]
 var _rt_argv: u64 = 0;
-`symbol("_rt_envp")`
+#[symbol("_rt_envp")]
 var _rt_envp: u64 = 0;
 
-`symbol("_rt_init")`
+#[symbol("_rt_init")]
 fun _rt_init() {
     os._envp = _rt_envp;
 }
 
-`symbol("_start")`
+#[symbol("_start")]
 pub fun _start() {
     asm x86_64 {
         mov rax, rsp      # rax = initial stack pointer

--- a/src/runtime/windows/x86_64.mach
+++ b/src/runtime/windows/x86_64.mach
@@ -10,7 +10,7 @@
 #   4. exits via ExitProcess with the return code from main
 #
 # user code must define:
-#   `symbol("main")`
+#   #[symbol("main")]
 #   fun main(argc: i64, argv: **u8) i64 { ... }
 
 use std.types.size.usize;
@@ -32,16 +32,16 @@ val MAX_ARGS: usize = 256;
 val MAX_CMDLINE: usize = 32768;
 
 # the entrypoint references these by literal name from inline asm (`[argc]`,
-# `[argv_ptrs]`, `call parse_cmdline`), so each carries a `symbol` decorator to
+# `[argv_ptrs]`, `call parse_cmdline`), so each carries a `#[symbol]` decorator to
 # keep its link name verbatim rather than mangled — mirroring the linux runtime's
 # `_rt_*` symbols.
 var cmdline_buf: [32768]u8;
-`symbol("argv_ptrs")`
+#[symbol("argv_ptrs")]
 var argv_ptrs: [256]usize;
-`symbol("argc")`
+#[symbol("argc")]
 var argc: i64 = 0;
 
-`symbol("mainCRTStartup")`
+#[symbol("mainCRTStartup")]
 pub fun _start() {
     asm x86_64 {
         and rsp, -16      # align stack to 16 bytes
@@ -66,7 +66,7 @@ pub fun _start() {
 # copies the command line into cmdline_buf, splits on whitespace,
 # handles double-quote grouping (quotes are stripped from the result).
 # populates argv_ptrs and argc.
-`symbol("parse_cmdline")`
+#[symbol("parse_cmdline")]
 fun parse_cmdline(cmdline: *u8) {
     if (cmdline == nil) {
         argc = 0;

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -46,7 +46,7 @@ val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAN
 # prologue (stp x29,x30,[sp,#-16]!; mov x29,sp) then places the four args at
 # [x29+16..x29+40]. NOTE: this offset assumes that frame-record convention and
 # must be confirmed against the mach aarch64 prologue under qemu.
-`symbol("_std_thread_trampoline")`
+#[symbol("_std_thread_trampoline")]
 fun thread_trampoline() {
     var fn_addr: usize = 0;
     var done_addr: usize = 0;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -1159,7 +1159,7 @@ rec spawn_ctx {
 # closes inherited fds, and execs — all stack-safe under CLONE_VM — and never
 # returns: a successful exec replaces the image, any failure exits the child
 # (126 on a failed redirect, 127 on a failed exec).
-`symbol("_std_spawn_trampoline")`
+#[symbol("_std_spawn_trampoline")]
 fun spawn_trampoline() {
     var ctx_addr: usize = 0;
     $if ($mach.build.arch == $mach.arch.x86_64) {

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -39,7 +39,7 @@ val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAN
 # the symbol is pinned so the inline-asm branch can target it. at entry rsp
 # points at the argument block on the child stack, so after the prologue the
 # args sit at [rbp+8..rbp+32] exactly as if the trampoline had been called.
-`symbol("_std_thread_trampoline")`
+#[symbol("_std_thread_trampoline")]
 fun thread_trampoline() {
     var fn_addr: usize = 0;
     var done_addr: usize = 0;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -3,7 +3,7 @@
 # windows has no stable syscall interface. all OS interaction goes through
 # kernel32.dll and ntdll.dll via ext fun declarations, plus ws2_32.dll for
 # sockets, advapi32.dll for RtlGenRandom, and api-ms-win-core-synch-l1-2-0.dll
-# for the wait-on-address family; these are pinned with a `library` decorator so
+# for the wait-on-address family; these are pinned with a `#[library]` decorator so
 # the PE import directory attributes them to the right DLL rather than the first
 # dependency. a HANDLE-to-fd mapping table bridges the POSIX-style fd interface
 # used by os.mach.
@@ -224,49 +224,49 @@ ext fun CreateThread(p0: ptr, p1: usize, p2: usize, p3: ptr, p4: u32, p5: *u32) 
 
 # WaitOnAddress / WakeByAddressSingle live in the synch apiset DLL, not kernel32.
 # real windows' kernel32 does not export them (only wine's does), so without
-# the `library` decorator the import binds to kernel32 and the native loader
+# the `#[library]` decorator the import binds to kernel32 and the native loader
 # rejects the exe with STATUS_ENTRYPOINT_NOT_FOUND. pin them to the canonical
 # apiset DLL. see issue #253.
-`library("api-ms-win-core-synch-l1-2-0.dll")`
+#[library("api-ms-win-core-synch-l1-2-0.dll")]
 ext fun WaitOnAddress(p0: ptr, p1: ptr, p2: usize, p3: u32) i32;
-`library("api-ms-win-core-synch-l1-2-0.dll")`
+#[library("api-ms-win-core-synch-l1-2-0.dll")]
 ext fun WakeByAddressSingle(p0: ptr);
 
 # Winsock2 API imports (ws2_32.dll). each is pinned to ws2_32.dll with a
-# `library` decorator; without it an `ext` import binds to the first dependency
+# `#[library]` decorator; without it an `ext` import binds to the first dependency
 # (kernel32.dll) and aborts at call time on a real loader.
 
-`library("ws2_32.dll")`
+#[library("ws2_32.dll")]
 ext fun WSAStartup(p0: u16, p1: *u8) i32;
-`library("ws2_32.dll")`
+#[library("ws2_32.dll")]
 ext fun WSAGetLastError() i32;
-`library("ws2_32.dll")` `symbol("socket")`
+#[library("ws2_32.dll")] #[symbol("socket")]
 ext fun ws2_socket(p0: i32, p1: i32, p2: i32) usize;
-`library("ws2_32.dll")` `symbol("bind")`
+#[library("ws2_32.dll")] #[symbol("bind")]
 ext fun ws2_bind(p0: usize, p1: *u8, p2: i32) i32;
-`library("ws2_32.dll")` `symbol("listen")`
+#[library("ws2_32.dll")] #[symbol("listen")]
 ext fun ws2_listen(p0: usize, p1: i32) i32;
-`library("ws2_32.dll")` `symbol("accept")`
+#[library("ws2_32.dll")] #[symbol("accept")]
 ext fun ws2_accept(p0: usize, p1: *u8, p2: *i32) usize;
-`library("ws2_32.dll")` `symbol("connect")`
+#[library("ws2_32.dll")] #[symbol("connect")]
 ext fun ws2_connect(p0: usize, p1: *u8, p2: i32) i32;
-`library("ws2_32.dll")` `symbol("sendto")`
+#[library("ws2_32.dll")] #[symbol("sendto")]
 ext fun ws2_sendto(p0: usize, p1: *u8, p2: i32, p3: i32, p4: *u8, p5: i32) i32;
-`library("ws2_32.dll")` `symbol("recvfrom")`
+#[library("ws2_32.dll")] #[symbol("recvfrom")]
 ext fun ws2_recvfrom(p0: usize, p1: *u8, p2: i32, p3: i32, p4: *u8, p5: *i32) i32;
-`library("ws2_32.dll")` `symbol("shutdown")`
+#[library("ws2_32.dll")] #[symbol("shutdown")]
 ext fun ws2_shutdown(p0: usize, p1: i32) i32;
-`library("ws2_32.dll")` `symbol("setsockopt")`
+#[library("ws2_32.dll")] #[symbol("setsockopt")]
 ext fun ws2_setsockopt(p0: usize, p1: i32, p2: i32, p3: *u8, p4: i32) i32;
-`library("ws2_32.dll")` `symbol("send")`
+#[library("ws2_32.dll")] #[symbol("send")]
 ext fun ws2_send(p0: usize, p1: *u8, p2: i32, p3: i32) i32;
-`library("ws2_32.dll")` `symbol("recv")`
+#[library("ws2_32.dll")] #[symbol("recv")]
 ext fun ws2_recv(p0: usize, p1: *u8, p2: i32, p3: i32) i32;
-`library("ws2_32.dll")`
+#[library("ws2_32.dll")]
 ext fun closesocket(p0: usize) i32;
 
 # advapi32.dll
-`library("advapi32.dll")`
+#[library("advapi32.dll")]
 ext fun SystemFunction036(p0: *u8, p1: u32) i32;
 
 ext fun GetCurrentProcessId() u32;


### PR DESCRIPTION
## Summary

- Migrate all 38 backtick decorator sites to `#[attr]` syntax (surface-syntax only, no behavior changes).
- Requires mach >= 2.3.0 (which parses both forms).
- 563 tests pass under mach v2.3.0.

## Changes

- `src/runtime.mach`, `src/runtime/darwin/{aarch64,x86_64}.mach`, `src/runtime/linux/{aarch64,x86_64}.mach`, `src/runtime/windows/x86_64.mach`, `src/system/os/linux/{aarch64,x86_64,shared}.mach`, `src/system/os/windows/shared.mach`

## Test plan

- [x] `mach build .` green under mach v2.3.0
- [x] `mach test .` — 563 passed, 0 failed
- [x] Zero remaining backtick decorator sites in `src/`