### PR TITLE
perf(string): bound str_region_equals scan to the compared region

### DIFF
--- a/src/types/string.mach
+++ b/src/types/string.mach
@@ -206,12 +206,11 @@ pub fun str_region_equals(s: str, start: usize, len: usize, other: str) bool {
     val other_len: usize = str_len(other);
     if (other_len != len) { ret false; }
 
-    val s_len: usize = str_len(s);
-    if (start + len > s_len) { ret false; }
-
     var i: usize = 0;
     for (i < len) {
-        if (s[start + i] != other[i]) { ret false; }
+        val c: char = s[start + i];
+        if (c == 0) { ret false; }
+        if (c != other[i]) { ret false; }
         i = i + 1;
     }
     ret true;


### PR DESCRIPTION
Drops the whole-source `str_len(s)` bounds check in `str_region_equals`, which made the function O(file size). Since the parser calls it per keyword probe per token via `at_kw`, that strlen turned parsing quadratic. The loop now scans only the compared region and returns false on a NUL terminator, preserving out-of-bounds safety for valid start offsets while restoring linear-time comparison.

`mach test .`: 563 passed, 0 failed.

Closes #301