### PR TITLE
doc(os/linux): fix page_size doclint warning

### DIFF
--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -27,7 +27,7 @@ $if ($mach.build.arch != $mach.arch.aarch64) {
 }
 
 # page_size: return the system page size.
-# ---
+#
 # NOTE: aarch64 linux supports 4 KiB, 16 KiB, and 64 KiB pages depending on
 # kernel configuration; 4096 is the common default and what qemu-user presents.
 # the robust fix is to query AT_PAGESZ from the auxiliary vector at startup;

--- a/src/system/os/linux/riscv64.mach
+++ b/src/system/os/linux/riscv64.mach
@@ -27,7 +27,7 @@ $if ($mach.build.arch != $mach.arch.riscv64) {
 }
 
 # page_size: return the system page size.
-# ---
+#
 # NOTE: riscv64 linux uses 4 KiB base pages (Sv39/Sv48/Sv57 all share the 4 KiB
 # leaf), which is what qemu-user presents. the robust fix is to query AT_PAGESZ
 # from the auxiliary vector at startup; tracked for follow-up once the runtime


### PR DESCRIPTION
Closes #310

The `page_size` docstrings in `src/system/os/linux/riscv64.mach` and `src/system/os/linux/aarch64.mach` put a `NOTE:` block between two `# ---` separators, so the doclint parsed `NOTE` as a documented component and logged `documented component matches no parameter, field, generic, or ret` whenever those modules compiled (surfaced by the cross-riscv64 lane). Moved the NOTE into the summary block (above the `---`) so the doc-item section holds only `ret`. Pure comment change.

## Verification
- riscv64: building the runtime consumer (compiles os.linux.riscv64) no longer logs the warning; the qemu smoke test still exits 42.
- aarch64: building an aarch64 consumer (compiles os.linux.aarch64) no longer logs the warning.
- x86_64: `mach test .` -> 563/563.