### PR TITLE
chore: repoint relocated repos to the briar-systems org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p /tmp/machdl
-          gh release download --repo octalide/mach \
+          gh release download --repo briar-systems/mach \
             --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
           tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
           cp /tmp/machdl/mach /usr/local/bin/mach

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p /tmp/machdl
-          gh release download --repo octalide/mach \
+          gh release download --repo briar-systems/mach \
             --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
           tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
           cp /tmp/machdl/mach /usr/local/bin/mach

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ from the constant seed directly. Built with mach 2.5.9.
 
 - crypto/hash: `fnv1a` exposes `pub val FNV_INIT` (and `pub` `FNV_OFFSET` /
   `FNV_PRIME`) instead of `pub fun init()`. Callers fold from the constant seed
-  rather than a function that returned it (#1600 on octalide/mach).
+  rather than a function that returned it (#1600 on briar-systems/mach).
 
 ### Removed
 
@@ -153,7 +153,7 @@ shell-outs (cross-platform, including native windows).
 Native-windows temp-file support: the temp directory is resolved per-OS at
 use time (GetTempPathA on windows, $TMPDIR with /tmp fallback on posix). With v0.8.0's
 loader fixes this completes the std side of the compiler's native windows
-CI lane (octalide/mach#1351); the exec-fixture half of #258 was already
+CI lane (briar-systems/mach#1351); the exec-fixture half of #258 was already
 fixed in v0.7.0's OS-gated tests and ships via the pin bump.
 
 ### Added
@@ -382,11 +382,11 @@ These tests fail or hang under `mach test` and are tracked for follow-up. All
 three are gaps in modules added during the 0.4.x rework (after 0.2.5), not
 regressions:
 - `thread: spawn and join` / `thread: is_done after join` deadlock — the clone
-  parent/child discrimination is a shared-memory race ([#195](https://github.com/octalide/mach-std/issues/195)).
+  parent/child discrimination is a shared-memory race ([#195](https://github.com/briar-systems/mach-std/issues/195)).
 - `json: value_find on object` never matches — object keys are stored as
-  non-null-terminated source slices but compared with `str_equals` ([#196](https://github.com/octalide/mach-std/issues/196)).
+  non-null-terminated source slices but compared with `str_equals` ([#196](https://github.com/briar-systems/mach-std/issues/196)).
 - `env: get PATH returns positive length` — the std code is correct; `mach test`
-  execs the test binary with an empty environment ([#197](https://github.com/octalide/mach-std/issues/197)).
+  execs the test binary with an empty environment ([#197](https://github.com/briar-systems/mach-std/issues/197)).
 
 ## [0.4.0] - 2026-03-10
 

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ To use the standard library in your Mach project, you can include it as a depend
 
 ```toml
 [deps.mach-std]
-git = "https://github.com/octalide/mach-std"
+git = "https://github.com/briar-systems/mach-std"
 ref = "branch/main"
 ```
 
 You can also use the Mach dependency manager to add it to your project:
 
 ```bash
-mach dep add mach-std --git https://github.com/octalide/mach-std --ref branch/main
+mach dep add mach-std --git https://github.com/briar-systems/mach-std --ref branch/main
 ```
 
 ## Documentation

--- a/src/runtime/linux/aarch64.mach
+++ b/src/runtime/linux/aarch64.mach
@@ -24,7 +24,7 @@
 #
 # VERIFICATION STATUS — written ahead of the mach aarch64 backend; two
 # assumptions cannot be checked until the backend + qemu are available and
-# MUST be confirmed there (tracked with #270 / octalide/mach#1431):
+# MUST be confirmed there (tracked with #270 / briar-systems/mach#1431):
 #   (a) Entry frame: like x86_64 `_start`, the first asm instruction reads the
 #       raw kernel-supplied sp (argc at [sp]). This relies on mach not emitting
 #       a frame-setup prologue that moves sp before the asm block for the entry


### PR DESCRIPTION
Repoints references to the 7 relocated repos (mach, mach-std, mach-boot, mach-lsp, mach-site, mach-vscode, mach-zed) from the octalide org to briar-systems. Only `octalide/mach` and `octalide/mach-std` references were present; all replaced. Ref-only diff, no stay-behind repos touched.

Companion of the hotfix PR into main (#312).