### PR TITLE
fix(runtime/darwin): export _rt_argc/_rt_argv/_rt_envp symbols

### DIFF
--- a/src/runtime/darwin/aarch64.mach
+++ b/src/runtime/darwin/aarch64.mach
@@ -28,8 +28,11 @@ $if ($mach.build.arch != $mach.arch.aarch64) {
 
 use os: std.system.os.darwin.aarch64;
 
+#[symbol("_rt_argc")]
 var _rt_argc: i64 = 0;
+#[symbol("_rt_argv")]
 var _rt_argv: u64 = 0;
+#[symbol("_rt_envp")]
 var _rt_envp: u64 = 0;
 
 #[symbol("_rt_init")]

--- a/src/runtime/darwin/x86_64.mach
+++ b/src/runtime/darwin/x86_64.mach
@@ -28,8 +28,11 @@ $if ($mach.build.arch != $mach.arch.x86_64) {
 
 use os: std.system.os.darwin.x86_64;
 
+#[symbol("_rt_argc")]
 var _rt_argc: i64 = 0;
+#[symbol("_rt_argv")]
 var _rt_argv: u64 = 0;
+#[symbol("_rt_envp")]
 var _rt_envp: u64 = 0;
 
 #[symbol("_rt_init")]


### PR DESCRIPTION
Adds the `#[symbol(...)]` annotations to the darwin runtime startup globals on both arches, mirroring `src/runtime/linux/x86_64.mach`.

Without the exports, the `start` inline-asm that stores into `_rt_argc` / `_rt_argv` / `_rt_envp` cannot resolve the symbols and the darwin link fails with `undefined symbol: _rt_argc`, blocking any mach-built darwin program.

- `src/runtime/darwin/x86_64.mach`
- `src/runtime/darwin/aarch64.mach`

Parity fix only; no behavioral change on linux. Darwin link advances past this error once applied (per issue verification).

Closes #314

🤖 Generated with [Claude Code](https://claude.com/claude-code)