### PR TITLE
release: v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.0] - 2026-06-28
+
+Add a riscv64-linux target — runtime entry, syscall layer, and atomics — with a
+qemu-backed CI lane, and fix the darwin entry so the darwin cross-build links and
+encodes. Built with mach 2.9.0.
+
+### Added
+
+- runtime: riscv64-linux `_start` entry plus the linux syscall stubs and os
+  module for riscv64 (#306).
+- sync/atomic: riscv64 atomic arms built on the A extension (`.aqrl` AMOs,
+  `lr.d`/`sc.d`, and FENCE barriers) (#308).
+- ci: a cross-riscv64 qemu lane that exercises the riscv64-linux runtime end to
+  end.
+
+### Fixed
+
+- runtime/darwin: export `_rt_argc` / `_rt_argv` / `_rt_envp` with `#[symbol]` so
+  the darwin entry links instead of failing with `undefined symbol: _rt_argc`
+  (#314).
+- os/darwin: load the aarch64 syscall number and arguments with `ldr` instead of
+  `mov`, which rejected the slot-bound operands at encode time (#315).
+- doc: rework the linux `page_size` docstring so it no longer trips the doclint
+  'documented component' warning (#310).
+
 ## [0.15.0] - 2026-06-25
 
 Expose the FNV-1a seed as a `pub val FNV_INIT` constant and publish the offset

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "std"
 name    = "Mach Standard Library"
-version = "0.15.0"
+version = "0.16.0"
 src     = "src"
 dep     = "dep"
 target  = "native"


### PR DESCRIPTION
Cuts **v0.16.0**, versioning the unreleased work that has accumulated on `dev` since v0.15.0 so it can sweep to `main`.

Bumps `mach.toml` to `0.16.0` and adds the CHANGELOG entry. Minor bump: introduces a new riscv64-linux target (additive), plus darwin and doc fixes — no breaking changes.

Covers:
- riscv64-linux runtime + syscall layer (#306) and atomics (#308), with a cross-riscv64 qemu CI lane
- darwin runtime symbol exports (#314) and aarch64 syscall encode fix (#315)
- linux `page_size` doclint fix (#310)

This is the release-prep commit; once on `dev` it becomes the tip for the `dev`→`main` sweep, matching the repo's release pattern (release commit lands on `dev`, then `dev`→`main`, then tag `v0.16.0`).

Note: "Built with mach 2.9.0" reflects the latest mach release that mach-std CI validates against (linux + cross-riscv64). The darwin cross-build's end-to-end proof is on the mach side against mach `dev` (carrying #1682) — adjust the version line if you'd rather pin that.