### PR TITLE
fix(runtime/darwin): rewrite aarch64 _start in mach's inline-asm dialect

### DIFF
--- a/src/runtime/darwin/aarch64.mach
+++ b/src/runtime/darwin/aarch64.mach
@@ -10,9 +10,9 @@
 #
 # this entrypoint:
 #   1. extracts argc and argv from the initial stack
-#   2. aligns the stack to 16 bytes (required by AAPCS64 before BL)
-#   3. calls user-supplied `main(argc, argv)`
-#   4. exits via sys_exit with the return code from main
+#   2. captures argc/argv/envp for the runtime, then calls `main(argc, argv)`
+#      (sp is already 16-byte aligned on kernel entry, an arm64 invariant)
+#   3. exits via sys_exit with the return code from main
 #
 # user code must define:
 #   #[symbol("main")]
@@ -43,30 +43,33 @@ fun _rt_init() {
 #[symbol("start")]
 pub fun _start() {
     asm aarch64 {
-        ldr x0, [sp]      # argc -> x0 (1st argument)
-        add x1, sp, #8    # argv -> x1 (2nd argument)
+        mov x9, sp            # x9 = initial stack pointer (argc at [x9])
+        ldr x0, [x9]          # argc -> x0 (1st argument to main)
+        add x1, x9, 8         # argv -> x1 (2nd argument to main)
 
         # envp = argv + (argc + 1) * 8
-        add x2, x0, #1
-        add x2, x1, x2, lsl #3
+        add x10, x0, 1
+        lsl x10, x10, 3
+        add x10, x1, x10      # x10 = envp
 
-        adrp x3, _rt_argc
-        str x0, [x3, :lo12:_rt_argc]
-        adrp x3, _rt_argv
-        str x1, [x3, :lo12:_rt_argv]
-        adrp x3, _rt_envp
-        str x2, [x3, :lo12:_rt_envp]
+        adrp x11, _rt_argc
+        str x0, [x11, :lo12:_rt_argc]
+        adrp x11, _rt_argv
+        str x1, [x11, :lo12:_rt_argv]
+        adrp x11, _rt_envp
+        str x10, [x11, :lo12:_rt_envp]
 
-        and sp, sp, #-16  # align stack to 16 bytes
+        # sp is 16-byte aligned on kernel entry (an arm64 architectural
+        # invariant), so no realignment is needed before the calls.
         bl _rt_init
 
-        adrp x3, _rt_argc
-        ldr x0, [x3, :lo12:_rt_argc]
-        adrp x3, _rt_argv
-        ldr x1, [x3, :lo12:_rt_argv]
+        adrp x11, _rt_argc
+        ldr x0, [x11, :lo12:_rt_argc]
+        adrp x11, _rt_argv
+        ldr x1, [x11, :lo12:_rt_argv]
         bl main
 
-        mov x16, #1       # SYS_exit
-        svc #0x80
+        mov x16, 1           # SYS_exit
+        svc 0x80
     }
 }


### PR DESCRIPTION
Closes #320.

The aarch64 darwin `_start` was written in standard ARM assembler syntax that
mach's inline-asm dialect rejects, so `mach build . --target darwin-aarch64` could
not link the runtime. Rewrites it in the dialect every other (working) runtime uses,
with **zero behavior change**.

## Offending forms → fix

- `#`-prefixed immediates (`add x1, sp, #8`, `mov x16, #1`, `svc #0x80`, ...) — `#`
  is mach's inline-asm comment character (stripped at lower time), so these became
  malformed operands. → **bare immediates** (as the x86_64 `_start` already uses).
- 4-operand shifted-register add `add x2, x1, x2, lsl #3` — unsupported. → explicit
  `lsl` then 3-operand `add`.
- bitmask-immediate `and sp, sp, #-16` — unsupported (and the register form can't
  target SP). → **dropped**: sp is 16-byte aligned on arm64 kernel entry (an
  architectural invariant the CI-tested linux aarch64 `_start` already relies on).

Mirrors the instruction-form style of the tested `src/runtime/linux/aarch64.mach`
`_start` while preserving the darwin semantics: entry symbol `start`, the
`_rt_argc`/`_rt_argv`/`_rt_envp` capture, `_rt_init` → `main`, and the darwin
`svc 0x80` exit. The file header doc is updated to match.

## Validation

Built end-to-end with a mach compiler whose lock points at this commit:
`mach build . --target darwin-aarch64 --profile release` links cleanly (no `cset` /
`undefined symbol` / `malformed` errors) to a valid **arm64** Mach-O executable —
`MH_NOUNDEFS`, full segment set (`__PAGEZERO`/`__TEXT`/`__DATA`/`__DATA_CONST`/
`__LINKEDIT`), `LC_UNIXTHREAD` entry, and an ad-hoc `LC_CODE_SIGNATURE` — verified
with llvm-otool. (Execution on macOS is gated on mach #1680's runners.)

Pairs with mach #1714 (the mach-side `cset` inline-asm dispatch); both are
prerequisites for the aarch64-darwin half of mach #1680.
