### PR TITLE
release: sweep dev → main (v0.16.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.1] - 2026-06-28
+
+Rewrite the aarch64 darwin `_start` entry in mach's inline-asm dialect so
+aarch64-darwin links. Built with mach 2.9.0.
+
+### Fixed
+
+- runtime/darwin: rewrite the aarch64 `_start` in mach's inline-asm dialect —
+  bare immediates, an explicit `lsl`+`add` for the envp scale, and no explicit
+  stack realignment (sp is 16-byte aligned on kernel entry). The prior standard
+  ARM syntax used `#`-prefixed immediates (mach's comment char), a 4-operand
+  shifted-register add, and a bitmask-immediate `and`, all of which mach's
+  dialect rejects — so darwin-aarch64 could not link. Semantics are preserved
+  (#320).
+
 ## [0.16.0] - 2026-06-28
 
 Add a riscv64-linux target — runtime entry, syscall layer, and atomics — with a

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,7 @@
 [project]
 id      = "std"
 name    = "Mach Standard Library"
-version = "0.16.0"
+version = "0.16.1"
 src     = "src"
 dep     = "dep"
 target  = "native"

--- a/src/runtime/darwin/aarch64.mach
+++ b/src/runtime/darwin/aarch64.mach
@@ -10,9 +10,9 @@
 #
 # this entrypoint:
 #   1. extracts argc and argv from the initial stack
-#   2. aligns the stack to 16 bytes (required by AAPCS64 before BL)
-#   3. calls user-supplied `main(argc, argv)`
-#   4. exits via sys_exit with the return code from main
+#   2. captures argc/argv/envp for the runtime, then calls `main(argc, argv)`
+#      (sp is already 16-byte aligned on kernel entry, an arm64 invariant)
+#   3. exits via sys_exit with the return code from main
 #
 # user code must define:
 #   #[symbol("main")]
@@ -43,30 +43,33 @@ fun _rt_init() {
 #[symbol("start")]
 pub fun _start() {
     asm aarch64 {
-        ldr x0, [sp]      # argc -> x0 (1st argument)
-        add x1, sp, #8    # argv -> x1 (2nd argument)
+        mov x9, sp            # x9 = initial stack pointer (argc at [x9])
+        ldr x0, [x9]          # argc -> x0 (1st argument to main)
+        add x1, x9, 8         # argv -> x1 (2nd argument to main)
 
         # envp = argv + (argc + 1) * 8
-        add x2, x0, #1
-        add x2, x1, x2, lsl #3
+        add x10, x0, 1
+        lsl x10, x10, 3
+        add x10, x1, x10      # x10 = envp
 
-        adrp x3, _rt_argc
-        str x0, [x3, :lo12:_rt_argc]
-        adrp x3, _rt_argv
-        str x1, [x3, :lo12:_rt_argv]
-        adrp x3, _rt_envp
-        str x2, [x3, :lo12:_rt_envp]
+        adrp x11, _rt_argc
+        str x0, [x11, :lo12:_rt_argc]
+        adrp x11, _rt_argv
+        str x1, [x11, :lo12:_rt_argv]
+        adrp x11, _rt_envp
+        str x10, [x11, :lo12:_rt_envp]
 
-        and sp, sp, #-16  # align stack to 16 bytes
+        # sp is 16-byte aligned on kernel entry (an arm64 architectural
+        # invariant), so no realignment is needed before the calls.
         bl _rt_init
 
-        adrp x3, _rt_argc
-        ldr x0, [x3, :lo12:_rt_argc]
-        adrp x3, _rt_argv
-        ldr x1, [x3, :lo12:_rt_argv]
+        adrp x11, _rt_argc
+        ldr x0, [x11, :lo12:_rt_argc]
+        adrp x11, _rt_argv
+        ldr x1, [x11, :lo12:_rt_argv]
         bl main
 
-        mov x16, #1       # SYS_exit
-        svc #0x80
+        mov x16, 1           # SYS_exit
+        svc 0x80
     }
 }


### PR DESCRIPTION
Integration sweep of `dev` → `main` for **v0.16.1**. No-fast-forward merge to preserve branching history.

## Contents

- **runtime/darwin** — aarch64 `_start` rewritten in mach's inline-asm dialect (bare immediates, explicit `lsl`+`add`, no `#`-immediates / shifted-register forms mach rejects) so aarch64-darwin links; darwin semantics preserved (#320, via #321).
- **release** — `mach.toml` 0.16.0 → 0.16.1 + CHANGELOG (#322).

## Notes

- Verified clean: a test merge of `dev` into a detached `main` resolved automatically with zero conflicts. `main` is behind `dev` only by the content-identical merge commits #312 (hotfix) and #319 (v0.16.0 sweep) — no merge-back needed.
- Single bug fix; no API change. Patch release.
- Unblocks the aarch64-darwin link: mach consumes mach-std at `branch/main`, so this reaching `main` is what the darwin build (briar-systems/mach#1680) needs.
- Tag `v0.16.1` is pushed separately after merge, not from this PR.