### PR TITLE
feat: output overhaul stdlib primitives (chrono format_duration + format left-align)

### DIFF
--- a/src/chrono/duration.mach
+++ b/src/chrono/duration.mach
@@ -2,6 +2,10 @@
 #
 # Duration represents elapsed time as nanoseconds (i64).
 
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
+
 # Duration: elapsed time in nanoseconds.
 pub def Duration: i64;
 
@@ -73,6 +77,105 @@ pub fun duration_abs(d: Duration) Duration {
     ret d;
 }
 
+# du_put: append byte b into buf at off if it fits; ret new offset, or cap + 1
+# when the buffer is full (a poison value that later appends propagate).
+fun du_put(buf: *u8, off: usize, cap: usize, b: u8) usize {
+    if (off >= cap) { ret cap + 1; }
+    buf[off] = b;
+    ret off + 1;
+}
+
+# du_put_str: append a null-terminated string into buf at off; ret new offset
+# (poison-propagating like du_put).
+fun du_put_str(buf: *u8, off: usize, cap: usize, s: str) usize {
+    var o: usize = off;
+    var i: usize = 0;
+    for (s[i] != 0) {
+        o = du_put(buf, o, cap, s[i]);
+        i = i + 1;
+    }
+    ret o;
+}
+
+# du_put_u64: append n's decimal digits into buf at off; ret new offset (poison
+# value > cap when the digits would not fit).
+fun du_put_u64(buf: *u8, off: usize, cap: usize, n: u64) usize {
+    if (n == 0) { ret du_put(buf, off, cap, '0'); }
+    var tmp: [20]u8;
+    var len: usize = 0;
+    var x: u64 = n;
+    for (x > 0) {
+        tmp[len] = (x % 10)::u8 + '0';
+        x = x / 10;
+        len = len + 1;
+    }
+    if (off + len > cap) { ret cap + 1; }
+    var i: usize = 0;
+    for (i < len) {
+        buf[off + i] = tmp[len - 1 - i];
+        i = i + 1;
+    }
+    ret off + len;
+}
+
+# format_duration: render d as a compact ASCII human-readable string into buf.
+# ---
+# writes a null-terminated string and returns it (aliasing buf), or nil if cap
+# is too small to hold the rendering plus its terminator. negative durations
+# carry a leading '-'. units are chosen by magnitude:
+#   zero            -> "0ms"
+#   sub-microsecond -> "<1ms"
+#   microseconds    -> "Nus"   (1..999)
+#   milliseconds    -> "Nms"   (1..999)
+#   seconds         -> "N.Ns"  (tenths truncate)
+#   minutes and up  -> "NmNs"  (no hours band; minutes accumulate)
+# a 24-byte buffer holds every i64 duration. fixed ASCII output, no platform
+# branches.
+# ---
+# d:   duration to render
+# buf: caller-provided byte buffer
+# cap: capacity of buf in bytes
+# ret: buf as a null-terminated str, or nil if cap is insufficient
+pub fun format_duration(d: Duration, buf: *u8, cap: usize) str {
+    if (d == 0) {
+        if (cap < 4) { ret nil; }
+        buf[0] = '0'; buf[1] = 'm'; buf[2] = 's'; buf[3] = 0;
+        ret buf::str;
+    }
+
+    var off: usize = 0;
+    if (d < 0) { off = du_put(buf, off, cap, '-'); }
+    val m: Duration = duration_abs(d);
+
+    if (m < MICROSECOND) {
+        off = du_put_str(buf, off, cap, "<1ms");
+    }
+    or (m < MILLISECOND) {
+        off = du_put_u64(buf, off, cap, (m / MICROSECOND)::u64);
+        off = du_put_str(buf, off, cap, "us");
+    }
+    or (m < SECOND) {
+        off = du_put_u64(buf, off, cap, (m / MILLISECOND)::u64);
+        off = du_put_str(buf, off, cap, "ms");
+    }
+    or (m < MINUTE) {
+        off = du_put_u64(buf, off, cap, (m / SECOND)::u64);
+        off = du_put(buf, off, cap, '.');
+        off = du_put_u64(buf, off, cap, ((m % SECOND) / (SECOND / 10))::u64);
+        off = du_put(buf, off, cap, 's');
+    }
+    or {
+        off = du_put_u64(buf, off, cap, (m / MINUTE)::u64);
+        off = du_put(buf, off, cap, 'm');
+        off = du_put_u64(buf, off, cap, ((m % MINUTE) / SECOND)::u64);
+        off = du_put(buf, off, cap, 's');
+    }
+
+    if (off >= cap) { ret nil; }
+    buf[off] = 0;
+    ret buf::str;
+}
+
 test "duration: constants" {
     if (NANOSECOND != 1) { ret 1; }
     if (MICROSECOND != 1000) { ret 2; }
@@ -99,5 +202,46 @@ test "duration: abs" {
     val neg: Duration = 0 - 1000;
     if (duration_abs(pos) != 1000) { ret 1; }
     if (duration_abs(neg) != 1000) { ret 2; }
+    ret 0;
+}
+
+test "duration: format_duration units" {
+    var b: [24]u8;
+    if (!str_equals(format_duration(0, ?b[0], 24), "0ms")) { ret 1; }
+    # sub-microsecond floors to "<1ms"
+    if (!str_equals(format_duration(500, ?b[0], 24), "<1ms")) { ret 2; }
+    # microseconds
+    if (!str_equals(format_duration(5 * MICROSECOND, ?b[0], 24), "5us")) { ret 3; }
+    if (!str_equals(format_duration(999 * MICROSECOND, ?b[0], 24), "999us")) { ret 4; }
+    # milliseconds
+    if (!str_equals(format_duration(1 * MILLISECOND, ?b[0], 24), "1ms")) { ret 5; }
+    if (!str_equals(format_duration(123 * MILLISECOND, ?b[0], 24), "123ms")) { ret 6; }
+    # seconds with truncated tenths
+    if (!str_equals(format_duration(1500 * MILLISECOND, ?b[0], 24), "1.5s")) { ret 7; }
+    if (!str_equals(format_duration(59900 * MILLISECOND, ?b[0], 24), "59.9s")) { ret 8; }
+    # tenths truncate rather than round
+    if (!str_equals(format_duration(1999 * MILLISECOND, ?b[0], 24), "1.9s")) { ret 9; }
+    # minutes
+    if (!str_equals(format_duration(2 * MINUTE + 3 * SECOND, ?b[0], 24), "2m3s")) { ret 10; }
+    ret 0;
+}
+
+test "duration: format_duration sign and boundaries" {
+    var b: [24]u8;
+    # negative carries a leading '-'
+    if (!str_equals(format_duration(0 - 250 * MILLISECOND, ?b[0], 24), "-250ms")) { ret 1; }
+    # exactly one second enters the seconds band
+    if (!str_equals(format_duration(SECOND, ?b[0], 24), "1.0s")) { ret 2; }
+    # exactly one minute enters the minutes band
+    if (!str_equals(format_duration(MINUTE, ?b[0], 24), "1m0s")) { ret 3; }
+    # over an hour stays in minutes (no hours band)
+    if (!str_equals(format_duration(90 * MINUTE, ?b[0], 24), "90m0s")) { ret 4; }
+    ret 0;
+}
+
+test "duration: format_duration insufficient capacity" {
+    var b: [4]u8;
+    # "999us" needs five bytes plus a terminator; cap 4 cannot hold it
+    if (format_duration(999 * MICROSECOND, ?b[0], 4) != nil) { ret 1; }
     ret 0;
 }

--- a/src/format.mach
+++ b/src/format.mach
@@ -11,10 +11,12 @@
 # representation, so they render as their numeric value — a bool prints 1 or 0;
 # reach for the `{:c}` spec to render an integer's low byte as a character.
 #
-# a hole may carry a spec after `:` — `x`/`X` for lower/upper hex, `c` for a
-# low-byte char, a decimal minimum width, and a leading `0` to zero-pad rather
-# than space-pad (e.g. `{:x}`, `{:c}`, `{:5}`, `{:08x}`). `{{` and `}}` emit
-# literal braces. a hole/argument count mismatch is an error in either direction.
+# a hole may carry a spec after `:` — a leading `<` to left-align (pad on the
+# right), `x`/`X` for lower/upper hex, `c` for a low-byte char, a decimal minimum
+# width, and a leading `0` to zero-pad rather than space-pad (e.g. `{:x}`, `{:c}`,
+# `{:5}`, `{:<5}`, `{:08x}`). width pads on the left (right-align) by default.
+# `{{` and `}}` emit literal braces. a hole/argument count mismatch is an error
+# in either direction.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -475,12 +477,14 @@ pub val ERR_MANY_HOLES: str = "more format holes than arguments";
 
 # Spec: a parsed `{...}` hole spec.
 # ---
+# left:  left-align (pad on the right) instead of the default right-align
 # hex:   render an integer in hexadecimal
 # upper: uppercase hex digits when hex
 # chr:   render an integer's low byte as a character
 # zero:  pad to width with '0' instead of ' '
 # width: minimum field width in bytes
 rec Spec {
+    left:  bool;
     hex:   bool;
     upper: bool;
     chr:   bool;
@@ -511,12 +515,12 @@ fun span_write(ctx: ptr, p: *u8, len: usize) Result[usize, str] {
 # parse_spec: parse a `{...}` hole, advancing *ip past the closing brace.
 # ---
 # precondition: fmt[*ip] == '{' opening a real hole (callers handle `{{`).
-# grammar: '{' [ ':' [ '0' ] [ width ] [ 'x' | 'X' | 'c' ] ] '}'
+# grammar: '{' [ ':' [ '<' ] [ '0' ] [ width ] [ 'x' | 'X' | 'c' ] ] '}'
 # ip:  in/out format cursor
 # ret: the parsed spec, or ERR_BAD_FORMAT on a malformed hole
 fun parse_spec(fmt: str, ip: *usize) Result[Spec, str] {
     var i: usize = @ip + 1;
-    var sp: Spec = Spec{ hex: false, upper: false, chr: false, zero: false, width: 0 };
+    var sp: Spec = Spec{ left: false, hex: false, upper: false, chr: false, zero: false, width: 0 };
 
     if (fmt[i] == '}') {
         @ip = i + 1;
@@ -526,6 +530,11 @@ fun parse_spec(fmt: str, ip: *usize) Result[Spec, str] {
         ret err[Spec, str](ERR_BAD_FORMAT);
     }
     i = i + 1;
+
+    if (fmt[i] == '<') {
+        sp.left = true;
+        i = i + 1;
+    }
 
     if (fmt[i] == '0') {
         sp.zero = true;
@@ -570,13 +579,23 @@ fun emit_pad(w: *writer.Writer, b: u8, n: usize) Result[usize, str] {
 
 # emit_field: write a rendered field with width padding per spec.
 # ---
-# right-aligned; a leading '-' stays ahead of '0' padding.
+# right-aligned by default; a leading '-' stays ahead of '0' padding. when
+# sp.left is set, the value is written first and space-padded on the right
+# (the zero flag is ignored — trailing zeros would corrupt the value).
 # ret: total bytes written (>= len), or an error
 fun emit_field(w: *writer.Writer, buf: *u8, len: usize, sp: *Spec) Result[usize, str] {
     if (sp.width <= len) {
         ret write_bytes(w, buf, len);
     }
     val pad: usize = sp.width - len;
+
+    if (sp.left) {
+        val rb: Result[usize, str] = write_bytes(w, buf, len);
+        if (is_err[usize, str](rb)) { ret rb; }
+        val rp: Result[usize, str] = emit_pad(w, ' ', pad);
+        if (is_err[usize, str](rp)) { ret rp; }
+        ret ok[usize, str](sp.width);
+    }
 
     if (sp.zero && len > 0 && buf[0] == '-') {
         val r1: Result[usize, str] = write_byte(w, '-');
@@ -708,14 +727,25 @@ fun fmt_ptr_field(w: *writer.Writer, p: ptr, sp: *Spec) Result[usize, str] {
     ret emit_field(w, ?scratch[0], s.len, sp);
 }
 
-# fmt_str_field: write a string with width padding (space-padded, right-aligned).
+# fmt_str_field: write a string with width padding (space-padded; right-aligned
+# by default, left-aligned when sp.left is set).
 fun fmt_str_field(w: *writer.Writer, sv: str, sp: *Spec) Result[usize, str] {
     var n: usize = 0;
     if (sv != nil) { n = str_len(sv); }
     if (sp.width <= n) {
         ret write_str(w, sv);
     }
-    val rp: Result[usize, str] = emit_pad(w, ' ', sp.width - n);
+    val pad: usize = sp.width - n;
+
+    if (sp.left) {
+        val rs: Result[usize, str] = write_str(w, sv);
+        if (is_err[usize, str](rs)) { ret rs; }
+        val rp: Result[usize, str] = emit_pad(w, ' ', pad);
+        if (is_err[usize, str](rp)) { ret rp; }
+        ret ok[usize, str](sp.width);
+    }
+
+    val rp: Result[usize, str] = emit_pad(w, ' ', pad);
     if (is_err[usize, str](rp)) { ret rp; }
     val rs: Result[usize, str] = write_str(w, sv);
     if (is_err[usize, str](rs)) { ret rs; }
@@ -726,7 +756,8 @@ fun fmt_str_field(w: *writer.Writer, sv: str, sp: *Spec) Result[usize, str] {
 #
 # holes are type-directed `{}` matched to args in order: signed/unsigned int ->
 # decimal, str -> text, ptr -> 0xHEX, f64 -> shortest round-trip decimal. specs:
-# `{:x}`/`{:X}` hex, `{:c}` low-byte char, `{:N}`/`{:0N}` minimum width. `{{` and
+# `{:x}`/`{:X}` hex, `{:c}` low-byte char, `{:N}`/`{:0N}` minimum width (right-
+# align), `{:<N}` left-align. `{{` and
 # `}}` are literal-brace escapes. the arg sequence is comptime-unrolled and
 # monomorphized per call; the format scan stays at runtime.
 # ---
@@ -963,6 +994,46 @@ test "format: hex, width and zero-pad specs" {
     # strings space-pad regardless of the zero flag.
     r = fmt_capture(?s[0], 64, "[{:5}]", "hi");
     if (is_err[usize, str](r) || !str_equals(?s[0], "[   hi]")) { ret 7; }
+    ret 0;
+}
+
+# `{:<N}` left-aligns: the value is written first and space-padded on the right.
+# right-aligned specs stay byte-identical (re-asserted against the cases above).
+test "format: left-align spec" {
+    var s: [64]u8;
+    var r: Result[usize, str];
+
+    # int: pad spaces on the right.
+    r = fmt_capture(?s[0], 64, "[{:<5}]", 42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[42   ]")) { ret 1; }
+
+    # str: pad spaces on the right.
+    r = fmt_capture(?s[0], 64, "[{:<5}]", "hi");
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[hi   ]")) { ret 2; }
+
+    # negative stays intact, padded on the right.
+    r = fmt_capture(?s[0], 64, "[{:<5}]", -42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[-42  ]")) { ret 3; }
+
+    # the zero flag is ignored for left-align (spaces, not trailing zeros).
+    r = fmt_capture(?s[0], 64, "[{:<05}]", 42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[42   ]")) { ret 4; }
+
+    # left-align composes with hex.
+    r = fmt_capture(?s[0], 64, "[{:<5x}]", 255::u64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[ff   ]")) { ret 5; }
+
+    # value at or over width: no padding either way.
+    r = fmt_capture(?s[0], 64, "[{:<2}]", 42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[42]")) { ret 6; }
+
+    # right-align (no `<`) unchanged: int pads on the left.
+    r = fmt_capture(?s[0], 64, "[{:5}]", 42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[   42]")) { ret 7; }
+
+    # right-align str unchanged.
+    r = fmt_capture(?s[0], 64, "[{:5}]", "hi");
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[   hi]")) { ret 8; }
     ret 0;
 }
 


### PR DESCRIPTION
Part of the output-overhaul epic (briar-systems/mach#1773), implementing briar-systems/mach#1774.

Two shared multiplatform stdlib primitives the terminal-output overhaul needs. ASCII-only, no platform branches, no allocation.

## 1. chrono `format_duration`
`chrono.Duration` had component accessors but no human string. Adds `format_duration(d: Duration, buf: *u8, cap: usize) str` — renders a Duration into a caller-provided buffer, returning the null-terminated string (aliasing `buf`), or `nil` if `cap` is insufficient. A 24-byte buffer holds every i64 duration. Unit chosen by magnitude:

| range | output |
|---|---|
| zero | `0ms` |
| sub-microsecond | `<1ms` |
| microseconds | `Nus` |
| milliseconds | `Nms` |
| seconds | `N.Ns` (tenths truncate) |
| minutes and up | `NmNs` |

Negative durations carry a leading `-`. Minutes is the top band (no hours).

## 2. format `{:<N}` left-align
Extends the hole-spec grammar from `'{' [':' ['0'] [width] [x|X|c] '}'` to `'{' [':' ['<'] ['0'] [width] [x|X|c] '}'`. A `<` immediately after `:` (before the optional `0`/width) sets a new `Spec.left` flag; `emit_field`/`fmt_str_field` then write the value first and space-pad on the **right**. The zero flag is ignored for left-align (trailing zeros would corrupt the value). Right-align specs (`{:N}`, `{:0N}`, `{:08x}`) are byte-identical.

## Tests
mach-std suite green (567 passed, 0 failed). New unit tests:
- `format_duration` across ns/us/ms/s/m ranges + sign, band boundaries (1s, 1m, >1h), and insufficient-capacity cases.
- `{:<N}` left-align for str + int (and hex, negative, zero-flag-ignored, value-over-width), asserting exact padded bytes, with `{:N}`/`{:0N}` right-align re-asserted unchanged.

Note: the consuming mach repo's `mach.lock` bump is coordinated centrally by the epic lead, not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)