### PR TITLE
release: output primitives (#1774) + static-PIE self-relocation (#1727)

### DIFF
--- a/src/chrono/duration.mach
+++ b/src/chrono/duration.mach
@@ -2,6 +2,10 @@
 #
 # Duration represents elapsed time as nanoseconds (i64).
 
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
+
 # Duration: elapsed time in nanoseconds.
 pub def Duration: i64;
 
@@ -73,6 +77,105 @@ pub fun duration_abs(d: Duration) Duration {
     ret d;
 }
 
+# du_put: append byte b into buf at off if it fits; ret new offset, or cap + 1
+# when the buffer is full (a poison value that later appends propagate).
+fun du_put(buf: *u8, off: usize, cap: usize, b: u8) usize {
+    if (off >= cap) { ret cap + 1; }
+    buf[off] = b;
+    ret off + 1;
+}
+
+# du_put_str: append a null-terminated string into buf at off; ret new offset
+# (poison-propagating like du_put).
+fun du_put_str(buf: *u8, off: usize, cap: usize, s: str) usize {
+    var o: usize = off;
+    var i: usize = 0;
+    for (s[i] != 0) {
+        o = du_put(buf, o, cap, s[i]);
+        i = i + 1;
+    }
+    ret o;
+}
+
+# du_put_u64: append n's decimal digits into buf at off; ret new offset (poison
+# value > cap when the digits would not fit).
+fun du_put_u64(buf: *u8, off: usize, cap: usize, n: u64) usize {
+    if (n == 0) { ret du_put(buf, off, cap, '0'); }
+    var tmp: [20]u8;
+    var len: usize = 0;
+    var x: u64 = n;
+    for (x > 0) {
+        tmp[len] = (x % 10)::u8 + '0';
+        x = x / 10;
+        len = len + 1;
+    }
+    if (off + len > cap) { ret cap + 1; }
+    var i: usize = 0;
+    for (i < len) {
+        buf[off + i] = tmp[len - 1 - i];
+        i = i + 1;
+    }
+    ret off + len;
+}
+
+# format_duration: render d as a compact ASCII human-readable string into buf.
+# ---
+# writes a null-terminated string and returns it (aliasing buf), or nil if cap
+# is too small to hold the rendering plus its terminator. negative durations
+# carry a leading '-'. units are chosen by magnitude:
+#   zero            -> "0ms"
+#   sub-microsecond -> "<1ms"
+#   microseconds    -> "Nus"   (1..999)
+#   milliseconds    -> "Nms"   (1..999)
+#   seconds         -> "N.Ns"  (tenths truncate)
+#   minutes and up  -> "NmNs"  (no hours band; minutes accumulate)
+# a 24-byte buffer holds every i64 duration. fixed ASCII output, no platform
+# branches.
+# ---
+# d:   duration to render
+# buf: caller-provided byte buffer
+# cap: capacity of buf in bytes
+# ret: buf as a null-terminated str, or nil if cap is insufficient
+pub fun format_duration(d: Duration, buf: *u8, cap: usize) str {
+    if (d == 0) {
+        if (cap < 4) { ret nil; }
+        buf[0] = '0'; buf[1] = 'm'; buf[2] = 's'; buf[3] = 0;
+        ret buf::str;
+    }
+
+    var off: usize = 0;
+    if (d < 0) { off = du_put(buf, off, cap, '-'); }
+    val m: Duration = duration_abs(d);
+
+    if (m < MICROSECOND) {
+        off = du_put_str(buf, off, cap, "<1ms");
+    }
+    or (m < MILLISECOND) {
+        off = du_put_u64(buf, off, cap, (m / MICROSECOND)::u64);
+        off = du_put_str(buf, off, cap, "us");
+    }
+    or (m < SECOND) {
+        off = du_put_u64(buf, off, cap, (m / MILLISECOND)::u64);
+        off = du_put_str(buf, off, cap, "ms");
+    }
+    or (m < MINUTE) {
+        off = du_put_u64(buf, off, cap, (m / SECOND)::u64);
+        off = du_put(buf, off, cap, '.');
+        off = du_put_u64(buf, off, cap, ((m % SECOND) / (SECOND / 10))::u64);
+        off = du_put(buf, off, cap, 's');
+    }
+    or {
+        off = du_put_u64(buf, off, cap, (m / MINUTE)::u64);
+        off = du_put(buf, off, cap, 'm');
+        off = du_put_u64(buf, off, cap, ((m % MINUTE) / SECOND)::u64);
+        off = du_put(buf, off, cap, 's');
+    }
+
+    if (off >= cap) { ret nil; }
+    buf[off] = 0;
+    ret buf::str;
+}
+
 test "duration: constants" {
     if (NANOSECOND != 1) { ret 1; }
     if (MICROSECOND != 1000) { ret 2; }
@@ -99,5 +202,46 @@ test "duration: abs" {
     val neg: Duration = 0 - 1000;
     if (duration_abs(pos) != 1000) { ret 1; }
     if (duration_abs(neg) != 1000) { ret 2; }
+    ret 0;
+}
+
+test "duration: format_duration units" {
+    var b: [24]u8;
+    if (!str_equals(format_duration(0, ?b[0], 24), "0ms")) { ret 1; }
+    # sub-microsecond floors to "<1ms"
+    if (!str_equals(format_duration(500, ?b[0], 24), "<1ms")) { ret 2; }
+    # microseconds
+    if (!str_equals(format_duration(5 * MICROSECOND, ?b[0], 24), "5us")) { ret 3; }
+    if (!str_equals(format_duration(999 * MICROSECOND, ?b[0], 24), "999us")) { ret 4; }
+    # milliseconds
+    if (!str_equals(format_duration(1 * MILLISECOND, ?b[0], 24), "1ms")) { ret 5; }
+    if (!str_equals(format_duration(123 * MILLISECOND, ?b[0], 24), "123ms")) { ret 6; }
+    # seconds with truncated tenths
+    if (!str_equals(format_duration(1500 * MILLISECOND, ?b[0], 24), "1.5s")) { ret 7; }
+    if (!str_equals(format_duration(59900 * MILLISECOND, ?b[0], 24), "59.9s")) { ret 8; }
+    # tenths truncate rather than round
+    if (!str_equals(format_duration(1999 * MILLISECOND, ?b[0], 24), "1.9s")) { ret 9; }
+    # minutes
+    if (!str_equals(format_duration(2 * MINUTE + 3 * SECOND, ?b[0], 24), "2m3s")) { ret 10; }
+    ret 0;
+}
+
+test "duration: format_duration sign and boundaries" {
+    var b: [24]u8;
+    # negative carries a leading '-'
+    if (!str_equals(format_duration(0 - 250 * MILLISECOND, ?b[0], 24), "-250ms")) { ret 1; }
+    # exactly one second enters the seconds band
+    if (!str_equals(format_duration(SECOND, ?b[0], 24), "1.0s")) { ret 2; }
+    # exactly one minute enters the minutes band
+    if (!str_equals(format_duration(MINUTE, ?b[0], 24), "1m0s")) { ret 3; }
+    # over an hour stays in minutes (no hours band)
+    if (!str_equals(format_duration(90 * MINUTE, ?b[0], 24), "90m0s")) { ret 4; }
+    ret 0;
+}
+
+test "duration: format_duration insufficient capacity" {
+    var b: [4]u8;
+    # "999us" needs five bytes plus a terminator; cap 4 cannot hold it
+    if (format_duration(999 * MICROSECOND, ?b[0], 4) != nil) { ret 1; }
     ret 0;
 }

--- a/src/format.mach
+++ b/src/format.mach
@@ -11,10 +11,12 @@
 # representation, so they render as their numeric value — a bool prints 1 or 0;
 # reach for the `{:c}` spec to render an integer's low byte as a character.
 #
-# a hole may carry a spec after `:` — `x`/`X` for lower/upper hex, `c` for a
-# low-byte char, a decimal minimum width, and a leading `0` to zero-pad rather
-# than space-pad (e.g. `{:x}`, `{:c}`, `{:5}`, `{:08x}`). `{{` and `}}` emit
-# literal braces. a hole/argument count mismatch is an error in either direction.
+# a hole may carry a spec after `:` — a leading `<` to left-align (pad on the
+# right), `x`/`X` for lower/upper hex, `c` for a low-byte char, a decimal minimum
+# width, and a leading `0` to zero-pad rather than space-pad (e.g. `{:x}`, `{:c}`,
+# `{:5}`, `{:<5}`, `{:08x}`). width pads on the left (right-align) by default.
+# `{{` and `}}` emit literal braces. a hole/argument count mismatch is an error
+# in either direction.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -475,12 +477,14 @@ pub val ERR_MANY_HOLES: str = "more format holes than arguments";
 
 # Spec: a parsed `{...}` hole spec.
 # ---
+# left:  left-align (pad on the right) instead of the default right-align
 # hex:   render an integer in hexadecimal
 # upper: uppercase hex digits when hex
 # chr:   render an integer's low byte as a character
 # zero:  pad to width with '0' instead of ' '
 # width: minimum field width in bytes
 rec Spec {
+    left:  bool;
     hex:   bool;
     upper: bool;
     chr:   bool;
@@ -511,12 +515,12 @@ fun span_write(ctx: ptr, p: *u8, len: usize) Result[usize, str] {
 # parse_spec: parse a `{...}` hole, advancing *ip past the closing brace.
 # ---
 # precondition: fmt[*ip] == '{' opening a real hole (callers handle `{{`).
-# grammar: '{' [ ':' [ '0' ] [ width ] [ 'x' | 'X' | 'c' ] ] '}'
+# grammar: '{' [ ':' [ '<' ] [ '0' ] [ width ] [ 'x' | 'X' | 'c' ] ] '}'
 # ip:  in/out format cursor
 # ret: the parsed spec, or ERR_BAD_FORMAT on a malformed hole
 fun parse_spec(fmt: str, ip: *usize) Result[Spec, str] {
     var i: usize = @ip + 1;
-    var sp: Spec = Spec{ hex: false, upper: false, chr: false, zero: false, width: 0 };
+    var sp: Spec = Spec{ left: false, hex: false, upper: false, chr: false, zero: false, width: 0 };
 
     if (fmt[i] == '}') {
         @ip = i + 1;
@@ -526,6 +530,11 @@ fun parse_spec(fmt: str, ip: *usize) Result[Spec, str] {
         ret err[Spec, str](ERR_BAD_FORMAT);
     }
     i = i + 1;
+
+    if (fmt[i] == '<') {
+        sp.left = true;
+        i = i + 1;
+    }
 
     if (fmt[i] == '0') {
         sp.zero = true;
@@ -570,13 +579,23 @@ fun emit_pad(w: *writer.Writer, b: u8, n: usize) Result[usize, str] {
 
 # emit_field: write a rendered field with width padding per spec.
 # ---
-# right-aligned; a leading '-' stays ahead of '0' padding.
+# right-aligned by default; a leading '-' stays ahead of '0' padding. when
+# sp.left is set, the value is written first and space-padded on the right
+# (the zero flag is ignored — trailing zeros would corrupt the value).
 # ret: total bytes written (>= len), or an error
 fun emit_field(w: *writer.Writer, buf: *u8, len: usize, sp: *Spec) Result[usize, str] {
     if (sp.width <= len) {
         ret write_bytes(w, buf, len);
     }
     val pad: usize = sp.width - len;
+
+    if (sp.left) {
+        val rb: Result[usize, str] = write_bytes(w, buf, len);
+        if (is_err[usize, str](rb)) { ret rb; }
+        val rp: Result[usize, str] = emit_pad(w, ' ', pad);
+        if (is_err[usize, str](rp)) { ret rp; }
+        ret ok[usize, str](sp.width);
+    }
 
     if (sp.zero && len > 0 && buf[0] == '-') {
         val r1: Result[usize, str] = write_byte(w, '-');
@@ -708,14 +727,25 @@ fun fmt_ptr_field(w: *writer.Writer, p: ptr, sp: *Spec) Result[usize, str] {
     ret emit_field(w, ?scratch[0], s.len, sp);
 }
 
-# fmt_str_field: write a string with width padding (space-padded, right-aligned).
+# fmt_str_field: write a string with width padding (space-padded; right-aligned
+# by default, left-aligned when sp.left is set).
 fun fmt_str_field(w: *writer.Writer, sv: str, sp: *Spec) Result[usize, str] {
     var n: usize = 0;
     if (sv != nil) { n = str_len(sv); }
     if (sp.width <= n) {
         ret write_str(w, sv);
     }
-    val rp: Result[usize, str] = emit_pad(w, ' ', sp.width - n);
+    val pad: usize = sp.width - n;
+
+    if (sp.left) {
+        val rs: Result[usize, str] = write_str(w, sv);
+        if (is_err[usize, str](rs)) { ret rs; }
+        val rp: Result[usize, str] = emit_pad(w, ' ', pad);
+        if (is_err[usize, str](rp)) { ret rp; }
+        ret ok[usize, str](sp.width);
+    }
+
+    val rp: Result[usize, str] = emit_pad(w, ' ', pad);
     if (is_err[usize, str](rp)) { ret rp; }
     val rs: Result[usize, str] = write_str(w, sv);
     if (is_err[usize, str](rs)) { ret rs; }
@@ -726,7 +756,8 @@ fun fmt_str_field(w: *writer.Writer, sv: str, sp: *Spec) Result[usize, str] {
 #
 # holes are type-directed `{}` matched to args in order: signed/unsigned int ->
 # decimal, str -> text, ptr -> 0xHEX, f64 -> shortest round-trip decimal. specs:
-# `{:x}`/`{:X}` hex, `{:c}` low-byte char, `{:N}`/`{:0N}` minimum width. `{{` and
+# `{:x}`/`{:X}` hex, `{:c}` low-byte char, `{:N}`/`{:0N}` minimum width (right-
+# align), `{:<N}` left-align. `{{` and
 # `}}` are literal-brace escapes. the arg sequence is comptime-unrolled and
 # monomorphized per call; the format scan stays at runtime.
 # ---
@@ -963,6 +994,46 @@ test "format: hex, width and zero-pad specs" {
     # strings space-pad regardless of the zero flag.
     r = fmt_capture(?s[0], 64, "[{:5}]", "hi");
     if (is_err[usize, str](r) || !str_equals(?s[0], "[   hi]")) { ret 7; }
+    ret 0;
+}
+
+# `{:<N}` left-aligns: the value is written first and space-padded on the right.
+# right-aligned specs stay byte-identical (re-asserted against the cases above).
+test "format: left-align spec" {
+    var s: [64]u8;
+    var r: Result[usize, str];
+
+    # int: pad spaces on the right.
+    r = fmt_capture(?s[0], 64, "[{:<5}]", 42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[42   ]")) { ret 1; }
+
+    # str: pad spaces on the right.
+    r = fmt_capture(?s[0], 64, "[{:<5}]", "hi");
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[hi   ]")) { ret 2; }
+
+    # negative stays intact, padded on the right.
+    r = fmt_capture(?s[0], 64, "[{:<5}]", -42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[-42  ]")) { ret 3; }
+
+    # the zero flag is ignored for left-align (spaces, not trailing zeros).
+    r = fmt_capture(?s[0], 64, "[{:<05}]", 42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[42   ]")) { ret 4; }
+
+    # left-align composes with hex.
+    r = fmt_capture(?s[0], 64, "[{:<5x}]", 255::u64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[ff   ]")) { ret 5; }
+
+    # value at or over width: no padding either way.
+    r = fmt_capture(?s[0], 64, "[{:<2}]", 42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[42]")) { ret 6; }
+
+    # right-align (no `<`) unchanged: int pads on the left.
+    r = fmt_capture(?s[0], 64, "[{:5}]", 42::i64);
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[   42]")) { ret 7; }
+
+    # right-align str unchanged.
+    r = fmt_capture(?s[0], 64, "[{:5}]", "hi");
+    if (is_err[usize, str](r) || !str_equals(?s[0], "[   hi]")) { ret 8; }
     ret 0;
 }
 

--- a/src/runtime/linux/aarch64.mach
+++ b/src/runtime/linux/aarch64.mach
@@ -37,6 +37,11 @@
 
 use os: std.system.os.linux.aarch64;
 
+# the static-PIE self-relocation pass, linked only into a `--pie` build.
+$if ($mach.build.pie == 1) {
+    use reloc: std.runtime.linux.reloc;
+}
+
 #[symbol("_rt_argc")]
 var _rt_argc: i64 = 0;
 #[symbol("_rt_argv")]
@@ -46,6 +51,12 @@ var _rt_envp: u64 = 0;
 
 #[symbol("_rt_init")]
 fun _rt_init() {
+    # a `--pie` build self-relocates here, before `main` and before any global pointer
+    # is read - the auxv is reached from envp, so `_start`'s raw-sp asm stays untouched
+    # (and a non-PIE build links none of this, leaving `_rt_init` byte-identical).
+    $if ($mach.build.pie == 1) {
+        reloc._rt_relocate(_rt_envp::ptr::*u64);
+    }
     os._envp = _rt_envp;
 }
 

--- a/src/runtime/linux/reloc.mach
+++ b/src/runtime/linux/reloc.mach
@@ -1,0 +1,127 @@
+# std.runtime.linux.reloc: static-PIE self-relocation
+# ---
+# A no-libc static-PIE (linux ASLR, `mach build --pie`) has no `ld.so`, so it applies
+# its own ELF RELATIVE relocations before `main`. `_rt_relocate` is called from
+# `_rt_init` - only in a `--pie` build, gated by `$mach.build.pie` - with the program's
+# `envp` pointer (the kernel-supplied initial-stack value `_start` already captured).
+# It runs in `_rt_init` rather than `_start` so the entry point's raw-`rsp` asm is left
+# byte-identical; the auxiliary vector sits immediately after envp's NULL terminator, so
+# envp is all it needs to reach it.
+#
+# It is deliberately position-independent: it reads only `envp`, the stack region it
+# points into, and addresses it computes, never an absolute global, so it is correct
+# before any relocation has been applied (the ELF constants below are literal immediates
+# for the same reason). It recovers the load bias from the kernel auxiliary vector
+# (AT_PHDR vs the link-time PT_PHDR.p_vaddr), finds `.rela.dyn` through PT_DYNAMIC's
+# DT_RELA/DT_RELASZ, and slides every entry by the bias: `*(bias + r_offset) = bias +
+# r_addend`. The mach ELF PIE writer emits only R_*_RELATIVE entries, so every entry is
+# applied unconditionally.
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+
+# read a u64 at a raw runtime address. PIC: pure pointer arithmetic, no global.
+# ---
+# addr: the runtime address to read
+# ret:  the 8 bytes at `addr`, little-endian native
+fun load64(addr: usize) u64 {
+    val p: *u64 = addr::ptr::*u64;
+    ret p[0];
+}
+
+# read a u32 at a raw runtime address. PIC: pure pointer arithmetic, no global.
+# ---
+# addr: the runtime address to read
+# ret:  the 4 bytes at `addr`, little-endian native
+fun load32(addr: usize) u32 {
+    val p: *u32 = addr::ptr::*u32;
+    ret p[0];
+}
+
+# store a u64 at a raw runtime address. PIC: pure pointer arithmetic, no global.
+# ---
+# addr:  the runtime address to write
+# value: the 8 bytes to store
+fun store64(addr: usize, value: u64) {
+    val p: *u64 = addr::ptr::*u64;
+    p[0] = value;
+}
+
+# apply the image's ELF RELATIVE relocations, sliding each by the load bias recovered
+# from the kernel auxiliary vector
+#
+# `envp` points at the program's environment vector: envp[0..] then a NULL, immediately
+# after which the kernel placed the auxv (type/value u64 pairs terminated by AT_NULL).
+# PIC by construction - only `envp`, the region it points into, and computed addresses
+# are touched - so it runs correctly before any relocation is applied.
+# ---
+# envp: the program's envp pointer (the value `_start` stored into `_rt_envp`)
+#[symbol("_rt_relocate")]
+pub fun _rt_relocate(envp: *u64) {
+    # walk envp to its NULL terminator; the auxv begins one slot past it.
+    var idx: usize = 0;
+    for (envp[idx] != 0) { idx = idx + 1; }
+    idx = idx + 1;
+
+    # scan the auxv for the program-header location: AT_PHDR=3, AT_PHENT=4, AT_PHNUM=5,
+    # terminated by AT_NULL=0.
+    var at_phdr:  u64 = 0;
+    var at_phent: u64 = 0;
+    var at_phnum: u64 = 0;
+    for (envp[idx] != 0) {
+        val t: u64 = envp[idx];
+        val v: u64 = envp[idx + 1];
+        if (t == 3) { at_phdr  = v; }
+        if (t == 4) { at_phent = v; }
+        if (t == 5) { at_phnum = v; }
+        idx = idx + 2;
+    }
+    if (at_phdr == 0 || at_phnum == 0) { ret; }
+    if (at_phent == 0) { at_phent = 56; }   # Elf64_Phdr stride
+
+    # walk the program headers (Elf64_Phdr: p_type u32 @0, p_vaddr u64 @16): PT_PHDR=6
+    # yields the load bias (runtime AT_PHDR minus its link-time vaddr), PT_DYNAMIC=2 the
+    # .dynamic table.
+    var bias:      u64 = 0;
+    var dyn_va:    u64 = 0;
+    var have_bias: bool = false;
+    var p: u64 = 0;
+    for (p < at_phnum) {
+        val ph: usize = (at_phdr + p * at_phent)::usize;
+        val p_type:  u32 = load32(ph);
+        val p_vaddr: u64 = load64(ph + 16);
+        if (p_type == 6) { bias = at_phdr - p_vaddr; have_bias = true; }
+        if (p_type == 2) { dyn_va = p_vaddr; }
+        p = p + 1;
+    }
+    if (!have_bias || dyn_va == 0) { ret; }
+
+    # walk .dynamic (Elf64_Dyn: d_tag u64 @0, d_val u64 @8, 16-byte stride) for the
+    # .rela.dyn location and size: DT_RELA=7, DT_RELASZ=8, terminated by DT_NULL=0.
+    val dyn_addr: usize = (dyn_va + bias)::usize;
+    var rela:   u64 = 0;
+    var relasz: u64 = 0;
+    var d: usize = 0;
+    for (load64(dyn_addr + d * 16) != 0) {
+        val tag:  u64 = load64(dyn_addr + d * 16);
+        val dval: u64 = load64(dyn_addr + d * 16 + 8);
+        if (tag == 7) { rela   = dval; }
+        if (tag == 8) { relasz = dval; }
+        d = d + 1;
+    }
+    if (rela == 0 || relasz == 0) { ret; }
+
+    # apply each RELATIVE entry (Elf64_Rela: r_offset u64 @0, r_addend u64 @16, 24-byte
+    # stride): *(bias + r_offset) = bias + r_addend.
+    val rela_addr: usize = (rela + bias)::usize;
+    var off: u64 = 0;
+    for (off < relasz) {
+        val ent: usize = rela_addr + off::usize;
+        val r_offset: u64 = load64(ent);
+        val r_addend: u64 = load64(ent + 16);
+        store64((bias + r_offset)::usize, bias + r_addend);
+        off = off + 24;
+    }
+}

--- a/src/runtime/linux/riscv64.mach
+++ b/src/runtime/linux/riscv64.mach
@@ -30,6 +30,11 @@
 
 use os: std.system.os.linux.riscv64;
 
+# the static-PIE self-relocation pass, linked only into a `--pie` build.
+$if ($mach.build.pie == 1) {
+    use reloc: std.runtime.linux.reloc;
+}
+
 #[symbol("_rt_argc")]
 var _rt_argc: i64 = 0;
 #[symbol("_rt_argv")]
@@ -39,6 +44,12 @@ var _rt_envp: u64 = 0;
 
 #[symbol("_rt_init")]
 fun _rt_init() {
+    # a `--pie` build self-relocates here, before `main` and before any global pointer
+    # is read - the auxv is reached from envp, so `_start`'s raw-sp asm stays untouched
+    # (and a non-PIE build links none of this, leaving `_rt_init` byte-identical).
+    $if ($mach.build.pie == 1) {
+        reloc._rt_relocate(_rt_envp::ptr::*u64);
+    }
     os._envp = _rt_envp;
 }
 

--- a/src/runtime/linux/x86_64.mach
+++ b/src/runtime/linux/x86_64.mach
@@ -25,6 +25,11 @@
 
 use os: std.system.os.linux.x86_64;
 
+# the static-PIE self-relocation pass, linked only into a `--pie` build.
+$if ($mach.build.pie == 1) {
+    use reloc: std.runtime.linux.reloc;
+}
+
 #[symbol("_rt_argc")]
 var _rt_argc: i64 = 0;
 #[symbol("_rt_argv")]
@@ -34,6 +39,12 @@ var _rt_envp: u64 = 0;
 
 #[symbol("_rt_init")]
 fun _rt_init() {
+    # a `--pie` build self-relocates here, before `main` and before any global pointer
+    # is read - the auxv is reached from envp, so `_start`'s raw-rsp asm stays untouched
+    # (and a non-PIE build links none of this, leaving `_rt_init` byte-identical).
+    $if ($mach.build.pie == 1) {
+        reloc._rt_relocate(_rt_envp::ptr::*u64);
+    }
     os._envp = _rt_envp;
 }
 


### PR DESCRIPTION
Release dev -> main. dev is a clean superset of main (ahead 5, behind 0); the only unreleased changes are:
- chrono.format_duration + {:<N} left-align format spec (mach #1774, the output-overhaul primitives)
- static-PIE self-relocation runtime gated on $mach.build.pie (mach #1727)

Brings both to main so the mach repo (pinned at branch/main) can bump to them. Execution-verified: the self-reloc runs a relocated-pointer program correctly under ASLR on x86_64/aarch64/riscv64; the primitives are unit-tested. No other dev work is swept in.