### PR TITLE
release: process parallelism primitives (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- process: `exec.spawn_redirected` — spawn without waiting, with stdout and/or
+  stderr bound to caller-supplied descriptors (stdin stays inherited); and
+  `exec.wait_any` — block until any child exits, returning the reaped child's
+  handle. POSIX `wait(-1)` semantics on every platform (the windows layer
+  multi-waits across its tracked child handles) (#331).
+- system: `os.cpu_count` — the number of CPUs available to the process; linux
+  popcounts the `sched_getaffinity` mask (honouring taskset/cgroup cpusets),
+  darwin reads `hw.ncpu` via `__sysctl`, windows uses
+  `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)`. Never less than 1 (#331).
+
 ## [0.16.2] - 2026-06-28
 
 Enter aarch64 darwin executables through the `LC_MAIN` register convention and

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -124,6 +124,25 @@ pub fun spawn(pathname: str, argv: **u8, envp: **u8) Result[Child, str] {
     ret ok[Child, str](Child{pid: pid});
 }
 
+# spawn_redirected: start a process without waiting, with its stdout and/or
+# stderr bound to caller-supplied descriptors.
+#
+# the parent keeps ownership of the passed descriptors (close them after the
+# child exits, or after the spawn to let a pipe's read end see EOF); -1 leaves
+# that stream inherited. stdin is always inherited.
+# ---
+# pathname:  path to executable
+# argv:      null-terminated argument array
+# envp:      null-terminated environment array
+# stdout_fd: descriptor for the child's stdout, or -1 to inherit
+# stderr_fd: descriptor for the child's stderr, or -1 to inherit
+# ret:       child handle, or an error message
+pub fun spawn_redirected(pathname: str, argv: **u8, envp: **u8, stdout_fd: i32, stderr_fd: i32) Result[Child, str] {
+    val pid: i64 = os.spawn_redirected(pathname, argv, envp, -1, stdout_fd, stderr_fd);
+    if (pid < 0) { ret err[Child, str]("spawn failed"); }
+    ret ok[Child, str](Child{pid: pid});
+}
+
 # wait: wait for a child process to exit.
 # ---
 # child: child handle from spawn
@@ -133,6 +152,23 @@ pub fun wait(child: Child) Result[ExitStatus, str] {
     val r: i64 = os.wait_pid(child.pid, ?wstatus, 0);
     if (r < 0) { ret err[ExitStatus, str]("wait failed"); }
     ret ok[ExitStatus, str](ExitStatus{raw: wstatus});
+}
+
+# wait_any: block until any child of this process exits.
+#
+# POSIX wait(-1) semantics on every platform (the windows layer emulates the
+# -1 pid by waiting across its tracked child handles). the returned handle
+# identifies which child was reaped, so a caller juggling several children can
+# map the exit back to its work item. errs when there is no child to wait for.
+# ---
+# out_status: receives the reaped child's exit status
+# ret:        the reaped child's handle, or an error message
+pub fun wait_any(out_status: *ExitStatus) Result[Child, str] {
+    var wstatus: i32 = 0;
+    val pid: i64 = os.wait_pid(-1, ?wstatus, 0);
+    if (pid <= 0) { ret err[Child, str]("wait failed"); }
+    out_status.raw = wstatus;
+    ret ok[Child, str](Child{pid: pid});
 }
 
 # exited: check if the process exited normally.
@@ -364,5 +400,76 @@ test "exec: repeated spawns stay correct" {
         if (code(s) != 0) { ret 1; }
         i = i + 1;
     }
+    ret 0;
+}
+
+var redir_buf: [64]u8;
+
+test "std.process.exec.spawn_redirected:pipes_child_stdout" {
+    var fds: [2]i32;
+    if (os.pipe(?fds[0]) < 0) { ret 1; }
+
+    var argv: [4]usize = argv_echo();
+    val sr: Result[Child, str] = spawn_redirected(prog_echo(), (?argv[0])::**u8, nil, fds[1], -1);
+    if (is_err[Child, str](sr)) {
+        os.close(fds[0]);
+        os.close(fds[1]);
+        ret 1;
+    }
+    # closing the parent's write end lets read see EOF once the child exits
+    os.close(fds[1]);
+
+    var total: usize = 0;
+    for (true) {
+        val n: i64 = os.read(fds[0], ((?redir_buf[0])::usize + total)::*u8, 64 - total);
+        if (n <= 0) { brk; }
+        total = total + n::usize;
+    }
+    os.close(fds[0]);
+
+    val wr: Result[ExitStatus, str] = wait(unwrap_ok[Child, str](sr));
+    if (is_err[ExitStatus, str](wr)) { ret 1; }
+    if (code(unwrap_ok[ExitStatus, str](wr)) != 0) { ret 1; }
+
+    if (total != ECHO_LEN) { ret 1; }
+    if (redir_buf[0] != 'h') { ret 1; }
+    if (redir_buf[4] != 'o') { ret 1; }
+    ret 0;
+}
+
+test "std.process.exec.wait_any:reaps_each_child_once" {
+    var argv_a: [4]usize = argv_ok();
+    val ra: Result[Child, str] = spawn(prog_ok(), (?argv_a[0])::**u8, nil);
+    if (is_err[Child, str](ra)) { ret 1; }
+    var argv_b: [4]usize = argv_ok();
+    val rb: Result[Child, str] = spawn(prog_ok(), (?argv_b[0])::**u8, nil);
+    if (is_err[Child, str](rb)) { ret 1; }
+    val pa: i64 = unwrap_ok[Child, str](ra).pid;
+    val pb: i64 = unwrap_ok[Child, str](rb).pid;
+
+    var st: ExitStatus;
+    st.raw = 0;
+    val w1: Result[Child, str] = wait_any(?st);
+    if (is_err[Child, str](w1)) { ret 1; }
+    if (!exited(st) || code(st) != 0) { ret 1; }
+    val p1: i64 = unwrap_ok[Child, str](w1).pid;
+
+    val w2: Result[Child, str] = wait_any(?st);
+    if (is_err[Child, str](w2)) { ret 1; }
+    if (!exited(st) || code(st) != 0) { ret 1; }
+    val p2: i64 = unwrap_ok[Child, str](w2).pid;
+
+    # both children reaped, each exactly once, in either order
+    if (p1 == p2) { ret 1; }
+    if (p1 != pa && p1 != pb) { ret 1; }
+    if (p2 != pa && p2 != pb) { ret 1; }
+    ret 0;
+}
+
+test "std.process.exec.wait_any:errs_with_no_children" {
+    var st: ExitStatus;
+    st.raw = 0;
+    val w: Result[Child, str] = wait_any(?st);
+    if (!is_err[Child, str](w)) { ret 1; }
     ret 0;
 }

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -143,6 +143,7 @@ fwd impl.spawn_redirected;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;
+fwd impl.cpu_count;
 fwd impl.getcwd;
 fwd impl.getenv;
 fwd impl.environ;
@@ -282,3 +283,9 @@ pub fun message(code: i64) str {
     }
     ret impl.error_message(code);
 }
+
+test "std.system.os.cpu_count:at_least_one" {
+    if (impl.cpu_count() < 1) { ret 1; }
+    ret 0;
+}
+

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -132,6 +132,7 @@ fwd impl.spawn_redirected;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;
+fwd impl.cpu_count;
 fwd impl.getcwd;
 fwd impl.getenv;
 fwd impl.environ;

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -131,6 +131,7 @@ fwd shared.spawn;
 fwd shared.spawn_redirected;
 fwd shared.getpid;
 fwd shared.sleep;
+fwd shared.cpu_count;
 fwd shared.getcwd;
 fwd shared.getenv;
 fwd shared.fork;

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -52,6 +52,7 @@ val SYS_GETTIMEOFDAY:     usize = 116;
 val SYS_CLOCK_GETTIME:    usize = 427;
 val SYS_GETPID:           usize = 20;
 val SYS_KILL:             usize = 37;
+val SYS___SYSCTL:         usize = 202;
 val SYS___GETCWD:         usize = 304;
 val SYS_GETENTROPY:       usize = 500;
 val SYS_SOCKET:           usize = 97;
@@ -928,6 +929,24 @@ pub fun sleep(nsec: i64) {
     tv.tv_sec = sec;
     tv.tv_usec = usec::i32;
     syscall5(SYS_SELECT, 0, 0, 0, 0, (?tv)::usize);
+}
+
+# cpu_count: the number of CPUs available to this process.
+#
+# reads `hw.ncpu` through the __sysctl syscall (mib [CTL_HW, HW_NCPU]).
+# never returns less than 1.
+# ---
+# ret: usable CPU count (>= 1)
+pub fun cpu_count() i64 {
+    # mib { CTL_HW = 6, HW_NCPU = 3 }
+    var mib: [2]i32;
+    mib[0] = 6;
+    mib[1] = 3;
+    var ncpu: i32   = 0;
+    var len:  usize = 4;
+    val r: i64 = syscall6(SYS___SYSCTL, (?mib[0])::usize, 2, (?ncpu)::usize, (?len)::usize, 0, 0);
+    if (r < 0 || ncpu < 1) { ret 1; }
+    ret ncpu::i64;
 }
 
 # getcwd: get the current working directory.

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -132,6 +132,7 @@ fwd shared.spawn;
 fwd shared.spawn_redirected;
 fwd shared.getpid;
 fwd shared.sleep;
+fwd shared.cpu_count;
 fwd shared.getcwd;
 fwd shared.getenv;
 fwd shared.fork;

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -144,6 +144,7 @@ fwd impl.spawn_redirected;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;
+fwd impl.cpu_count;
 fwd impl.getcwd;
 fwd impl.getenv;
 fwd impl.environ;

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -259,6 +259,7 @@ fwd shared.spawn_redirected;
 fwd shared.getpid;
 fwd shared.pipe;
 fwd shared.sleep;
+fwd shared.cpu_count;
 fwd shared.getcwd;
 fwd shared.getenv;
 fwd shared.fork;

--- a/src/system/os/linux/riscv64.mach
+++ b/src/system/os/linux/riscv64.mach
@@ -256,6 +256,7 @@ fwd shared.spawn_redirected;
 fwd shared.getpid;
 fwd shared.pipe;
 fwd shared.sleep;
+fwd shared.cpu_count;
 fwd shared.getcwd;
 fwd shared.getenv;
 fwd shared.fork;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -44,6 +44,7 @@ $if ($mach.build.arch == $mach.arch.x86_64) {
     val SYS_EXIT:          usize = 60;
     val SYS_EXIT_GROUP:    usize = 231;
     val SYS_WAIT4:         usize = 61;
+    val SYS_SCHED_GETAFFINITY: usize = 204;
     val SYS_PIPE2:         usize = 293;
     val SYS_GETCWD:        usize = 79;
     val SYS_MLOCK:         usize = 149;
@@ -94,6 +95,7 @@ $or ($mach.build.arch == $mach.arch.aarch64) {
     val SYS_EXIT:          usize = 93;
     val SYS_EXIT_GROUP:    usize = 94;
     val SYS_WAIT4:         usize = 260;
+    val SYS_SCHED_GETAFFINITY: usize = 123;
     val SYS_PIPE2:         usize = 59;
     val SYS_GETCWD:        usize = 17;
     val SYS_MLOCK:         usize = 228;
@@ -144,6 +146,7 @@ $or ($mach.build.arch == $mach.arch.riscv64) {
     val SYS_EXIT:          usize = 93;
     val SYS_EXIT_GROUP:    usize = 94;
     val SYS_WAIT4:         usize = 260;
+    val SYS_SCHED_GETAFFINITY: usize = 123;
     val SYS_PIPE2:         usize = 59;
     val SYS_GETCWD:        usize = 17;
     val SYS_MLOCK:         usize = 228;
@@ -1551,6 +1554,36 @@ pub fun sleep(nsec: i64) {
     req.tv_sec = nsec / 1000000000;
     req.tv_nsec = nsec % 1000000000;
     syscall2(SYS_NANOSLEEP, (?req)::usize, 0);
+}
+
+# cpu_count: the number of CPUs available to this process.
+#
+# popcounts the sched_getaffinity mask, so taskset/cgroup cpuset restrictions
+# are honoured; the kernel reports the mask size it wrote in the return value.
+# never returns less than 1.
+# ---
+# ret: usable CPU count (>= 1)
+pub fun cpu_count() i64 {
+    # 128 bytes covers 1024 CPUs
+    var mask: [128]u8;
+    var i: usize = 0;
+    for (i < 128) { mask[i] = 0; i = i + 1; }
+
+    val written: i64 = syscall3(SYS_SCHED_GETAFFINITY, 0, 128, (?mask[0])::usize);
+    if (written <= 0) { ret 1; }
+
+    var n: i64 = 0;
+    i = 0;
+    for (i < written::usize && i < 128) {
+        var b: u8 = mask[i];
+        for (b != 0) {
+            n = n + (b & 1)::i64;
+            b = b >> 1;
+        }
+        i = i + 1;
+    }
+    if (n < 1) { ret 1; }
+    ret n;
 }
 
 # getcwd: get the current working directory.

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -245,6 +245,7 @@ fwd shared.spawn_redirected;
 fwd shared.getpid;
 fwd shared.pipe;
 fwd shared.sleep;
+fwd shared.cpu_count;
 fwd shared.getcwd;
 fwd shared.getenv;
 fwd shared.fork;

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -120,6 +120,7 @@ fwd impl.spawn_redirected;
 fwd impl.getpid;
 fwd impl.pipe;
 fwd impl.sleep;
+fwd impl.cpu_count;
 fwd impl.getcwd;
 fwd impl.getenv;
 fwd impl.temp_dir;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -192,6 +192,7 @@ ext fun HeapAlloc(p0: isize, p1: u32, p2: usize) ptr;
 ext fun HeapFree(p0: isize, p1: u32, p2: ptr) i32;
 ext fun HeapReAlloc(p0: isize, p1: u32, p2: ptr, p3: usize) ptr;
 ext fun GetSystemInfo(p0: *u8);
+ext fun GetActiveProcessorCount(p0: u16) u32;
 
 ext fun CreateFileA(p0: *u8, p1: u32, p2: u32, p3: ptr, p4: u32, p5: u32, p6: isize) isize;
 ext fun ReadFile(p0: isize, p1: *u8, p2: u32, p3: *u32, p4: ptr) i32;
@@ -1733,6 +1734,19 @@ pub fun sleep(nsec: i64) {
     if (nsec <= 0) { ret; }
     val ms: u32 = (nsec / 1000000)::u32;
     Sleep(ms);
+}
+
+# cpu_count: the number of CPUs available to this process.
+#
+# GetActiveProcessorCount over all processor groups, so machines with more
+# than 64 logical processors report fully. never returns less than 1.
+# ---
+# ret: usable CPU count (>= 1)
+pub fun cpu_count() i64 {
+    # ALL_PROCESSOR_GROUPS = 0xffff
+    val n: u32 = GetActiveProcessorCount(0xffff);
+    if (n < 1) { ret 1; }
+    ret n::i64;
 }
 
 # getcwd: get the current working directory.

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -119,6 +119,7 @@ fwd shared.spawn_redirected;
 fwd shared.getpid;
 fwd shared.pipe;
 fwd shared.sleep;
+fwd shared.cpu_count;
 fwd shared.getcwd;
 fwd shared.getenv;
 fwd shared.temp_dir;


### PR DESCRIPTION
Sweep dev → main: public `exec.spawn_redirected` + `exec.wait_any` and `os.cpu_count` (#331, PR #332) — the mach-std side of briar-systems/mach#1788's parallel test runner (briar-systems/mach#1791). mach consumes this via a `mach.lock` bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011wvvqFRodZG3ZgLqerptnr