### PR TITLE
fix(data/json): escape strings and keys on emit (RFC 8259)

### DIFF
--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -2,7 +2,16 @@
 #
 # parses JSON text into a tree of Value nodes. strings are zero-copy
 # pointers into the original input buffer (escape sequences are not
-# unescaped). the caller must keep the input alive while values are in use.
+# unescaped: str_val holds the raw on-wire bytes). the caller must keep the
+# input alive while values are in use.
+#
+# WARNING: parse and emit disagree on what a string's bytes mean. parse
+# yields raw wire bytes with escapes intact; emit treats str_val as logical
+# bytes and re-escapes '"', '\', and control bytes. so emitting a tree that
+# came from parse double-escapes any wire escapes it contained (parse "a\nb"
+# -> str_val a\nb -> emit "a\\nb"). build trees with make_string for
+# emission; do not round-trip parse -> emit for strings holding escapes.
+# tracked in mach-std#340.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -217,6 +226,12 @@ pub fun value_find(v: *Value, key: str) *Value {
 }
 
 # emit: emit a Value as JSON text into a buffer.
+#
+# strings and object keys are escaped as RFC 8259 string bodies: '"', '\',
+# and control bytes 0x00-0x1F are escaped (short escapes \b \t \n \f \r, else
+# \u00xx); other bytes, including valid UTF-8, are written verbatim. str_val
+# and keys are treated as logical bytes, so emitting a PARSED tree double-
+# escapes any escapes the source contained -- see the file header (mach-std#340).
 # ---
 # v:   value to emit
 # buf: destination buffer
@@ -560,14 +575,6 @@ fun emit_byte(e: *Emitter, c: u8) {
     e.pos = e.pos + 1;
 }
 
-fun emit_bytes(e: *Emitter, s: *u8, slen: usize) {
-    var i: usize = 0;
-    for (i < slen) {
-        emit_byte(e, s[i]);
-        i = i + 1;
-    }
-}
-
 fun emit_str(e: *Emitter, s: str) {
     var i: usize = 0;
     for (s[i] != 0) {
@@ -607,6 +614,43 @@ fun emit_u64(e: *Emitter, n: u64) {
     }
 }
 
+fun hex_digit(n: u8) u8 {
+    if (n < 10) { ret n + '0'; }
+    ret (n - 10) + 'a';
+}
+
+fun emit_u_escape(e: *Emitter, c: u8) {
+    emit_byte(e, '\\');
+    emit_byte(e, 'u');
+    emit_byte(e, '0');
+    emit_byte(e, '0');
+    emit_byte(e, hex_digit(c / 16));
+    emit_byte(e, hex_digit(c % 16));
+}
+
+# writes s[0..slen) as an RFC 8259 string body (no surrounding quotes),
+# escaping '"', '\', and control bytes 0x00-0x1F. controls use the short
+# escapes \b \t \n \f \r where defined, else \u00xx; all other bytes,
+# including valid UTF-8, are written verbatim (this is NOT #338's ensure-ascii
+# policy). s is treated as logical bytes -- see emit() on the parse/emit
+# representation asymmetry.
+fun emit_escaped(e: *Emitter, s: *u8, slen: usize) {
+    var i: usize = 0;
+    for (i < slen) {
+        val c: u8 = s[i];
+        i = i + 1;
+        if (c == '"')  { emit_byte(e, '\\'); emit_byte(e, '"');  cnt; }
+        if (c == '\\') { emit_byte(e, '\\'); emit_byte(e, '\\'); cnt; }
+        if (c == 0x08) { emit_byte(e, '\\'); emit_byte(e, 'b');  cnt; }
+        if (c == 0x09) { emit_byte(e, '\\'); emit_byte(e, 't');  cnt; }
+        if (c == 0x0a) { emit_byte(e, '\\'); emit_byte(e, 'n');  cnt; }
+        if (c == 0x0c) { emit_byte(e, '\\'); emit_byte(e, 'f');  cnt; }
+        if (c == 0x0d) { emit_byte(e, '\\'); emit_byte(e, 'r');  cnt; }
+        if (c < 0x20)  { emit_u_escape(e, c); cnt; }
+        emit_byte(e, c);
+    }
+}
+
 fun emit_value(e: *Emitter, v: *Value) {
     if (v.kind == NULL) {
         emit_str(e, "null");
@@ -629,7 +673,7 @@ fun emit_value(e: *Emitter, v: *Value) {
 
     if (v.kind == STRING) {
         emit_byte(e, '"');
-        emit_bytes(e, v.str_val::*u8, v.str_len);
+        emit_escaped(e, v.str_val::*u8, v.str_len);
         emit_byte(e, '"');
         ret;
     }
@@ -652,7 +696,7 @@ fun emit_value(e: *Emitter, v: *Value) {
         for (i < v.count) {
             if (i > 0) { emit_byte(e, ','); }
             emit_byte(e, '"');
-            emit_bytes(e, v.keys[i]::*u8, v.keys_len[i]);
+            emit_escaped(e, v.keys[i]::*u8, v.keys_len[i]);
             emit_byte(e, '"');
             emit_byte(e, ':');
             emit_value(e, ?v.children[i]);

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -974,3 +974,105 @@ test "json: whitespace tolerance" {
     if (v.count != 1) { ret 1; }
     ret 0;
 }
+
+test "json: emit escapes quotes and backslashes" {
+    # logical string: a"b\c
+    var raw: [5]u8 = [5]u8{'a', '"', 'b', '\\', 'c'};
+    val v: Value = make_string(((?raw[0])::usize)::str, 5);
+    var buf: [16]u8;
+    val n: usize = emit(?v, ?buf[0], 16);
+    # expected: "a\"b\\c" (9 bytes)
+    if (n != 9) { ret 1; }
+    if (buf[0] != '"')  { ret 1; }
+    if (buf[1] != 'a')  { ret 1; }
+    if (buf[2] != '\\') { ret 1; }
+    if (buf[3] != '"')  { ret 1; }
+    if (buf[4] != 'b')  { ret 1; }
+    if (buf[5] != '\\') { ret 1; }
+    if (buf[6] != '\\') { ret 1; }
+    if (buf[7] != 'c')  { ret 1; }
+    if (buf[8] != '"')  { ret 1; }
+    ret 0;
+}
+
+test "json: emit escapes control bytes" {
+    # logical: 0x08 0x09 0x0a 0x0c 0x0d 0x01
+    var raw: [6]u8 = [6]u8{0x08, 0x09, 0x0a, 0x0c, 0x0d, 0x01};
+    val v: Value = make_string(((?raw[0])::usize)::str, 6);
+    var buf: [32]u8;
+    val n: usize = emit(?v, ?buf[0], 32);
+    # expected: "\b\t\n\f\r" (18 bytes)
+    if (n != 18) { ret 1; }
+    if (buf[0]  != '"')  { ret 1; }
+    if (buf[1]  != '\\') { ret 1; }
+    if (buf[2]  != 'b')  { ret 1; }
+    if (buf[3]  != '\\') { ret 1; }
+    if (buf[4]  != 't')  { ret 1; }
+    if (buf[5]  != '\\') { ret 1; }
+    if (buf[6]  != 'n')  { ret 1; }
+    if (buf[7]  != '\\') { ret 1; }
+    if (buf[8]  != 'f')  { ret 1; }
+    if (buf[9]  != '\\') { ret 1; }
+    if (buf[10] != 'r')  { ret 1; }
+    if (buf[11] != '\\') { ret 1; }
+    if (buf[12] != 'u')  { ret 1; }
+    if (buf[13] != '0')  { ret 1; }
+    if (buf[14] != '0')  { ret 1; }
+    if (buf[15] != '0')  { ret 1; }
+    if (buf[16] != '1')  { ret 1; }
+    if (buf[17] != '"')  { ret 1; }
+    ret 0;
+}
+
+test "json: emit escaped output reparses" {
+    var a: allo.Allocator;
+    page.make(?a);
+    # logical: x " \ 0x01 y
+    var raw: [5]u8 = [5]u8{'x', '"', '\\', 0x01, 'y'};
+    val v: Value = make_string(((?raw[0])::usize)::str, 5);
+    var buf: [32]u8;
+    val n: usize = emit(?v, ?buf[0], 32);
+    # the emitted document must parse cleanly through the module's own parser
+    val r: Result[Value, str] = parse(?buf[0], n, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val rv: Value = unwrap_ok[Value, str](r);
+    if (rv.kind != STRING) { ret 1; }
+    ret 0;
+}
+
+test "json: emit escapes object keys" {
+    var a: allo.Allocator;
+    page.make(?a);
+    # key: a"b   value: 1
+    var keyraw: [3]u8 = [3]u8{'a', '"', 'b'};
+    var keys: [1]str = [1]str{((?keyraw[0])::usize)::str};
+    var klens: [1]usize = [1]usize{3};
+    var children: [1]Value;
+    children[0] = make_number(1);
+    var o: Value = make_object();
+    o.keys = ?keys[0];
+    o.keys_len = ?klens[0];
+    o.children = ?children[0];
+    o.count = 1;
+    var buf: [32]u8;
+    val n: usize = emit(?o, ?buf[0], 32);
+    # expected: {"a\"b":1} (10 bytes)
+    if (n != 10) { ret 1; }
+    if (buf[0] != '{')  { ret 1; }
+    if (buf[1] != '"')  { ret 1; }
+    if (buf[2] != 'a')  { ret 1; }
+    if (buf[3] != '\\') { ret 1; }
+    if (buf[4] != '"')  { ret 1; }
+    if (buf[5] != 'b')  { ret 1; }
+    if (buf[6] != '"')  { ret 1; }
+    if (buf[7] != ':')  { ret 1; }
+    if (buf[8] != '1')  { ret 1; }
+    if (buf[9] != '}')  { ret 1; }
+    # and the emitted object re-parses cleanly
+    val r: Result[Value, str] = parse(?buf[0], n, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val rv: Value = unwrap_ok[Value, str](r);
+    if (rv.kind != OBJECT) { ret 1; }
+    if (rv.count != 1) { ret 1; }
+    ret 0;
+}


### PR DESCRIPTION
Closes #337.

## Problem

`emit_value` wrote string values and object keys as raw bytes between quotes, so any value
holding a `"`, `\`, or control byte (0x00-0x1F) emitted invalid JSON (e.g. `say "hi"` ->
`"say "hi""`).

## Fix

`emit_escaped` writes a string body escaping `"` -> `\"`, `\` -> `\\`, and control bytes via
the short escapes `\b \t \n \f \r` where JSON defines them, else `\u00xx`. All other bytes,
including valid UTF-8, pass through verbatim per RFC 8259. Applied to both the STRING value
path and the object-key path (the issue only named values; keys had the identical bug).

This is the minimal structural escaping. It deliberately does **not** adopt mach.cli.json`s
UTF-8-validating / ensure-ascii policy — that unification is #338.

## Representation asymmetry (documented, tracked as #340)

The parser stores string values as raw on-wire bytes (escapes intact, zero-copy); emit now
treats them as logical bytes. So emitting a *parsed* tree double-escapes any wire escapes it
held. This asymmetry is documented loudly in the file header and `emit` doc, and the deeper
contract decision (parser-side decode vs decode-on-demand accessor) is filed as #340, linked
to #337/#338.

## Tests

- exact-byte assertions for quote/backslash escaping
- exact-byte assertions for control bytes (named short escapes + `\u00xx`)
- emitted output for a tree with quote+backslash+control re-parses cleanly through the
  module`s own parser
- object-key escaping, exact bytes + clean re-parse

`mach build .` and `mach test .` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)