### PR TITLE
release: JSON emit escaping + auxv page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   darwin reads `hw.ncpu` via `__sysctl`, windows uses
   `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)`. Never less than 1 (#331).
 
+### Fixed
+
+- system: `os.page_size` on linux now returns the runtime `AT_PAGESZ` the
+  entrypoint captures from the auxiliary vector at startup, instead of a
+  hardcoded 4096 — correct on aarch64 kernels configured for 16 KiB or 64 KiB
+  pages. The runtime publishes the auxv page size into the OS layer
+  (`capture_pagesz`) right after `_envp`, post-relocation, giving page_size() one
+  source of truth; `std.runtime.linux.reloc` keeps its own pre-relocation read
+  for the RELRO mprotect (#336).
+
 ## [0.16.2] - 2026-06-28
 
 Enter aarch64 darwin executables through the `LC_MAIN` register convention and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pages. The runtime publishes the auxv page size into the OS layer
   (`capture_pagesz`) right after `_envp`, post-relocation, giving page_size() one
   source of truth; `std.runtime.linux.reloc` keeps its own pre-relocation read
-  for the RELRO mprotect (#336).
+  for the RELRO mprotect. `AT_PAGESZ` is mandatory on linux, so page_size()
+  panics when it is unavailable rather than fabricating a default (#336).
 
 ## [0.16.2] - 2026-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- chrono: `format_duration` — renders a `Duration` into a caller-supplied buffer
+  as a human string (`0ms`, `<1ms`, `Nus`, `Nms`, `N.Ns`, `NmNs`; minutes is the
+  top band, negatives carry a leading `-`), returning the null-terminated `str`
+  aliasing the buffer or `nil` when capacity is short. A 24-byte buffer holds
+  every i64 duration; ASCII-only, no allocation (mach#1774).
+- format: `{:<N}` left-align spec flag — a `<` immediately after `:` writes the
+  value then space-pads on the right; the zero flag is ignored for left-align.
+  Right-align specs (`{:N}`, `{:0N}`, `{:08x}`) are byte-identical (mach#1774).
+- runtime/linux: static-PIE self-relocation — a no-libc `mach build --pie` image
+  applies its own ELF `R_*_RELATIVE` relocations before `main`. `_rt_relocate`
+  recovers the load bias from the kernel auxv (`AT_PHDR` vs the link-time
+  `PT_PHDR`) and slides every `.rela.dyn` entry; it is position-independent by
+  construction, runs from `_rt_init`, and is gated on `$mach.build.pie` so a
+  non-PIE build links none of it (mach#1727).
+- runtime/linux: `PT_GNU_RELRO` re-protection — after applying the RELATIVE
+  relocations, `_rt_relocate` `mprotect`s the linker's `PT_GNU_RELRO` region
+  (relocated constants in `.rodata`, mapped writable for self-relocation) back to
+  `PROT_READ`, so those constants are read-only before `main`. Page-exact and
+  reloc-independent: it captures `AT_PAGESZ`, gates on the region being a whole
+  number of runtime pages, and skips (leaving it writable) on a kernel page
+  larger than the image's 4 KiB segment alignment (mach#1778).
 - process: `exec.spawn_redirected` — spawn without waiting, with stdout and/or
   stderr bound to caller-supplied descriptors (stdin stays inherited); and
   `exec.wait_any` — block until any child exits, returning the reaped child's

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -2,7 +2,16 @@
 #
 # parses JSON text into a tree of Value nodes. strings are zero-copy
 # pointers into the original input buffer (escape sequences are not
-# unescaped). the caller must keep the input alive while values are in use.
+# unescaped: str_val holds the raw on-wire bytes). the caller must keep the
+# input alive while values are in use.
+#
+# WARNING: parse and emit disagree on what a string's bytes mean. parse
+# yields raw wire bytes with escapes intact; emit treats str_val as logical
+# bytes and re-escapes '"', '\', and control bytes. so emitting a tree that
+# came from parse double-escapes any wire escapes it contained (parse "a\nb"
+# -> str_val a\nb -> emit "a\\nb"). build trees with make_string for
+# emission; do not round-trip parse -> emit for strings holding escapes.
+# tracked in mach-std#340.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -217,6 +226,12 @@ pub fun value_find(v: *Value, key: str) *Value {
 }
 
 # emit: emit a Value as JSON text into a buffer.
+#
+# strings and object keys are escaped as RFC 8259 string bodies: '"', '\',
+# and control bytes 0x00-0x1F are escaped (short escapes \b \t \n \f \r, else
+# \u00xx); other bytes, including valid UTF-8, are written verbatim. str_val
+# and keys are treated as logical bytes, so emitting a PARSED tree double-
+# escapes any escapes the source contained -- see the file header (mach-std#340).
 # ---
 # v:   value to emit
 # buf: destination buffer
@@ -560,14 +575,6 @@ fun emit_byte(e: *Emitter, c: u8) {
     e.pos = e.pos + 1;
 }
 
-fun emit_bytes(e: *Emitter, s: *u8, slen: usize) {
-    var i: usize = 0;
-    for (i < slen) {
-        emit_byte(e, s[i]);
-        i = i + 1;
-    }
-}
-
 fun emit_str(e: *Emitter, s: str) {
     var i: usize = 0;
     for (s[i] != 0) {
@@ -607,6 +614,43 @@ fun emit_u64(e: *Emitter, n: u64) {
     }
 }
 
+fun hex_digit(n: u8) u8 {
+    if (n < 10) { ret n + '0'; }
+    ret (n - 10) + 'a';
+}
+
+fun emit_u_escape(e: *Emitter, c: u8) {
+    emit_byte(e, '\\');
+    emit_byte(e, 'u');
+    emit_byte(e, '0');
+    emit_byte(e, '0');
+    emit_byte(e, hex_digit(c / 16));
+    emit_byte(e, hex_digit(c % 16));
+}
+
+# writes s[0..slen) as an RFC 8259 string body (no surrounding quotes),
+# escaping '"', '\', and control bytes 0x00-0x1F. controls use the short
+# escapes \b \t \n \f \r where defined, else \u00xx; all other bytes,
+# including valid UTF-8, are written verbatim (this is NOT #338's ensure-ascii
+# policy). s is treated as logical bytes -- see emit() on the parse/emit
+# representation asymmetry.
+fun emit_escaped(e: *Emitter, s: *u8, slen: usize) {
+    var i: usize = 0;
+    for (i < slen) {
+        val c: u8 = s[i];
+        i = i + 1;
+        if (c == '"')  { emit_byte(e, '\\'); emit_byte(e, '"');  cnt; }
+        if (c == '\\') { emit_byte(e, '\\'); emit_byte(e, '\\'); cnt; }
+        if (c == 0x08) { emit_byte(e, '\\'); emit_byte(e, 'b');  cnt; }
+        if (c == 0x09) { emit_byte(e, '\\'); emit_byte(e, 't');  cnt; }
+        if (c == 0x0a) { emit_byte(e, '\\'); emit_byte(e, 'n');  cnt; }
+        if (c == 0x0c) { emit_byte(e, '\\'); emit_byte(e, 'f');  cnt; }
+        if (c == 0x0d) { emit_byte(e, '\\'); emit_byte(e, 'r');  cnt; }
+        if (c < 0x20)  { emit_u_escape(e, c); cnt; }
+        emit_byte(e, c);
+    }
+}
+
 fun emit_value(e: *Emitter, v: *Value) {
     if (v.kind == NULL) {
         emit_str(e, "null");
@@ -629,7 +673,7 @@ fun emit_value(e: *Emitter, v: *Value) {
 
     if (v.kind == STRING) {
         emit_byte(e, '"');
-        emit_bytes(e, v.str_val::*u8, v.str_len);
+        emit_escaped(e, v.str_val::*u8, v.str_len);
         emit_byte(e, '"');
         ret;
     }
@@ -652,7 +696,7 @@ fun emit_value(e: *Emitter, v: *Value) {
         for (i < v.count) {
             if (i > 0) { emit_byte(e, ','); }
             emit_byte(e, '"');
-            emit_bytes(e, v.keys[i]::*u8, v.keys_len[i]);
+            emit_escaped(e, v.keys[i]::*u8, v.keys_len[i]);
             emit_byte(e, '"');
             emit_byte(e, ':');
             emit_value(e, ?v.children[i]);

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -974,3 +974,105 @@ test "json: whitespace tolerance" {
     if (v.count != 1) { ret 1; }
     ret 0;
 }
+
+test "json: emit escapes quotes and backslashes" {
+    # logical string: a"b\c
+    var raw: [5]u8 = [5]u8{'a', '"', 'b', '\\', 'c'};
+    val v: Value = make_string(((?raw[0])::usize)::str, 5);
+    var buf: [16]u8;
+    val n: usize = emit(?v, ?buf[0], 16);
+    # expected: "a\"b\\c" (9 bytes)
+    if (n != 9) { ret 1; }
+    if (buf[0] != '"')  { ret 1; }
+    if (buf[1] != 'a')  { ret 1; }
+    if (buf[2] != '\\') { ret 1; }
+    if (buf[3] != '"')  { ret 1; }
+    if (buf[4] != 'b')  { ret 1; }
+    if (buf[5] != '\\') { ret 1; }
+    if (buf[6] != '\\') { ret 1; }
+    if (buf[7] != 'c')  { ret 1; }
+    if (buf[8] != '"')  { ret 1; }
+    ret 0;
+}
+
+test "json: emit escapes control bytes" {
+    # logical: 0x08 0x09 0x0a 0x0c 0x0d 0x01
+    var raw: [6]u8 = [6]u8{0x08, 0x09, 0x0a, 0x0c, 0x0d, 0x01};
+    val v: Value = make_string(((?raw[0])::usize)::str, 6);
+    var buf: [32]u8;
+    val n: usize = emit(?v, ?buf[0], 32);
+    # expected: "\b\t\n\f\r" (18 bytes)
+    if (n != 18) { ret 1; }
+    if (buf[0]  != '"')  { ret 1; }
+    if (buf[1]  != '\\') { ret 1; }
+    if (buf[2]  != 'b')  { ret 1; }
+    if (buf[3]  != '\\') { ret 1; }
+    if (buf[4]  != 't')  { ret 1; }
+    if (buf[5]  != '\\') { ret 1; }
+    if (buf[6]  != 'n')  { ret 1; }
+    if (buf[7]  != '\\') { ret 1; }
+    if (buf[8]  != 'f')  { ret 1; }
+    if (buf[9]  != '\\') { ret 1; }
+    if (buf[10] != 'r')  { ret 1; }
+    if (buf[11] != '\\') { ret 1; }
+    if (buf[12] != 'u')  { ret 1; }
+    if (buf[13] != '0')  { ret 1; }
+    if (buf[14] != '0')  { ret 1; }
+    if (buf[15] != '0')  { ret 1; }
+    if (buf[16] != '1')  { ret 1; }
+    if (buf[17] != '"')  { ret 1; }
+    ret 0;
+}
+
+test "json: emit escaped output reparses" {
+    var a: allo.Allocator;
+    page.make(?a);
+    # logical: x " \ 0x01 y
+    var raw: [5]u8 = [5]u8{'x', '"', '\\', 0x01, 'y'};
+    val v: Value = make_string(((?raw[0])::usize)::str, 5);
+    var buf: [32]u8;
+    val n: usize = emit(?v, ?buf[0], 32);
+    # the emitted document must parse cleanly through the module's own parser
+    val r: Result[Value, str] = parse(?buf[0], n, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val rv: Value = unwrap_ok[Value, str](r);
+    if (rv.kind != STRING) { ret 1; }
+    ret 0;
+}
+
+test "json: emit escapes object keys" {
+    var a: allo.Allocator;
+    page.make(?a);
+    # key: a"b   value: 1
+    var keyraw: [3]u8 = [3]u8{'a', '"', 'b'};
+    var keys: [1]str = [1]str{((?keyraw[0])::usize)::str};
+    var klens: [1]usize = [1]usize{3};
+    var children: [1]Value;
+    children[0] = make_number(1);
+    var o: Value = make_object();
+    o.keys = ?keys[0];
+    o.keys_len = ?klens[0];
+    o.children = ?children[0];
+    o.count = 1;
+    var buf: [32]u8;
+    val n: usize = emit(?o, ?buf[0], 32);
+    # expected: {"a\"b":1} (10 bytes)
+    if (n != 10) { ret 1; }
+    if (buf[0] != '{')  { ret 1; }
+    if (buf[1] != '"')  { ret 1; }
+    if (buf[2] != 'a')  { ret 1; }
+    if (buf[3] != '\\') { ret 1; }
+    if (buf[4] != '"')  { ret 1; }
+    if (buf[5] != 'b')  { ret 1; }
+    if (buf[6] != '"')  { ret 1; }
+    if (buf[7] != ':')  { ret 1; }
+    if (buf[8] != '1')  { ret 1; }
+    if (buf[9] != '}')  { ret 1; }
+    # and the emitted object re-parses cleanly
+    val r: Result[Value, str] = parse(?buf[0], n, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val rv: Value = unwrap_ok[Value, str](r);
+    if (rv.kind != OBJECT) { ret 1; }
+    if (rv.count != 1) { ret 1; }
+    ret 0;
+}

--- a/src/runtime/linux/aarch64.mach
+++ b/src/runtime/linux/aarch64.mach
@@ -58,6 +58,9 @@ fun _rt_init() {
         reloc._rt_relocate(_rt_envp::ptr::*u64);
     }
     os._envp = _rt_envp;
+    # publish AT_PAGESZ into the OS layer for page_size(); runs after _envp is set
+    # and (under --pie) after relocation, so it is ordinary post-relocation code.
+    os.capture_pagesz();
 }
 
 #[symbol("_start")]

--- a/src/runtime/linux/riscv64.mach
+++ b/src/runtime/linux/riscv64.mach
@@ -51,6 +51,9 @@ fun _rt_init() {
         reloc._rt_relocate(_rt_envp::ptr::*u64);
     }
     os._envp = _rt_envp;
+    # publish AT_PAGESZ into the OS layer for page_size(); runs after _envp is set
+    # and (under --pie) after relocation, so it is ordinary post-relocation code.
+    os.capture_pagesz();
 }
 
 #[symbol("_start")]

--- a/src/runtime/linux/x86_64.mach
+++ b/src/runtime/linux/x86_64.mach
@@ -46,6 +46,9 @@ fun _rt_init() {
         reloc._rt_relocate(_rt_envp::ptr::*u64);
     }
     os._envp = _rt_envp;
+    # publish AT_PAGESZ into the OS layer for page_size(); runs after _envp is set
+    # and (under --pie) after relocation, so it is ordinary post-relocation code.
+    os.capture_pagesz();
 }
 
 #[symbol("_start")]

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -28,13 +28,14 @@ $if ($mach.build.arch != $mach.arch.aarch64) {
 
 # page_size: return the system page size.
 #
-# NOTE: aarch64 linux supports 4 KiB, 16 KiB, and 64 KiB pages depending on
-# kernel configuration; 4096 is the common default and what qemu-user presents.
-# the robust fix is to query AT_PAGESZ from the auxiliary vector at startup;
-# tracked for follow-up once the runtime aux-vector plumbing lands.
+# aarch64 linux supports 4 KiB, 16 KiB, and 64 KiB pages depending on kernel
+# configuration, so it reads the runtime AT_PAGESZ the entrypoint captured
+# (shared.capture_pagesz), falling back to the 4 KiB base page only when the
+# auxv lacked it.
 # ---
 # ret: page size in bytes
 pub fun page_size() usize {
+    if (shared._pagesz != 0) { ret shared._pagesz; }
     ret 4096;
 }
 
@@ -235,6 +236,7 @@ fwd shared.sync_file;
 # environment
 fwd shared._envp;
 fwd shared.environ;
+fwd shared.capture_pagesz;
 
 # filesystem
 fwd shared.read;

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -4,6 +4,7 @@
 # everything else is in shared.mach.
 
 use std.types.size.usize;
+use std.system.panic.panic;
 
 use shared: std.system.os.linux.shared;
 
@@ -30,13 +31,17 @@ $if ($mach.build.arch != $mach.arch.aarch64) {
 #
 # aarch64 linux supports 4 KiB, 16 KiB, and 64 KiB pages depending on kernel
 # configuration, so it reads the runtime AT_PAGESZ the entrypoint captured
-# (shared.capture_pagesz), falling back to the 4 KiB base page only when the
-# auxv lacked it.
+# (shared.capture_pagesz). AT_PAGESZ is mandatory on linux, so a 0 here means the
+# auxv lacked it or a caller ran before runtime init; page_size() panics rather
+# than fabricating a default, which on a large-page kernel would be a wrong and
+# caller-dependent answer.
 # ---
 # ret: page size in bytes
 pub fun page_size() usize {
-    if (shared._pagesz != 0) { ret shared._pagesz; }
-    ret 4096;
+    if (shared._pagesz == 0) {
+        panic("std.system.os.page_size: AT_PAGESZ unavailable (auxv lacks it, or called before runtime init)\n");
+    }
+    ret shared._pagesz;
 }
 
 val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM;

--- a/src/system/os/linux/riscv64.mach
+++ b/src/system/os/linux/riscv64.mach
@@ -28,13 +28,14 @@ $if ($mach.build.arch != $mach.arch.riscv64) {
 
 # page_size: return the system page size.
 #
-# NOTE: riscv64 linux uses 4 KiB base pages (Sv39/Sv48/Sv57 all share the 4 KiB
-# leaf), which is what qemu-user presents. the robust fix is to query AT_PAGESZ
-# from the auxiliary vector at startup; tracked for follow-up once the runtime
-# aux-vector plumbing lands.
+# riscv64 linux uses 4 KiB base pages (Sv39/Sv48/Sv57 all share the 4 KiB leaf),
+# but it reads the runtime AT_PAGESZ the entrypoint captured
+# (shared.capture_pagesz) for one page-size source of truth, falling back to the
+# 4 KiB base page only when the auxv lacked it.
 # ---
 # ret: page size in bytes
 pub fun page_size() usize {
+    if (shared._pagesz != 0) { ret shared._pagesz; }
     ret 4096;
 }
 
@@ -232,6 +233,7 @@ fwd shared.sync_file;
 # environment
 fwd shared._envp;
 fwd shared.environ;
+fwd shared.capture_pagesz;
 
 # filesystem
 fwd shared.read;

--- a/src/system/os/linux/riscv64.mach
+++ b/src/system/os/linux/riscv64.mach
@@ -4,6 +4,7 @@
 # everything else is in shared.mach.
 
 use std.types.size.usize;
+use std.system.panic.panic;
 
 use shared: std.system.os.linux.shared;
 
@@ -30,13 +31,16 @@ $if ($mach.build.arch != $mach.arch.riscv64) {
 #
 # riscv64 linux uses 4 KiB base pages (Sv39/Sv48/Sv57 all share the 4 KiB leaf),
 # but it reads the runtime AT_PAGESZ the entrypoint captured
-# (shared.capture_pagesz) for one page-size source of truth, falling back to the
-# 4 KiB base page only when the auxv lacked it.
+# (shared.capture_pagesz) for one page-size source of truth. AT_PAGESZ is
+# mandatory on linux, so a 0 here means the auxv lacked it or a caller ran before
+# runtime init; page_size() panics rather than fabricating a default.
 # ---
 # ret: page size in bytes
 pub fun page_size() usize {
-    if (shared._pagesz != 0) { ret shared._pagesz; }
-    ret 4096;
+    if (shared._pagesz == 0) {
+        panic("std.system.os.page_size: AT_PAGESZ unavailable (auxv lacks it, or called before runtime init)\n");
+    }
+    ret shared._pagesz;
 }
 
 val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -1164,6 +1164,47 @@ pub fun environ() **u8 {
     ret _envp::**u8;
 }
 
+# _pagesz: the runtime page size in bytes, read from the auxiliary vector
+# (AT_PAGESZ) at program start. 0 until the runtime publishes it, and also if
+# the auxv lacked AT_PAGESZ; page_size() reads 0 as "unavailable" and falls back
+# to the 4 KiB base page. this is the single consumer-facing page-size source
+# (briar-systems/mach-std#336): std.runtime.linux.reloc keeps its own private
+# pre-relocation read of AT_PAGESZ for the RELRO mprotect (it runs before any
+# global is safe to touch), but every page_size() caller reads this global.
+pub var _pagesz: usize = 0;
+
+# pagesz_from_auxv: read AT_PAGESZ from the auxiliary vector reachable from envp.
+#
+# the auxv (type/value u64 pairs, AT_NULL-terminated) sits immediately past the
+# NULL terminator of the null-terminated pointer array `envp` addresses. walks
+# envp to its terminator, then scans the auxv for AT_PAGESZ.
+# ---
+# envp: the runtime envp pointer (the value the entrypoint captured)
+# ret:  the AT_PAGESZ value in bytes, or 0 if the auxv lacks it
+fun pagesz_from_auxv(envp: *u64) usize {
+    var idx: usize = 0;
+    for (envp[idx] != 0) { idx = idx + 1; }
+    idx = idx + 1;
+    for (envp[idx] != 0) {
+        val t: u64 = envp[idx];
+        val v: u64 = envp[idx + 1];
+        if (t == 6) { ret v::usize; }   # AT_PAGESZ
+        idx = idx + 2;
+    }
+    ret 0;
+}
+
+# capture_pagesz: publish the auxv page size into `_pagesz`.
+#
+# called once by the entrypoint at startup, after `_envp` is set and (in a --pie
+# build) after `_rt_relocate` has applied the relocations, so it runs as ordinary
+# post-relocation code that may touch globals. leaves `_pagesz` at 0 when the
+# auxv lacks AT_PAGESZ, which page_size() reads as the fallback signal.
+pub fun capture_pagesz() {
+    if (_envp == 0) { ret; }
+    _pagesz = pagesz_from_auxv(_envp::*u64);
+}
+
 # process
 
 # terminate: exit the process with the given code.

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -1165,12 +1165,14 @@ pub fun environ() **u8 {
 }
 
 # _pagesz: the runtime page size in bytes, read from the auxiliary vector
-# (AT_PAGESZ) at program start. 0 until the runtime publishes it, and also if
-# the auxv lacked AT_PAGESZ; page_size() reads 0 as "unavailable" and falls back
-# to the 4 KiB base page. this is the single consumer-facing page-size source
-# (briar-systems/mach-std#336): std.runtime.linux.reloc keeps its own private
-# pre-relocation read of AT_PAGESZ for the RELRO mprotect (it runs before any
-# global is safe to touch), but every page_size() caller reads this global.
+# (AT_PAGESZ) at program start. 0 until the runtime publishes it; AT_PAGESZ is
+# mandatory on linux, so a 0 still seen at a page_size() call means the auxv
+# lacked it (broken/nonstandard environment) or a caller ran before _rt_init
+# published — page_size() panics on either rather than fabricating a value. this
+# is the single consumer-facing page-size source (briar-systems/mach-std#336):
+# std.runtime.linux.reloc keeps its own private pre-relocation read of AT_PAGESZ
+# for the RELRO mprotect (it runs before any global is safe to touch), but every
+# page_size() caller reads this global.
 pub var _pagesz: usize = 0;
 
 # pagesz_from_auxv: read AT_PAGESZ from the auxiliary vector reachable from envp.
@@ -1198,8 +1200,9 @@ fun pagesz_from_auxv(envp: *u64) usize {
 #
 # called once by the entrypoint at startup, after `_envp` is set and (in a --pie
 # build) after `_rt_relocate` has applied the relocations, so it runs as ordinary
-# post-relocation code that may touch globals. leaves `_pagesz` at 0 when the
-# auxv lacks AT_PAGESZ, which page_size() reads as the fallback signal.
+# post-relocation code that may touch globals. `_pagesz` stays 0 only if the auxv
+# lacks the mandatory AT_PAGESZ, which page_size() treats as a fatal invariant
+# breach rather than fabricating a default.
 pub fun capture_pagesz() {
     if (_envp == 0) { ret; }
     _pagesz = pagesz_from_auxv(_envp::*u64);

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -26,10 +26,16 @@ $if ($mach.build.arch != $mach.arch.x86_64) {
     $error("std.system.os.linux.x86_64: requires x86_64 target");
 }
 
-# page_size: return the system page size (4096 on x86_64 linux).
+# page_size: return the system page size.
+#
+# x86_64 linux always presents a 4 KiB base page, but it reads the runtime
+# AT_PAGESZ the entrypoint captured (shared.capture_pagesz) for one page-size
+# source of truth across the linux arches, falling back to 4 KiB only when the
+# auxv lacked it.
 # ---
 # ret: page size in bytes
 pub fun page_size() usize {
+    if (shared._pagesz != 0) { ret shared._pagesz; }
     ret 4096;
 }
 
@@ -221,6 +227,7 @@ fwd shared.sync_file;
 # environment
 fwd shared._envp;
 fwd shared.environ;
+fwd shared.capture_pagesz;
 
 # filesystem
 fwd shared.read;

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -4,6 +4,7 @@
 # everything else is in shared.mach.
 
 use std.types.size.usize;
+use std.system.panic.panic;
 
 use shared: std.system.os.linux.shared;
 
@@ -30,13 +31,16 @@ $if ($mach.build.arch != $mach.arch.x86_64) {
 #
 # x86_64 linux always presents a 4 KiB base page, but it reads the runtime
 # AT_PAGESZ the entrypoint captured (shared.capture_pagesz) for one page-size
-# source of truth across the linux arches, falling back to 4 KiB only when the
-# auxv lacked it.
+# source of truth across the linux arches. AT_PAGESZ is mandatory on linux, so a
+# 0 here means the auxv lacked it or a caller ran before runtime init;
+# page_size() panics rather than fabricating a default.
 # ---
 # ret: page size in bytes
 pub fun page_size() usize {
-    if (shared._pagesz != 0) { ret shared._pagesz; }
-    ret 4096;
+    if (shared._pagesz == 0) {
+        panic("std.system.os.page_size: AT_PAGESZ unavailable (auxv lacks it, or called before runtime init)\n");
+    }
+    ret shared._pagesz;
 }
 
 val THREAD_CLONE_FLAGS: usize = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM;


### PR DESCRIPTION
Release dev -> main. Three merges since the RELRO release:
- #341 (fixes #337): `std.data.json` emit now escapes strings and object keys per RFC 8259 (quotes, backslashes, control bytes) — emitted trees were invalid JSON for any such content. The parse-raw/emit-logical representation asymmetry is documented loudly and tracked in #340.
- #343 (fixes #336): linux `os.page_size()` returns the runtime AT_PAGESZ captured from the auxv at startup instead of a hardcoded 4096 (correct on 16K/64K-page aarch64 kernels); panics instead of guessing when the invariant is breached. `_rt_relocate` keeps its private pre-relocation read.
- #342: changelog backfill (output primitives, static-PIE self-reloc, RELRO entries).

Verified: mach test . 571→575 green through the sweep; page-size probe (independent auxv read == page_size()) passes on x86_64 native + aarch64/riscv64 qemu in default and --pie builds; JSON emit output revalidated through the module's own parser. No other dev work is swept in.