### PR TITLE
chore: update stale octalide URLs to briar-systems

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y qemu-user
           mkdir -p /tmp/machdl
-          gh release download --repo octalide/mach \
+          gh release download --repo briar-systems/mach \
             --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
           tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
           cp /tmp/machdl/mach /usr/local/bin/mach


### PR DESCRIPTION
Sweeps stale `octalide/<name>` references to the canonical `briar-systems` org.

The `github.com/octalide/mach-std` URLs in README.md / CHANGELOG.md were already repointed on `dev` (commit 47b51d8), so the only remaining straggler was CI: `.github/workflows/ci.yml` downloaded the Mach compiler via `gh release download --repo octalide/mach`. Repointed to `briar-systems/mach` (verified to exist; `octalide/mach` currently redirects there).

Closes #345