### PR TITLE
feat(data/json): unify JSON escapers and add streaming NDJSON emitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   popcounts the `sched_getaffinity` mask (honouring taskset/cgroup cpusets),
   darwin reads `hw.ncpu` via `__sysctl`, windows uses
   `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)`. Never less than 1 (#331).
+- data/json: streaming NDJSON emitter — `Object` with `object_begin`/
+  `object_end` and `field_str`/`field_str_or_null`/`field_i64`/`field_bool`
+  write flat one-object-per-line JSON through a caller-owned `io.Writer`, plus
+  `write_json_string` for a lone escaped string literal. `mach.cli.json` moves
+  into std as the one JSON emission home; the tree `emit` and the streaming
+  surface now share a single escape core (`escape_unit`) with an explicit
+  policy: `ESCAPE_VERBATIM` (structural, UTF-8 verbatim) for `emit`, and
+  `ESCAPE_ENSURE_ASCII` (RFC 3629 decode to `\uXXXX`, astral surrogate pairs,
+  U+FFFD on invalid input) for the stream. Both surfaces are byte-identical to
+  their pre-unification output (#338).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,16 +39,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   popcounts the `sched_getaffinity` mask (honouring taskset/cgroup cpusets),
   darwin reads `hw.ncpu` via `__sysctl`, windows uses
   `GetActiveProcessorCount(ALL_PROCESSOR_GROUPS)`. Never less than 1 (#331).
-- data/json: streaming NDJSON emitter — `Object` with `object_begin`/
-  `object_end` and `field_str`/`field_str_or_null`/`field_i64`/`field_bool`
-  write flat one-object-per-line JSON through a caller-owned `io.Writer`, plus
-  `write_json_string` for a lone escaped string literal. `mach.cli.json` moves
-  into std as the one JSON emission home; the tree `emit` and the streaming
-  surface now share a single escape core (`escape_unit`) with an explicit
-  policy: `ESCAPE_VERBATIM` (structural, UTF-8 verbatim) for `emit`, and
-  `ESCAPE_ENSURE_ASCII` (RFC 3629 decode to `\uXXXX`, astral surrogate pairs,
-  U+FFFD on invalid input) for the stream. Both surfaces are byte-identical to
-  their pre-unification output (#338).
+- data/json: streaming NDJSON emitter — `Object`/`Array` with `object_begin`/
+  `object_end`, the nesting primitives `object_end_value`/`field_object_begin`/
+  `field_array_begin`/`array_end`/`array_object_begin`, and the members
+  `field_str`/`field_str_or_null`/`field_null`/`field_i64`/`field_bool` write
+  one-object-per-line JSON (objects nest onto a single line) through a
+  caller-owned `io.Writer`, plus `write_json_string` for a lone escaped string
+  literal. `mach.cli.json` moves into std as the one JSON emission home; the
+  tree `emit` and the streaming surface now share a single escape core
+  (`escape_unit`) with an explicit policy: `ESCAPE_VERBATIM` (structural, UTF-8
+  verbatim) for `emit`, and `ESCAPE_ENSURE_ASCII` (RFC 3629 decode to `\uXXXX`,
+  astral surrogate pairs, U+FFFD on invalid input) for the stream. Both surfaces
+  are byte-identical to their pre-unification output (#338).
 
 ### Fixed
 

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -7,9 +7,12 @@
 #     into the original input buffer (escape sequences are not unescaped:
 #     str_val holds the raw on-wire bytes); the caller must keep the input
 #     alive while values are in use.
-#   - the streaming NDJSON emitter (Object/field_*/write_json_string): writes
-#     flat JSON objects one-per-line through a caller-owned writer, for
-#     machine-consumed output streams.
+#   - the streaming NDJSON emitter (Object/Array/field_*/write_json_string):
+#     writes JSON objects one-per-line through a caller-owned writer, for
+#     machine-consumed output streams. objects nest: a member value or an array
+#     element may itself be an object (field_object_begin / array_object_begin,
+#     closed with object_end_value), and only the top-level object_end writes
+#     the line terminator, so a whole nested object still lands on one line.
 #
 # both surfaces escape string bodies through one escaper (escape_unit) with an
 # explicit policy:
@@ -826,6 +829,16 @@ pub rec Object {
     first: bool;
 }
 
+# an open JSON array in the streaming NDJSON emitter, tracking the comma
+# boundary between its elements.
+# ---
+# w:     the writer the array is emitted through (borrowed)
+# first: no element has been emitted into the array yet
+pub rec Array {
+    w:     *writer.Writer;
+    first: bool;
+}
+
 # object_begin: begin a JSON object, writing `{` and arming the first-member
 # state.
 # ---
@@ -842,8 +855,66 @@ pub fun object_begin(w: *writer.Writer, o: *Object) {
 # ---
 # o: the object to close
 pub fun object_end(o: *Object) {
-    fmt.write_byte(o.w, '}');
+    object_end_value(o);
     fmt.write_newline(o.w);
+}
+
+# object_end_value: close a nested object, writing `}` without the NDJSON line
+# terminator.
+#
+# Used for an object that is a member value or an array element, where the
+# enclosing container - not this object - owns the line boundary.
+# ---
+# o: the object to close
+pub fun object_end_value(o: *Object) {
+    fmt.write_byte(o.w, '}');
+}
+
+# field_object_begin: open an object-valued member: the key lead-in, then `{`,
+# arming `child` over the parent's writer.
+#
+# Fill `child` with the field_* helpers and close it with object_end_value; the
+# parent stays open and takes further members afterwards.
+# ---
+# o:     the open parent object
+# key:   the member key
+# child: the nested object state to initialise
+pub fun field_object_begin(o: *Object, key: *u8, child: *Object) {
+    member(o, key);
+    object_begin(o.w, child);
+}
+
+# field_array_begin: open an array-valued member: the key lead-in, then `[`,
+# arming `arr` over the parent's writer. Close it with array_end.
+# ---
+# o:   the open parent object
+# key: the member key
+# arr: the array state to initialise
+pub fun field_array_begin(o: *Object, key: *u8, arr: *Array) {
+    member(o, key);
+    arr.w     = o.w;
+    arr.first = true;
+    fmt.write_byte(o.w, '[');
+}
+
+# array_end: close an array, writing `]`.
+# ---
+# arr: the array to close
+pub fun array_end(arr: *Array) {
+    fmt.write_byte(arr.w, ']');
+}
+
+# array_object_begin: open an object element of `arr`: the element separator,
+# then `{`, arming `child` over the array's writer.
+#
+# Fill `child` with the field_* helpers and close it with object_end_value.
+# ---
+# arr:   the open array
+# child: the element object state to initialise
+pub fun array_object_begin(arr: *Array, child: *Object) {
+    if (!arr.first) { fmt.write_byte(arr.w, ','); }
+    arr.first = false;
+    object_begin(arr.w, child);
 }
 
 # field_str: emit a string-valued member (the value quoted and ASCII-escaped).
@@ -869,6 +940,15 @@ pub fun field_str_or_null(o: *Object, key: *u8, v: *u8) {
         ret;
     }
     write_json_string(o.w, v);
+}
+
+# field_null: emit a JSON `null`-valued member.
+# ---
+# o:   the open object
+# key: the member key
+pub fun field_null(o: *Object, key: *u8) {
+    member(o, key);
+    fmt.write_str(o.w, "null");
 }
 
 # field_i64: emit an integer-valued member.
@@ -1543,12 +1623,72 @@ test "json: ndjson object exact bytes" {
     field_str(?o, "s", "a\"b");
     field_bool(?o, "b", true);
     field_str_or_null(?o, "o", nil);
+    field_null(?o, "z");
     object_end(?o);
 
-    # {"n":7,"s":"a\"b","b":true,"o":null}\n
-    val want: str = "{\"n\":7,\"s\":\"a\\\"b\",\"b\":true,\"o\":null}\n";
+    # {"n":7,"s":"a\"b","b":true,"o":null,"z":null}\n
+    val want: str = "{\"n\":7,\"s\":\"a\\\"b\",\"b\":true,\"o\":null,\"z\":null}\n";
     var wlen: usize = 0;
     for (want[wlen] != 0) { wlen = wlen + 1; }
     if (!sink_is(?sink, want::*u8, wlen)) { ret 1; }
+    ret 0;
+}
+
+# nested object and array members compose into one valid NDJSON line.
+test "json: ndjson nested object and array" {
+    var out:  [128]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 128);
+
+    var root: Object;
+    object_begin(?w, ?root);
+    field_i64(?root, "a", 1);
+
+    var loc: Object;
+    field_object_begin(?root, "loc", ?loc);
+    field_i64(?loc, "line", 2);
+    field_i64(?loc, "col", 3);
+    object_end_value(?loc);
+
+    var rel: Array;
+    field_array_begin(?root, "rel", ?rel);
+    var e0: Object;
+    array_object_begin(?rel, ?e0);
+    field_str(?e0, "label", "x");
+    object_end_value(?e0);
+    var e1: Object;
+    array_object_begin(?rel, ?e1);
+    field_str(?e1, "label", "y");
+    object_end_value(?e1);
+    array_end(?rel);
+
+    object_end(?root);
+
+    val want: *u8 = "{\"a\":1,\"loc\":{\"line\":2,\"col\":3},\"rel\":[{\"label\":\"x\"},{\"label\":\"y\"}]}\n";
+    var wl: usize = 0;
+    for (want[wl] != 0) { wl = wl + 1; }
+    if (!sink_is(?sink, want, wl)) { ret 1; }
+    ret 0;
+}
+
+# an empty array member emits `[]`.
+test "json: ndjson empty array" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    var root: Object;
+    object_begin(?w, ?root);
+    var rel: Array;
+    field_array_begin(?root, "rel", ?rel);
+    array_end(?rel);
+    object_end(?root);
+
+    val want: *u8 = "{\"rel\":[]}\n";
+    var wl: usize = 0;
+    for (want[wl] != 0) { wl = wl + 1; }
+    if (!sink_is(?sink, want, wl)) { ret 1; }
     ret 0;
 }

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -1,17 +1,36 @@
 # JSON parser and emitter (integer numbers only).
 #
-# parses JSON text into a tree of Value nodes. strings are zero-copy
-# pointers into the original input buffer (escape sequences are not
-# unescaped: str_val holds the raw on-wire bytes). the caller must keep the
-# input alive while values are in use.
+# this module hosts two emission surfaces over one escape core:
 #
-# WARNING: parse and emit disagree on what a string's bytes mean. parse
-# yields raw wire bytes with escapes intact; emit treats str_val as logical
-# bytes and re-escapes '"', '\', and control bytes. so emitting a tree that
-# came from parse double-escapes any wire escapes it contained (parse "a\nb"
-# -> str_val a\nb -> emit "a\\nb"). build trees with make_string for
-# emission; do not round-trip parse -> emit for strings holding escapes.
-# tracked in mach-std#340.
+#   - the tree emitter (parse/emit): parses JSON text into a tree of Value
+#     nodes and emits a Value back to JSON text. strings are zero-copy pointers
+#     into the original input buffer (escape sequences are not unescaped:
+#     str_val holds the raw on-wire bytes); the caller must keep the input
+#     alive while values are in use.
+#   - the streaming NDJSON emitter (Object/field_*/write_json_string): writes
+#     flat JSON objects one-per-line through a caller-owned writer, for
+#     machine-consumed output streams.
+#
+# both surfaces escape string bodies through one escaper (escape_unit) with an
+# explicit policy:
+#
+#   - ESCAPE_VERBATIM (structural-utf8-verbatim): escapes '"', '\', and the C0
+#     controls only; every other byte, including UTF-8 lead/continuation bytes,
+#     passes through verbatim. the tree emitter uses this so valid UTF-8 input
+#     round-trips as UTF-8.
+#   - ESCAPE_ENSURE_ASCII: as above for bytes < 0x80, but each byte >= 0x80 is
+#     UTF-8 decoded (RFC 3629) and emitted as a \uXXXX escape (astral code
+#     points as a surrogate pair); invalid UTF-8 emits the U+FFFD replacement
+#     escape. every emitted byte is printable ASCII on every platform. the
+#     streaming emitter uses this so a machine consumer reads a stable, valid
+#     stream regardless of the bytes a test label or path carries.
+#
+# WARNING: parse and emit disagree on what a string's bytes mean. parse yields
+# raw wire bytes with escapes intact; emit treats str_val as logical bytes and
+# re-escapes '"', '\', and control bytes. so emitting a tree that came from
+# parse double-escapes any wire escapes it contained (parse "a\nb" -> str_val
+# a\nb -> emit "a\\nb"). build trees with make_string for emission; do not
+# round-trip parse -> emit for strings holding escapes. tracked in mach-std#340.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -25,7 +44,9 @@ use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 use std.types.string.str;
 use std.memory.raw_copy;
-use allo: std.allocator;
+use allo:   std.allocator;
+use writer: std.io.writer;
+use fmt:    std.format;
 
 pub def Kind: u8;
 pub val NULL:   Kind = 0;
@@ -70,12 +91,6 @@ rec Parser {
     len:   usize;
     pos:   usize;
     alloc: *allo.Allocator;
-}
-
-rec Emitter {
-    buf: *u8;
-    len: usize;
-    pos: usize;
 }
 
 # parse: parse JSON text into a Value tree.
@@ -227,8 +242,8 @@ pub fun value_find(v: *Value, key: str) *Value {
 
 # emit: emit a Value as JSON text into a buffer.
 #
-# strings and object keys are escaped as RFC 8259 string bodies: '"', '\',
-# and control bytes 0x00-0x1F are escaped (short escapes \b \t \n \f \r, else
+# strings and object keys are escaped under ESCAPE_VERBATIM: '"', '\', and
+# control bytes 0x00-0x1F are escaped (short escapes \b \t \n \f \r, else
 # \u00xx); other bytes, including valid UTF-8, are written verbatim. str_val
 # and keys are treated as logical bytes, so emitting a PARSED tree double-
 # escapes any escapes the source contained -- see the file header (mach-std#340).
@@ -238,12 +253,15 @@ pub fun value_find(v: *Value, key: str) *Value {
 # len: size of destination buffer in bytes
 # ret: number of bytes written (may exceed len if buffer too small)
 pub fun emit(v: *Value, buf: *u8, len: usize) usize {
-    var e: Emitter;
-    e.buf = buf;
-    e.len = len;
-    e.pos = 0;
-    emit_value(?e, v);
-    ret e.pos;
+    var b: BufWriter;
+    b.data = buf;
+    b.cap  = len;
+    b.pos  = 0;
+    var w: writer.Writer;
+    w.ctx      = (?b)::ptr;
+    w.fn_write = bufw_write;
+    emit_value(?w, v);
+    ret b.pos;
 }
 
 fun make_null() Value {
@@ -568,143 +586,337 @@ fun parse_object(p: *Parser) Result[Value, str] {
     ret err[Value, str]("unterminated object");
 }
 
-fun emit_byte(e: *Emitter, c: u8) {
-    if (e.pos < e.len) {
-        e.buf[e.pos] = c;
-    }
-    e.pos = e.pos + 1;
+# a counting writer over a fixed buffer: copies the bytes that fit and counts
+# every requested byte, so emit() can report the length a full render needs even
+# when the buffer is too small.
+# ---
+# data: destination buffer
+# cap:  buffer capacity
+# pos:  bytes requested so far (the render length; may exceed cap)
+rec BufWriter {
+    data: *u8;
+    cap:  usize;
+    pos:  usize;
 }
 
-fun emit_str(e: *Emitter, s: str) {
+# writer callback for BufWriter: copies the bytes that fit and advances pos by
+# the full request, always reporting a complete write.
+fun bufw_write(ctx: ptr, buf: *u8, len: usize) Result[usize, str] {
+    val s: *BufWriter = ctx::*BufWriter;
     var i: usize = 0;
-    for (s[i] != 0) {
-        emit_byte(e, s[i]);
+    for (i < len) {
+        if (s.pos < s.cap) { s.data[s.pos] = buf[i]; }
+        s.pos = s.pos + 1;
         i = i + 1;
     }
+    ret ok[usize, str](len);
 }
 
-fun emit_i64(e: *Emitter, n: i64) {
-    if (n < 0) {
-        emit_byte(e, '-');
-        emit_u64(e, (0 - n)::u64);
-        ret;
-    }
-    emit_u64(e, n::u64);
+# the escape policy for a JSON string body: how bytes >= 0x80 are rendered.
+def EscapePolicy: u8;
+
+# structural-utf8-verbatim: escape '"', '\', and the C0 controls only; every
+# other byte, including UTF-8 lead/continuation bytes, passes through verbatim.
+val ESCAPE_VERBATIM: EscapePolicy = 0;
+
+# ensure-ascii: as ESCAPE_VERBATIM for bytes < 0x80, but each byte >= 0x80 is
+# UTF-8 decoded and emitted as a \uXXXX escape (U+FFFD on invalid input), so
+# every emitted byte is printable ASCII.
+val ESCAPE_ENSURE_ASCII: EscapePolicy = 1;
+
+# escape one code unit of `s` starting at `i` as a JSON string body, returning
+# the next byte index.
+#
+# '"', '\', and the C0 controls become their short or \u00XX escapes; printable
+# ASCII passes through verbatim. a byte >= 0x80 passes through verbatim under
+# ESCAPE_VERBATIM, or begins a UTF-8 sequence decoded to a \uXXXX escape under
+# ESCAPE_ENSURE_ASCII. under ESCAPE_ENSURE_ASCII `s` must be null-terminated or
+# hold its continuation bytes within bounds, since a multi-byte decode reads
+# past `i`; a NUL or bad byte resynchronizes as one U+FFFD escape.
+# ---
+# w:      the writer to emit through
+# policy: the escape policy
+# s:      the source bytes
+# i:      the byte index to escape
+# ret:    the index of the next byte to process
+fun escape_unit(w: *writer.Writer, policy: EscapePolicy, s: *u8, i: usize) usize {
+    val c: u8 = s[i];
+    if (c == '"')  { fmt.write_str(w, "\\\""); ret i + 1; }
+    if (c == '\\') { fmt.write_str(w, "\\\\"); ret i + 1; }
+    if (c == 0x08) { fmt.write_str(w, "\\b");  ret i + 1; }
+    if (c == 0x09) { fmt.write_str(w, "\\t");  ret i + 1; }
+    if (c == 0x0a) { fmt.write_str(w, "\\n");  ret i + 1; }
+    if (c == 0x0c) { fmt.write_str(w, "\\f");  ret i + 1; }
+    if (c == 0x0d) { fmt.write_str(w, "\\r");  ret i + 1; }
+    if (c < 0x20)  { write_u_hex(w, c::u32);   ret i + 1; }
+    if (c < 0x80)  { fmt.write_byte(w, c);     ret i + 1; }
+    if (policy == ESCAPE_VERBATIM) { fmt.write_byte(w, c); ret i + 1; }
+    ret write_utf8_escape(w, s, i);
 }
 
-fun emit_u64(e: *Emitter, n: u64) {
-    if (n == 0) {
-        emit_byte(e, '0');
-        ret;
-    }
+# escape s[0..slen) as a JSON string body (no surrounding quotes) under policy.
+fun escape_bytes(w: *writer.Writer, policy: EscapePolicy, s: *u8, slen: usize) {
+    var i: usize = 0;
+    for (i < slen) { i = escape_unit(w, policy, s, i); }
+}
 
-    var buf: [20]u8;
+# decode the UTF-8 sequence at `i` and emit it as a \uXXXX escape, returning the
+# index past the sequence.
+#
+# Full RFC 3629 validation: the lead byte fixes the length and the first
+# continuation byte's allowed range, which together reject overlong encodings
+# (0xC0/0xC1, 0xE0 80-9F, 0xF0 80-8F), the UTF-16 surrogate range (0xED A0-BF),
+# and code points above U+10FFFF (0xF4 90-BF); invalid lead bytes (0x80-0xBF,
+# 0xF5-0xFF) and any bad or truncated continuation are rejected too. A rejected
+# sequence emits the U+FFFD replacement escape and consumes exactly one byte, so
+# the scan resynchronizes on the next byte.
+# ---
+# w: the writer to emit through
+# s: the source (a NUL terminates any truncated sequence)
+# i: the index of the sequence's lead byte (>= 0x80)
+# ret: the index of the next byte to process
+fun write_utf8_escape(w: *writer.Writer, s: *u8, i: usize) usize {
+    val b0: u8 = s[i];
+
+    # length, plus the tightened [lo, hi] range for the first continuation byte
+    # that pins overlong / surrogate / out-of-range sequences to their lead.
     var len: usize = 0;
-    var tmp: u64 = n;
-    for (tmp > 0) {
-        buf[len] = (tmp % 10)::u8 + '0';
-        tmp = tmp / 10;
-        len = len + 1;
+    var lo:  u8    = 0x80;
+    var hi:  u8    = 0xBF;
+    var cp:  u32   = 0;
+    if (b0 >= 0xC2 && b0 <= 0xDF) { len = 2; cp = (b0 & 0x1F)::u32; }
+    or (b0 == 0xE0)               { len = 3; lo = 0xA0; cp = (b0 & 0x0F)::u32; }
+    or (b0 >= 0xE1 && b0 <= 0xEC) { len = 3; cp = (b0 & 0x0F)::u32; }
+    or (b0 == 0xED)               { len = 3; hi = 0x9F; cp = (b0 & 0x0F)::u32; }
+    or (b0 >= 0xEE && b0 <= 0xEF) { len = 3; cp = (b0 & 0x0F)::u32; }
+    or (b0 == 0xF0)               { len = 4; lo = 0x90; cp = (b0 & 0x07)::u32; }
+    or (b0 >= 0xF1 && b0 <= 0xF3) { len = 4; cp = (b0 & 0x07)::u32; }
+    or (b0 == 0xF4)               { len = 4; hi = 0x8F; cp = (b0 & 0x07)::u32; }
+    or {
+        write_u_hex(w, 0xFFFD);
+        ret i + 1;
     }
 
-    var i: usize = len;
-    for (i > 0) {
-        i = i - 1;
-        emit_byte(e, buf[i]);
+    var k: usize = 1;
+    var j: usize = i + 1;
+    for (k < len) {
+        val cb: u8 = s[j];
+        # the first continuation byte carries the tightened range; the rest span
+        # the full 0x80-0xBF. a NUL (truncated sequence) fails the lower bound.
+        var clo: u8 = 0x80;
+        var chi: u8 = 0xBF;
+        if (k == 1) { clo = lo; chi = hi; }
+        if (cb < clo || cb > chi) {
+            write_u_hex(w, 0xFFFD);
+            ret i + 1;
+        }
+        cp = (cp << 6) | (cb & 0x3F)::u32;
+        j  = j + 1;
+        k  = k + 1;
     }
+
+    write_codepoint(w, cp);
+    ret i + len;
 }
 
-fun hex_digit(n: u8) u8 {
-    if (n < 10) { ret n + '0'; }
-    ret (n - 10) + 'a';
-}
-
-fun emit_u_escape(e: *Emitter, c: u8) {
-    emit_byte(e, '\\');
-    emit_byte(e, 'u');
-    emit_byte(e, '0');
-    emit_byte(e, '0');
-    emit_byte(e, hex_digit(c / 16));
-    emit_byte(e, hex_digit(c % 16));
-}
-
-# writes s[0..slen) as an RFC 8259 string body (no surrounding quotes),
-# escaping '"', '\', and control bytes 0x00-0x1F. controls use the short
-# escapes \b \t \n \f \r where defined, else \u00xx; all other bytes,
-# including valid UTF-8, are written verbatim (this is NOT #338's ensure-ascii
-# policy). s is treated as logical bytes -- see emit() on the parse/emit
-# representation asymmetry.
-fun emit_escaped(e: *Emitter, s: *u8, slen: usize) {
-    var i: usize = 0;
-    for (i < slen) {
-        val c: u8 = s[i];
-        i = i + 1;
-        if (c == '"')  { emit_byte(e, '\\'); emit_byte(e, '"');  cnt; }
-        if (c == '\\') { emit_byte(e, '\\'); emit_byte(e, '\\'); cnt; }
-        if (c == 0x08) { emit_byte(e, '\\'); emit_byte(e, 'b');  cnt; }
-        if (c == 0x09) { emit_byte(e, '\\'); emit_byte(e, 't');  cnt; }
-        if (c == 0x0a) { emit_byte(e, '\\'); emit_byte(e, 'n');  cnt; }
-        if (c == 0x0c) { emit_byte(e, '\\'); emit_byte(e, 'f');  cnt; }
-        if (c == 0x0d) { emit_byte(e, '\\'); emit_byte(e, 'r');  cnt; }
-        if (c < 0x20)  { emit_u_escape(e, c); cnt; }
-        emit_byte(e, c);
+# emit a valid Unicode scalar as a \uXXXX escape, or a surrogate pair when
+# astral.
+#
+# `cp` is a validated scalar (U+0000-U+10FFFF, never a surrogate), so the astral
+# branch always yields a well-formed high/low surrogate pair.
+# ---
+# w:  the writer to emit through
+# cp: the Unicode scalar value
+fun write_codepoint(w: *writer.Writer, cp: u32) {
+    if (cp <= 0xFFFF) {
+        write_u_hex(w, cp);
+        ret;
     }
+    val v:  u32 = cp - 0x10000;
+    val hi: u32 = 0xD800 + (v >> 10);
+    val lo: u32 = 0xDC00 + (v & 0x3FF);
+    write_u_hex(w, hi);
+    write_u_hex(w, lo);
 }
 
-fun emit_value(e: *Emitter, v: *Value) {
+# emit a \u escape for a 16-bit value.
+# ---
+# w:    the writer to emit through
+# code: the 16-bit value (only the low 16 bits are used)
+fun write_u_hex(w: *writer.Writer, code: u32) {
+    fmt.write_str(w, "\\u");
+    fmt.write_byte(w, hex_digit((code >> 12) & 0xF));
+    fmt.write_byte(w, hex_digit((code >> 8) & 0xF));
+    fmt.write_byte(w, hex_digit((code >> 4) & 0xF));
+    fmt.write_byte(w, hex_digit(code & 0xF));
+}
+
+# map a nibble (0-15) to its lowercase hexadecimal ASCII digit.
+# ---
+# n:   the nibble value
+# ret: the ASCII digit byte
+fun hex_digit(n: u32) u8 {
+    if (n < 10) { ret n::u8 + '0'; }
+    ret n::u8 - 10 + 'a';
+}
+
+fun emit_value(w: *writer.Writer, v: *Value) {
     if (v.kind == NULL) {
-        emit_str(e, "null");
+        fmt.write_str(w, "null");
         ret;
     }
 
     if (v.kind == BOOL) {
         if (v.bool_val != 0) {
-            emit_str(e, "true");
+            fmt.write_str(w, "true");
         } or {
-            emit_str(e, "false");
+            fmt.write_str(w, "false");
         }
         ret;
     }
 
     if (v.kind == NUMBER) {
-        emit_i64(e, v.num_val);
+        fmt.write_i64(w, v.num_val);
         ret;
     }
 
     if (v.kind == STRING) {
-        emit_byte(e, '"');
-        emit_escaped(e, v.str_val::*u8, v.str_len);
-        emit_byte(e, '"');
+        fmt.write_byte(w, '"');
+        escape_bytes(w, ESCAPE_VERBATIM, v.str_val::*u8, v.str_len);
+        fmt.write_byte(w, '"');
         ret;
     }
 
     if (v.kind == ARRAY) {
-        emit_byte(e, '[');
+        fmt.write_byte(w, '[');
         var i: usize = 0;
         for (i < v.count) {
-            if (i > 0) { emit_byte(e, ','); }
-            emit_value(e, ?v.children[i]);
+            if (i > 0) { fmt.write_byte(w, ','); }
+            emit_value(w, ?v.children[i]);
             i = i + 1;
         }
-        emit_byte(e, ']');
+        fmt.write_byte(w, ']');
         ret;
     }
 
     if (v.kind == OBJECT) {
-        emit_byte(e, '{');
+        fmt.write_byte(w, '{');
         var i: usize = 0;
         for (i < v.count) {
-            if (i > 0) { emit_byte(e, ','); }
-            emit_byte(e, '"');
-            emit_escaped(e, v.keys[i]::*u8, v.keys_len[i]);
-            emit_byte(e, '"');
-            emit_byte(e, ':');
-            emit_value(e, ?v.children[i]);
+            if (i > 0) { fmt.write_byte(w, ','); }
+            fmt.write_byte(w, '"');
+            escape_bytes(w, ESCAPE_VERBATIM, v.keys[i]::*u8, v.keys_len[i]);
+            fmt.write_byte(w, '"');
+            fmt.write_byte(w, ':');
+            emit_value(w, ?v.children[i]);
             i = i + 1;
         }
-        emit_byte(e, '}');
+        fmt.write_byte(w, '}');
         ret;
     }
+}
+
+# an open JSON object in the streaming NDJSON emitter, tracking the comma
+# boundary between its members.
+# ---
+# w:     the writer the object is emitted through (borrowed)
+# first: no member has been emitted into the object yet
+pub rec Object {
+    w:     *writer.Writer;
+    first: bool;
+}
+
+# object_begin: begin a JSON object, writing `{` and arming the first-member
+# state.
+# ---
+# w: the writer to emit through (must outlive the object)
+# o: the object state to initialise
+pub fun object_begin(w: *writer.Writer, o: *Object) {
+    o.w     = w;
+    o.first = true;
+    fmt.write_byte(w, '{');
+}
+
+# object_end: end a JSON object, writing `}` and the newline that terminates the
+# NDJSON line.
+# ---
+# o: the object to close
+pub fun object_end(o: *Object) {
+    fmt.write_byte(o.w, '}');
+    fmt.write_newline(o.w);
+}
+
+# field_str: emit a string-valued member (the value quoted and ASCII-escaped).
+# ---
+# o:   the open object
+# key: the member key (ASCII, emitted verbatim between quotes)
+# v:   the null-terminated value, escaped; nil emits an empty string
+pub fun field_str(o: *Object, key: *u8, v: *u8) {
+    member(o, key);
+    write_json_string(o.w, v);
+}
+
+# field_str_or_null: emit a string-or-null member: the escaped value, or JSON
+# `null` when `v` is nil.
+# ---
+# o:   the open object
+# key: the member key
+# v:   the null-terminated value, or nil for a JSON null
+pub fun field_str_or_null(o: *Object, key: *u8, v: *u8) {
+    member(o, key);
+    if (v == nil) {
+        fmt.write_str(o.w, "null");
+        ret;
+    }
+    write_json_string(o.w, v);
+}
+
+# field_i64: emit an integer-valued member.
+# ---
+# o:   the open object
+# key: the member key
+# v:   the integer value
+pub fun field_i64(o: *Object, key: *u8, v: i64) {
+    member(o, key);
+    fmt.write_i64(o.w, v);
+}
+
+# field_bool: emit a boolean-valued member.
+# ---
+# o:   the open object
+# key: the member key
+# v:   the boolean value
+pub fun field_bool(o: *Object, key: *u8, v: bool) {
+    member(o, key);
+    if (v) { fmt.write_str(o.w, "true"); }
+    or     { fmt.write_str(o.w, "false"); }
+}
+
+# write_json_string: write a JSON string literal under ESCAPE_ENSURE_ASCII: the
+# value quoted, every byte escaped to printable ASCII.
+# ---
+# w: the writer to emit through
+# s: the null-terminated value, or nil for an empty string
+pub fun write_json_string(w: *writer.Writer, s: *u8) {
+    fmt.write_byte(w, '"');
+    if (s != nil) {
+        var i: usize = 0;
+        for (s[i] != 0) { i = escape_unit(w, ESCAPE_ENSURE_ASCII, s, i); }
+    }
+    fmt.write_byte(w, '"');
+}
+
+# write the key/colon lead-in of a member, prefixing a comma after the first.
+# ---
+# o:   the open object
+# key: the member key (ASCII, emitted verbatim)
+fun member(o: *Object, key: *u8) {
+    if (!o.first) { fmt.write_byte(o.w, ','); }
+    o.first = false;
+    fmt.write_byte(o.w, '"');
+    fmt.write_str(o.w, key::str);
+    fmt.write_byte(o.w, '"');
+    fmt.write_byte(o.w, ':');
 }
 
 use page: std.allocator.page;
@@ -1074,5 +1286,269 @@ test "json: emit escapes object keys" {
     val rv: Value = unwrap_ok[Value, str](r);
     if (rv.kind != OBJECT) { ret 1; }
     if (rv.count != 1) { ret 1; }
+    ret 0;
+}
+
+# a fixed-capacity byte sink used to capture streaming emitter output in tests.
+# ---
+# buf: destination buffer
+# cap: buffer capacity
+# len: bytes written so far
+rec TestSink {
+    buf: *u8;
+    cap: usize;
+    len: usize;
+}
+
+# writer callback appending to a TestSink, dropping bytes past its capacity.
+fun test_sink_write(ctx: ptr, buf: *u8, len: usize) Result[usize, str] {
+    val s: *TestSink = ctx::*TestSink;
+    var i: usize = 0;
+    for (i < len && s.len < s.cap) {
+        s.buf[s.len] = buf[i];
+        s.len = s.len + 1;
+        i = i + 1;
+    }
+    ret ok[usize, str](len);
+}
+
+# whether the sink's captured bytes equal the first `wlen` bytes of `want`.
+fun sink_is(s: *TestSink, want: *u8, wlen: usize) bool {
+    if (s.len != wlen) { ret false; }
+    var i: usize = 0;
+    for (i < wlen) {
+        if (s.buf[i] != want[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# wire a Writer over a TestSink backed by `buf`.
+fun test_writer(w: *writer.Writer, s: *TestSink, buf: *u8, cap: usize) {
+    s.buf = buf;
+    s.cap = cap;
+    s.len = 0;
+    w.ctx      = s::ptr;
+    w.fn_write = test_sink_write;
+}
+
+# printable ASCII passes through verbatim, wrapped in quotes.
+test "json: write_json_string plain_ascii" {
+    var out:  [64]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 64);
+
+    write_json_string(?w, "mach.cli.json");
+
+    var want: [15]u8;
+    want[0] = '"';
+    val src: *u8 = "mach.cli.json";
+    var i: usize = 0;
+    for (src[i] != 0) { want[i + 1] = src[i]; i = i + 1; }
+    want[i + 1] = '"';
+    if (!sink_is(?sink, ?want[0], i + 2)) { ret 1; }
+    ret 0;
+}
+
+# quotes and backslashes get their short escapes.
+test "json: write_json_string quote_and_backslash" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    var input: [5]u8;
+    input[0] = 'x'; input[1] = '"'; input[2] = '\\'; input[3] = 'y'; input[4] = 0;
+    write_json_string(?w, ?input[0]);
+
+    var want: [8]u8;
+    want[0] = '"'; want[1] = 'x'; want[2] = '\\'; want[3] = '"';
+    want[4] = '\\'; want[5] = '\\'; want[6] = 'y'; want[7] = '"';
+    if (!sink_is(?sink, ?want[0], 8)) { ret 1; }
+    ret 0;
+}
+
+# a newline is the short `\n` escape; a bare control byte is a `\u00XX` escape.
+test "json: write_json_string control_escapes" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    var nl: [2]u8;
+    nl[0] = 10; nl[1] = 0;
+    write_json_string(?w, ?nl[0]);
+    var want_nl: [4]u8;
+    want_nl[0] = '"'; want_nl[1] = '\\'; want_nl[2] = 'n'; want_nl[3] = '"';
+    if (!sink_is(?sink, ?want_nl[0], 4)) { ret 1; }
+
+    test_writer(?w, ?sink, ?out[0], 32);
+    var c1: [2]u8;
+    c1[0] = 1; c1[1] = 0;
+    write_json_string(?w, ?c1[0]);
+    var want_c1: [8]u8;
+    want_c1[0] = '"'; want_c1[1] = '\\'; want_c1[2] = 'u'; want_c1[3] = '0';
+    want_c1[4] = '0'; want_c1[5] = '0'; want_c1[6] = '1'; want_c1[7] = '"';
+    if (!sink_is(?sink, ?want_c1[0], 8)) { ret 1; }
+    ret 0;
+}
+
+# a two-byte UTF-8 sequence is decoded to a single `\uXXXX` escape.
+test "json: write_json_string utf8_bmp" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    # U+00E9 (e-acute) encodes as 0xC3 0xA9.
+    var input: [3]u8;
+    input[0] = 0xC3; input[1] = 0xA9; input[2] = 0;
+    write_json_string(?w, ?input[0]);
+
+    var want: [8]u8;
+    want[0] = '"'; want[1] = '\\'; want[2] = 'u'; want[3] = '0';
+    want[4] = '0'; want[5] = 'e'; want[6] = '9'; want[7] = '"';
+    if (!sink_is(?sink, ?want[0], 8)) { ret 1; }
+    ret 0;
+}
+
+# an astral code point is decoded to a UTF-16 surrogate pair.
+test "json: write_json_string utf8_astral" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    # U+1F600 (grinning face) encodes as 0xF0 0x9F 0x98 0x80.
+    var input: [5]u8;
+    input[0] = 0xF0; input[1] = 0x9F; input[2] = 0x98; input[3] = 0x80; input[4] = 0;
+    write_json_string(?w, ?input[0]);
+
+    var want: [14]u8;
+    want[0]  = '"'; want[1]  = '\\'; want[2]  = 'u'; want[3]  = 'd';
+    want[4]  = '8'; want[5]  = '3'; want[6]  = 'd'; want[7]  = '\\';
+    want[8]  = 'u'; want[9]  = 'd'; want[10] = 'e'; want[11] = '0';
+    want[12] = '0'; want[13] = '"';
+    if (!sink_is(?sink, ?want[0], 14)) { ret 1; }
+    ret 0;
+}
+
+# whether the sink holds exactly `count` U+FFFD replacement escapes, quoted.
+#
+# A pure run of the replacement escape proves the decoder rejected the input
+# entirely: any accepted (overlong, surrogate, or out-of-range) decode would
+# emit different bytes, and a lone surrogate would emit `\ud...` instead.
+fun sink_is_replacements(s: *TestSink, count: usize) bool {
+    if (s.len != count * 6 + 2) { ret false; }
+    if (s.buf[0] != '"' || s.buf[s.len - 1] != '"') { ret false; }
+    var k: usize = 0;
+    for (k < count) {
+        val b: usize = 1 + k * 6;
+        if (s.buf[b] != '\\' || s.buf[b + 1] != 'u') { ret false; }
+        if (s.buf[b + 2] != 'f' || s.buf[b + 3] != 'f') { ret false; }
+        if (s.buf[b + 4] != 'f' || s.buf[b + 5] != 'd') { ret false; }
+        k = k + 1;
+    }
+    ret true;
+}
+
+# a UTF-16 surrogate encoded as UTF-8 (CESU-8) is rejected, never emitted as a
+# lone `\ud...` escape.
+test "json: write_json_string utf8_surrogate_rejected" {
+    var out:  [64]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 64);
+
+    # U+D800 CESU-8 encodes as 0xED 0xA0 0x80; each byte resyncs to a replacement.
+    var input: [4]u8;
+    input[0] = 0xED; input[1] = 0xA0; input[2] = 0x80; input[3] = 0;
+    write_json_string(?w, ?input[0]);
+    if (!sink_is_replacements(?sink, 3)) { ret 1; }
+    ret 0;
+}
+
+# an overlong 2-byte encoding is rejected.
+test "json: write_json_string utf8_overlong_rejected" {
+    var out:  [64]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 64);
+
+    # 0xC0 0x80 is an overlong NUL; the lead and the stray byte each resync.
+    var input: [3]u8;
+    input[0] = 0xC0; input[1] = 0x80; input[2] = 0;
+    write_json_string(?w, ?input[0]);
+    if (!sink_is_replacements(?sink, 2)) { ret 1; }
+    ret 0;
+}
+
+# a lead byte above the UTF-8 range is rejected.
+test "json: write_json_string utf8_bad_lead_rejected" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    # 0xF5 begins no valid sequence (max lead is 0xF4).
+    var input: [2]u8;
+    input[0] = 0xF5; input[1] = 0;
+    write_json_string(?w, ?input[0]);
+    if (!sink_is_replacements(?sink, 1)) { ret 1; }
+    ret 0;
+}
+
+# a 4-byte sequence decoding above U+10FFFF is rejected.
+test "json: write_json_string utf8_above_max_rejected" {
+    var out:  [64]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 64);
+
+    # 0xF4 0x90 ... would be U+110000; 0x90 is out of 0xF4's [0x80,0x8F] range.
+    var input: [5]u8;
+    input[0] = 0xF4; input[1] = 0x90; input[2] = 0x80; input[3] = 0x80; input[4] = 0;
+    write_json_string(?w, ?input[0]);
+    if (!sink_is_replacements(?sink, 4)) { ret 1; }
+    ret 0;
+}
+
+# a truncated multi-byte sequence (valid prefix, missing tail) is rejected.
+test "json: write_json_string utf8_truncated_rejected" {
+    var out:  [32]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 32);
+
+    # 0xE2 0x82 starts a 3-byte sequence that the NUL terminates early.
+    var input: [3]u8;
+    input[0] = 0xE2; input[1] = 0x82; input[2] = 0;
+    write_json_string(?w, ?input[0]);
+    if (!sink_is_replacements(?sink, 2)) { ret 1; }
+    ret 0;
+}
+
+# a full NDJSON object call sequence renders exact bytes, terminated by a
+# newline; the members carry every field kind and comma boundary.
+test "json: ndjson object exact bytes" {
+    var out:  [64]u8;
+    var sink: TestSink;
+    var w:    writer.Writer;
+    test_writer(?w, ?sink, ?out[0], 64);
+
+    var o: Object;
+    object_begin(?w, ?o);
+    field_i64(?o, "n", 7);
+    field_str(?o, "s", "a\"b");
+    field_bool(?o, "b", true);
+    field_str_or_null(?o, "o", nil);
+    object_end(?o);
+
+    # {"n":7,"s":"a\"b","b":true,"o":null}\n
+    val want: str = "{\"n\":7,\"s\":\"a\\\"b\",\"b\":true,\"o\":null}\n";
+    var wlen: usize = 0;
+    for (want[wlen] != 0) { wlen = wlen + 1; }
+    if (!sink_is(?sink, want::*u8, wlen)) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #338.

## What

Moves the streaming ASCII escaper out of the mach compiler's `mach.cli.json` and into `std.data.json` as the one JSON emission home, unifying it with the tree emitter's `#337` structural escaper into a single escape core.

### One escaper, explicit policy knob

Both emission surfaces now escape string bodies through one core (`escape_unit`) selected by `EscapePolicy`:

- **`ESCAPE_VERBATIM`** (structural-utf8-verbatim) — escapes `"`, `\`, and the C0 controls only; every other byte, including UTF-8 lead/continuation bytes, passes through verbatim. The tree emitter `emit()` uses this, so valid UTF-8 round-trips as UTF-8.
- **`ESCAPE_ENSURE_ASCII`** — as above for bytes `< 0x80`, but each byte `>= 0x80` is UTF-8 decoded (full RFC 3629 validation) and emitted as a `\uXXXX` escape (astral code points as a surrogate pair); invalid UTF-8 emits the U+FFFD replacement escape, so every emitted byte is printable ASCII. The streaming NDJSON surface uses this.

The tree emitter now renders through a counting `io.Writer` (`BufWriter`) instead of a bespoke `Emitter`, so both surfaces share one sink and one escaper. `emit()` keeps its exact measure-when-buffer-short semantics (returns the required length even when the buffer is too small).

### Streaming NDJSON surface (full flat + nested/array)

Ported verbatim from the current-dev `mach.cli.json` (which mach#1838 extended past the original flat surface): `Object`, `Array`, `object_begin`/`object_end`, the nesting primitives `object_end_value`/`field_object_begin`/`field_array_begin`/`array_end`/`array_object_begin`, and the members `field_str`/`field_str_or_null`/`field_null`/`field_i64`/`field_bool`, plus `write_json_string`. The `Object.first`/`Array.first` comma-state machine is ported unchanged. `object_end` closes via `object_end_value` and writes the sole NDJSON line terminator, so a whole nested object lands on one line. Public names match the compiler's exactly, so the mach-side rewire (`refactor/338-json-to-std`, rewiring **both** `testing.mach` and `diagnostic.mach`/`flush_json`) is a `use` swap with no call-site churn.

### Placement rationale

Kept in `std.data.json` itself (not a sibling module). The one escape core stays **private**, shared by both public emission surfaces; a sibling module would force exporting the escaper or adding a third module just to share it. "One home" = one module.

## Byte-identity

- Tree emitter: the pre-existing exact-byte `emit` tests (null/number/bool, array/object round-trips, quote/backslash/control escapes, object keys) all still pass unchanged.
- Streaming emitter: the exact-byte `write_json_string` tests were ported over from `mach.cli.json` (identical inputs and `want` byte arrays); mach#1838's compose tests (nested object + array-of-objects `{"a":1,"loc":{"line":2,"col":3},"rel":[{"label":"x"},{"label":"y"}]}\n`, and empty array `{"rel":[]}\n`) were ported verbatim; and a flat full-object sequence test asserts `{"n":7,"s":"a\"b","b":true,"o":null,"z":null}\n` byte-for-byte (exercising `field_null`).

## Scope

- `#337`/`#340` parse/emit representation-asymmetry warnings preserved intact; `#340` stays open.
- `CHANGELOG.md` `[Unreleased]` entry added.

## Verification

`mach build .` and `mach test .` green — **588 passed, 0 failed** (36 in `std.data.json`: 23 tree + 13 streaming). Both CI checks (build + cross-riscv64) pass.

> Note: `#338` is a mach-std issue; this merge closes it on the mach-std side. The paired mach-side refactor (`refactor/338-json-to-std`) lands separately after the mach-std release and mach.lock bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)