### PR TITLE
chore: permanent [target.linux-arm64] + qemu aarch64 CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,27 @@ jobs:
 
       - name: Cross-compile and run the riscv64 runtime smoke test
         run: bash test/riscv64/verify.sh
+
+  cross-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install mach and qemu
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user
+          mkdir -p /tmp/machdl
+          gh release download --repo briar-systems/mach \
+            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
+          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
+          cp /tmp/machdl/mach /usr/local/bin/mach
+          chmod +x /usr/local/bin/mach
+          mach info
+
+      - name: Cross-build the test suite for aarch64 and run it under qemu
+        run: mach test . --target linux-arm64 --runner qemu-aarch64

--- a/mach.toml
+++ b/mach.toml
@@ -16,6 +16,11 @@ isa = "x86_64"
 os  = "linux"
 abi = "sysv64"
 
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
 [os.windows]
 libs = ["kernel32.dll", "ws2_32.dll", "advapi32.dll", "api-ms-win-core-synch-l1-2-0.dll"]
 


### PR DESCRIPTION
Closes #280

## What

- Adds a permanent `[target.linux-arm64]` (isa=aarch64, os=linux, abi=aapcs64) to std's `mach.toml`, matching mach's own `[target.linux-arm64]`. std is now cross-buildable to aarch64 out of the box.
- Adds a `cross-arm64` CI lane that installs `qemu-user`, cross-builds std's **test suite** for `linux-arm64`, and runs each test under `qemu-aarch64` via `mach test . --target linux-arm64 --runner qemu-aarch64`.

This gives std an independent, automatic aarch64 regression signal over its full unit suite — including `std.data.toml`, the coverage that would have auto-caught the f64 memory-load miscompile from #278/#279. The lane mirrors the install shape of the existing `cross-riscv64` lane.

## Local verification

Cross-built and ran std's suite under `qemu-aarch64` on an x86_64 host with the v2.13.0 seed compiler:

```
588 passed, 0 failed, 588 total
```

Related: #278, #279.