### PR TITLE
feat(data/json): float support in number parsing

### DIFF
--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -1,4 +1,4 @@
-# JSON parser and emitter (integer numbers only).
+# JSON parser and emitter.
 #
 # this module hosts two emission surfaces over one escape core:
 #
@@ -55,6 +55,7 @@ use allo:   std.allocator;
 use writer: std.io.writer;
 use fmt:    std.format;
 use utf8:   std.text.utf8;
+use std.text.parse.parse_f64_len;
 
 pub def Kind: u8;
 pub val NULL:   Kind = 0;
@@ -70,29 +71,34 @@ val USIZE_SIZE: usize = $size_of(usize);
 
 # a parsed JSON value.
 # ---
-# kind:     type discriminator (NULL, BOOL, NUMBER, STRING, ARRAY, OBJECT)
-# bool_val: boolean value (1 = true, 0 = false) when kind == BOOL
-# num_val:  integer value when kind == NUMBER
-# str_val:  pointer into original input when kind == STRING; the RAW on-wire
-#           bytes with escapes intact (use value_string_decode for logical bytes)
-# str_len:  byte length of string (not null-terminated)
-# children: heap-allocated array of child Values (ARRAY or OBJECT)
-# keys:     heap-allocated array of key strings (OBJECT only, parallel with children;
-#           pointers into the original input, not null-terminated)
-# keys_len: heap-allocated array of key byte lengths (parallel with keys)
-# count:    number of children/keys
-# cap:      allocated capacity of children/keys arrays
+# kind:      type discriminator (NULL, BOOL, NUMBER, STRING, ARRAY, OBJECT)
+# bool_val:  boolean value (1 = true, 0 = false) when kind == BOOL
+# is_float:  for a NUMBER, 1 if parsed as a float (had a fraction or exponent),
+#            else 0 (an integer); selects num_val vs float_val
+# num_val:   integer value when kind == NUMBER and is_float == 0
+# float_val: float value when kind == NUMBER and is_float == 1
+# str_val:   pointer into original input when kind == STRING; the RAW on-wire
+#            bytes with escapes intact (use value_string_decode for logical bytes)
+# str_len:   byte length of string (not null-terminated)
+# children:  heap-allocated array of child Values (ARRAY or OBJECT)
+# keys:      heap-allocated array of key strings (OBJECT only, parallel with children;
+#            pointers into the original input, not null-terminated)
+# keys_len:  heap-allocated array of key byte lengths (parallel with keys)
+# count:     number of children/keys
+# cap:       allocated capacity of children/keys arrays
 pub rec Value {
-    kind:     Kind;
-    bool_val: u8;
-    num_val:  i64;
-    str_val:  str;
-    str_len:  usize;
-    children: *Value;
-    keys:     *str;
-    keys_len: *usize;
-    count:    usize;
-    cap:      usize;
+    kind:      Kind;
+    bool_val:  u8;
+    is_float:  u8;
+    num_val:   i64;
+    float_val: f64;
+    str_val:   str;
+    str_len:   usize;
+    children:  *Value;
+    keys:      *str;
+    keys_len:  *usize;
+    count:     usize;
+    cap:       usize;
 }
 
 rec Parser {
@@ -173,9 +179,29 @@ pub fun value_bool(v: *Value) bool {
     ret v.bool_val != 0;
 }
 
-# value_number: get the integer value.
+# value_is_float: whether a NUMBER value was parsed as a float.
+#
+# true for a number with a fraction or exponent, false for an integer-looking
+# number; selects whether to read it with value_float or value_number.
+pub fun value_is_float(v: *Value) bool {
+    ret v.kind == NUMBER && v.is_float != 0;
+}
+
+# value_number: get the integer value of an integer NUMBER.
+#
+# meaningful when the number was parsed as an integer (value_is_float is false);
+# read a float number with value_float.
 pub fun value_number(v: *Value) i64 {
     ret v.num_val;
+}
+
+# value_float: get the value of a NUMBER as a 64-bit float.
+#
+# returns the float value for a number parsed as a float, or the integer value
+# widened to f64 for an integer number, so it is defined for any NUMBER.
+pub fun value_float(v: *Value) f64 {
+    if (v.is_float != 0) { ret v.float_val; }
+    ret v.num_val::f64;
 }
 
 # value_string: get the raw string pointer and length.
@@ -313,7 +339,9 @@ fun make_null() Value {
     var v: Value;
     v.kind = NULL;
     v.bool_val = 0;
+    v.is_float = 0;
     v.num_val = 0;
+    v.float_val = 0.0;
     v.str_val = nil;
     v.str_len = 0;
     v.children = nil;
@@ -335,6 +363,14 @@ fun make_number(n: i64) Value {
     var v: Value = make_null();
     v.kind = NUMBER;
     v.num_val = n;
+    ret v;
+}
+
+fun make_float(f: f64) Value {
+    var v: Value = make_null();
+    v.kind = NUMBER;
+    v.is_float = 1;
+    v.float_val = f;
     ret v;
 }
 
@@ -440,8 +476,15 @@ fun parse_bool(p: *Parser) Result[Value, str] {
     ret ok[Value, str](make_bool(0));
 }
 
+# parse a JSON number (RFC 8259): optional minus, integer part, optional fraction
+# and optional exponent. a number with a fraction or exponent yields a float
+# value (parsed with correct rounding via parse_f64_len over the zero-copy span);
+# an integer-looking number keeps yielding an i64, unchanged.
 fun parse_number(p: *Parser) Result[Value, str] {
+    val start: usize = p.pos;
     var neg: bool = false;
+    var is_float: bool = false;
+
     if (p.src[p.pos] == '-') {
         neg = true;
         p.pos = p.pos + 1;
@@ -460,6 +503,44 @@ fun parse_number(p: *Parser) Result[Value, str] {
 
     if (!has_digit) {
         ret err[Value, str]("invalid number: no digits");
+    }
+
+    if (p.pos < p.len && p.src[p.pos] == '.') {
+        is_float = true;
+        p.pos = p.pos + 1;
+        var frac_digit: bool = false;
+        for (p.pos < p.len && p.src[p.pos] >= '0' && p.src[p.pos] <= '9') {
+            frac_digit = true;
+            p.pos = p.pos + 1;
+        }
+        if (!frac_digit) {
+            ret err[Value, str]("invalid number: no fraction digits");
+        }
+    }
+
+    if (p.pos < p.len && (p.src[p.pos] == 'e' || p.src[p.pos] == 'E')) {
+        is_float = true;
+        p.pos = p.pos + 1;
+        if (p.pos < p.len && (p.src[p.pos] == '+' || p.src[p.pos] == '-')) {
+            p.pos = p.pos + 1;
+        }
+        var exp_digit: bool = false;
+        for (p.pos < p.len && p.src[p.pos] >= '0' && p.src[p.pos] <= '9') {
+            exp_digit = true;
+            p.pos = p.pos + 1;
+        }
+        if (!exp_digit) {
+            ret err[Value, str]("invalid number: no exponent digits");
+        }
+    }
+
+    if (is_float) {
+        val span: str = (p.src::usize + start)::str;
+        val fr: Result[f64, str] = parse_f64_len(span, p.pos - start);
+        if (is_err[f64, str](fr)) {
+            ret err[Value, str](unwrap_err[f64, str](fr));
+        }
+        ret ok[Value, str](make_float(unwrap_ok[f64, str](fr)));
     }
 
     if (neg) { n = 0 - n; }
@@ -952,7 +1033,11 @@ fun emit_value(w: *writer.Writer, v: *Value) {
     }
 
     if (v.kind == NUMBER) {
-        fmt.write_i64(w, v.num_val);
+        if (v.is_float != 0) {
+            fmt.write_f64(w, v.float_val);
+        } or {
+            fmt.write_i64(w, v.num_val);
+        }
         ret;
     }
 
@@ -2062,5 +2147,206 @@ test "json: decode parsed string" {
     if (is_err[usize, str](dr)) { ret 1; }
     if (unwrap_ok[usize, str](dr) != 3) { ret 1; }
     if (buf[0] != 'a' || buf[1] != 0x0a || buf[2] != 'b') { ret 1; }
+    ret 0;
+}
+
+# a fraction makes the number a float, read with value_float.
+test "json: parse float" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "3.14";
+    val r: Result[Value, str] = parse(src::*u8, 4, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (v.kind != NUMBER) { ret 1; }
+    if (!value_is_float(?v)) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < 3.139 || f > 3.141) { ret 1; }
+    ret 0;
+}
+
+# a negative float carries its sign.
+test "json: parse negative float" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "-2.5";
+    val r: Result[Value, str] = parse(src::*u8, 4, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (!value_is_float(?v)) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < -2.51 || f > -2.49) { ret 1; }
+    ret 0;
+}
+
+# an exponent with no fraction still makes the number a float.
+test "json: parse float exponent" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "1e3";
+    val r: Result[Value, str] = parse(src::*u8, 3, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (!value_is_float(?v)) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < 999.0 || f > 1001.0) { ret 1; }
+    ret 0;
+}
+
+# fraction and a signed uppercase exponent together.
+test "json: parse float frac and exponent" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "6.022E2";
+    val r: Result[Value, str] = parse(src::*u8, 7, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (!value_is_float(?v)) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < 602.1 || f > 602.3) { ret 1; }
+    ret 0;
+}
+
+# a negative exponent.
+test "json: parse float negative exponent" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "5e-2";
+    val r: Result[Value, str] = parse(src::*u8, 4, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (!value_is_float(?v)) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < 0.049 || f > 0.051) { ret 1; }
+    ret 0;
+}
+
+# an integer-looking number stays an integer: value_number works, value_is_float
+# is false, and value_float widens it.
+test "json: parse integer unchanged" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "42";
+    val r: Result[Value, str] = parse(src::*u8, 2, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (value_is_float(?v)) { ret 1; }
+    if (value_number(?v) != 42) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < 41.9 || f > 42.1) { ret 1; }
+    ret 0;
+}
+
+# a mixed array keeps integers as integers and floats as floats.
+test "json: parse mixed number array" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "[1,2.5,3]";
+    val r: Result[Value, str] = parse(src::*u8, 9, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (v.kind != ARRAY || v.count != 3) { ret 1; }
+    if (value_is_float(?v.children[0])) { ret 1; }
+    if (value_number(?v.children[0]) != 1) { ret 1; }
+    if (!value_is_float(?v.children[1])) { ret 1; }
+    val f: f64 = value_float(?v.children[1]);
+    if (f < 2.49 || f > 2.51) { ret 1; }
+    if (value_is_float(?v.children[2])) { ret 1; }
+    if (value_number(?v.children[2]) != 3) { ret 1; }
+    ret 0;
+}
+
+# a float value inside an object.
+test "json: parse float in object" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "{\"x\":1.5}";
+    val r: Result[Value, str] = parse(src::*u8, 9, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    val x: *Value = value_find(?v, "x");
+    if (x == nil) { ret 1; }
+    if (!value_is_float(x)) { ret 1; }
+    val f: f64 = value_float(x);
+    if (f < 1.49 || f > 1.51) { ret 1; }
+    ret 0;
+}
+
+# a bare decimal point with no fraction digits is rejected.
+test "json: parse float rejects empty fraction" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "1.";
+    val r: Result[Value, str] = parse(src::*u8, 2, ?a);
+    if (!is_err[Value, str](r)) { ret 1; }
+    ret 0;
+}
+
+# an exponent marker with no digits is rejected.
+test "json: parse float rejects empty exponent" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "1e";
+    val r: Result[Value, str] = parse(src::*u8, 2, ?a);
+    if (!is_err[Value, str](r)) { ret 1; }
+    ret 0;
+}
+
+# a fraction followed by an empty exponent is rejected.
+test "json: parse float rejects frac empty exponent" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "1.5e";
+    val r: Result[Value, str] = parse(src::*u8, 4, ?a);
+    if (!is_err[Value, str](r)) { ret 1; }
+    ret 0;
+}
+
+# a float emits in shortest round-trippable form.
+test "json: emit float" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "1.5";
+    val r: Result[Value, str] = parse(src::*u8, 3, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    var buf: [16]u8;
+    val n: usize = emit(?v, ?buf[0], 16);
+    if (n != 3) { ret 1; }
+    if (buf[0] != '1' || buf[1] != '.' || buf[2] != '5') { ret 1; }
+    ret 0;
+}
+
+# a programmatically built float emits and re-parses as a float.
+test "json: emit built float" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val v: Value = make_float(2.5);
+    var buf: [16]u8;
+    val n: usize = emit(?v, ?buf[0], 16);
+    if (buf[0] != '2' || buf[1] != '.' || buf[2] != '5') { ret 1; }
+    val r: Result[Value, str] = parse(?buf[0], n, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val rv: Value = unwrap_ok[Value, str](r);
+    if (!value_is_float(?rv)) { ret 1; }
+    ret 0;
+}
+
+# a parsed float round-trips through emit and parse back to the same value.
+test "json: float roundtrip parse emit parse" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "3.14159";
+    val r: Result[Value, str] = parse(src::*u8, 7, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    var buf: [32]u8;
+    val n: usize = emit(?v, ?buf[0], 32);
+    val r2: Result[Value, str] = parse(?buf[0], n, ?a);
+    if (is_err[Value, str](r2)) { ret 1; }
+    val v2: Value = unwrap_ok[Value, str](r2);
+    if (!value_is_float(?v2)) { ret 1; }
+    val f: f64 = value_float(?v2);
+    if (f < 3.14158 || f > 3.14160) { ret 1; }
     ret 0;
 }

--- a/src/text/parse.mach
+++ b/src/text/parse.mach
@@ -502,12 +502,26 @@ fun collect_significand(s: str, len: usize, i: *usize, M: *bn.Big, out_dexp: *i6
 }
 
 # stops at the first character that is not part of a valid float. use
-# parse_f64_exact to require full input consumption.
+# parse_f64_exact to require full input consumption, or parse_f64_len for a span
+# that is not null-terminated.
 # ---
 # s:   string to parse
 # ret: the parsed value, or an error message
 pub fun parse_f64(s: str) Result[f64, str] {
-    val len: usize = str_len(s);
+    ret parse_f64_len(s, str_len(s));
+}
+
+# parse a 64-bit floating point number prefix from the first `len` bytes of `s`.
+#
+# like parse_f64 but bounded by an explicit length instead of a null terminator,
+# so it is safe on a byte span embedded in a larger buffer (e.g. a zero-copy
+# slice into a parse input). stops at the first byte that is not part of a valid
+# float, or at `len`.
+# ---
+# s:   the bytes to parse
+# len: the number of bytes available in s
+# ret: the parsed value, or an error message
+pub fun parse_f64_len(s: str, len: usize) Result[f64, str] {
     if (len == 0) { ret err[f64, str]("empty string"); }
 
     var i: usize = 0;
@@ -899,6 +913,23 @@ test "parse: f64 with underscores" {
 
 test "parse: f64 empty string" {
     val r: Result[f64, str] = parse_f64("");
+    if (is_ok[f64, str](r)) { ret 1; }
+    ret 0;
+}
+
+# parse_f64_len stops at `len` and never reads a trailing null, so a float span
+# embedded in a larger buffer parses without consuming its neighbours.
+test "parse: f64_len bounded span" {
+    # only the first 3 bytes ("1.5") are in scope; the "e9" must be ignored.
+    val r: Result[f64, str] = parse_f64_len("1.5e9", 3);
+    if (is_err[f64, str](r)) { ret 1; }
+    val v: f64 = unwrap_ok[f64, str](r);
+    if (v < 1.49 || v > 1.51) { ret 1; }
+    ret 0;
+}
+
+test "parse: f64_len zero length" {
+    val r: Result[f64, str] = parse_f64_len("3.14", 0);
     if (is_ok[f64, str](r)) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Closes #349.

## Problem

`std.data.json` parsed integer numbers only. Downstream `mach-gltf` needs full
JSON numeric support (node transforms, accessor bounds, keyframes, material
factors are all floats), so the loader cannot progress past structural parsing
until floats land here.

## Change

- **Number parsing** now accepts the full RFC 8259 grammar (`int frac? exp?`). A
  number carrying a fraction or exponent becomes a **float**; an integer-looking
  number keeps yielding an `i64`, byte-for-byte the same path and error messages
  as before.
- Float values are parsed with **correct rounding** by reusing
  `std.text.parse`'s bignum decimal→f64 machinery over the **zero-copy source
  span** — no allocation, no copy.
- `Value` gains `is_float` + `float_val`. New accessors:
  - `value_is_float(v) bool` — whether the number was parsed as a float.
  - `value_float(v) f64` — the float value, or an integer widened to `f64`, so it
    is defined for any `NUMBER`.
  - `value_number(v) i64` unchanged; documented as the integer-number accessor.
- `emit` writes floats in shortest round-trippable form (`fmt.write_f64`).

## Enabling change (`std.text.parse`)

`parse_f64` derives its length via `str_len`, assuming null termination — unsafe
on a span embedded in a larger buffer, which is exactly the zero-copy JSON case.
Factored the body into `parse_f64_len(s, len)` (bounded by an explicit length);
`parse_f64` now delegates. No behaviour change for existing callers.

## Tests

json (+14): float with fraction / exponent / signed & uppercase exponent /
negative, integer-stays-integer, mixed int+float array, float in object,
malformed rejection (`1.`, `1e`, `1.5e`), emit exact bytes, built-float emit,
and parse→emit→parse round-trip. parse (+2): `parse_f64_len` bounded span (does
not read past `len`) and zero length. Full suite: 620 passed / 0 failed
(`std.data.json` 52→66). riscv64 cross smoke test green.