### PR TITLE
runtime/linux: make RELRO re-protection failure fatal (part C)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Test
         run: mach test .
 
+      - name: RELRO re-protection contract
+        run: bash test/relro/verify.sh
+
   cross-riscv64:
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +57,9 @@ jobs:
       - name: Cross-compile and run the riscv64 runtime smoke test
         run: bash test/riscv64/verify.sh
 
+      - name: RELRO re-protection contract (riscv64)
+        run: bash test/relro/verify.sh mach linux-riscv64 qemu-riscv64
+
   cross-arm64:
     runs-on: ubuntu-latest
     steps:
@@ -77,3 +83,6 @@ jobs:
 
       - name: Cross-build the test suite for aarch64 and run it under qemu
         run: mach test . --target linux-arm64 --runner qemu-aarch64
+
+      - name: RELRO re-protection contract (aarch64)
+        run: bash test/relro/verify.sh mach linux-arm64 qemu-aarch64

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ cmach
 tmp
 output
 dep
+
+# core dumps from the RELRO fault probe (test/relro)
+*.core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- runtime/linux: RELRO re-protection is now fatal on any failure. `_rt_relocate`'s
+  `PT_GNU_RELRO` re-protection was best-effort — it skipped a region not congruent
+  with the runtime page and ignored the `mprotect` result. Now that the ELF writer
+  aligns every segment to the target's max page (≥ any supported kernel page,
+  mach#1845), the region is always a whole number of runtime pages, so an absent
+  `AT_PAGESZ`, a congruence mismatch, or a failed `mprotect` is a broken
+  environment or a violated layout contract. The extracted `relro_reprotect`
+  panics naming the violated invariant in each case — the glibc stance, matching
+  `os.page_size`'s `AT_PAGESZ` precedent (#336) — so a `--pie` binary either runs
+  fully hardened or dies loudly; no silent-unhardened path remains (#347).
 - system: `os.page_size` on linux now returns the runtime `AT_PAGESZ` the
   entrypoint captures from the auxiliary vector at startup, instead of a
   hardcoded 4096 — correct on aarch64 kernels configured for 16 KiB or 64 KiB

--- a/src/runtime/linux/reloc.mach
+++ b/src/runtime/linux/reloc.mach
@@ -18,9 +18,13 @@
 # applied unconditionally.
 #
 # RELRO: once the relocations are applied, the region the writer marked PT_GNU_RELRO
-# (`.rodata` holding relocated constants, mapped writable for this pass) is mprotect'd
-# read-only, restoring the hardening of those constants before `main`. This step runs
-# after relocation, so it may use the ordinary syscall path.
+# (`.data.rel.ro` holding relocated constants, mapped writable for this pass) is
+# mprotect'd read-only, restoring the hardening of those constants before `main`. This
+# step runs after relocation, so it may use the ordinary syscall path. Its re-protection
+# is now fatal on any failure (`relro_reprotect`): once the ELF writer aligns segments to
+# the target's max page (>= every supported kernel page, briar-systems/mach#1845), a
+# congruence mismatch, an absent AT_PAGESZ, or a failed mprotect is a broken environment
+# or a violated layout contract, not a skippable degradation.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -30,6 +34,10 @@ use std.types.size.usize;
 # for the post-relocation RELRO mprotect (see `_rt_relocate`); safe here because it is
 # reached only after every RELATIVE entry has been slid, never before.
 use sys: std.system.os.linux.shared;
+
+# `relro_reprotect` aborts naming the violated invariant when the region cannot be
+# hardened; panic is reached only post-relocation, so its message pointer is already slid.
+use std.system.panic.panic;
 
 # read a u64 at a raw runtime address. PIC: pure pointer arithmetic, no global.
 # ---
@@ -143,20 +151,53 @@ pub fun _rt_relocate(envp: *u64) {
         }
     }
 
-    # RELRO: re-protect the region the PIE writer marked PT_GNU_RELRO. it holds relocated
-    # constants (vtables, `val` pointer globals) mapped writable for the pass above; now
-    # that they are slid, mprotect it read-only to restore their hardening before `main`.
-    # the writer emits p_vaddr page-aligned and p_memsz already page-rounded, so this does
-    # no arithmetic: it gates on the region being a whole number of runtime pages and
-    # mprotects it exactly. AT_PAGESZ is mandatory on linux; when it is absent, or the
-    # region is not congruent with the runtime page (a kernel page larger than the writer's
-    # 4 KiB segment alignment - briar-systems/mach-std#336), the region is left writable
-    # (correct, just unhardened) rather than risking EINVAL or over-protecting the next
-    # segment. this best-effort skip is the one large-page degradation.
-    if (relro_va != 0 && relro_sz != 0 && at_pagesz != 0) {
-        val relro_start: u64 = bias + relro_va;
-        if (relro_start % at_pagesz == 0 && relro_sz % at_pagesz == 0) {
-            sys.protect(relro_start::usize::ptr, relro_sz::usize, sys.PROT_READ::u32);
-        }
+    # RELRO: re-protect the region the PIE writer marked PT_GNU_RELRO. it holds the
+    # relocated constants (`.data.rel.ro`) mapped writable for the pass above; now that
+    # they are slid, restore them read-only before `main`. done only when the image
+    # actually carries a RELRO region - a `--pie` binary with no reloc-bearing constants
+    # emits none, and re-protecting nothing is correct. `relro_reprotect` enforces the
+    # page-congruence and mprotect invariants fatally.
+    if (relro_va != 0 && relro_sz != 0) {
+        relro_reprotect(bias + relro_va, relro_sz, at_pagesz);
+    }
+}
+
+# re-protect the PT_GNU_RELRO region read-only, or abort naming the violated invariant
+#
+# The region holds the relocated constants (`.data.rel.ro`: vtables, `val` pointer
+# globals, `str` literals) mapped writable for the relocation pass; once the RELATIVE
+# slots are slid it must be restored read-only before `main`. This was best-effort - it
+# skipped a region not congruent with the runtime page and ignored the mprotect result -
+# the documented large-page degradation while the writer aligned segments to a fixed 4 KiB
+# (briar-systems/mach-std#336). Now that the ELF writer aligns every segment to the
+# target's max page (>= any supported kernel page, briar-systems/mach#1845), the region is
+# always a whole number of runtime pages, so neither escape is legitimate: an absent
+# AT_PAGESZ, a congruence mismatch, or an mprotect failure is a broken environment or a
+# violated layout contract, and running unhardened would silently mask it. Each aborts
+# naming the invariant - the glibc stance, matching `std.system.os.page_size`'s AT_PAGESZ
+# precedent (#336/#343).
+#
+# Reached only after relocation (it uses panic + the syscall path), so its message
+# pointers are already slid; `_rt_relocate` invokes it once the RELATIVE slots are applied.
+# ---
+# relro_start: the runtime start address of the region (load bias + PT_GNU_RELRO p_vaddr)
+# relro_sz:    the region size (PT_GNU_RELRO p_memsz, page-rounded by the writer)
+# at_pagesz:   the runtime page size from AT_PAGESZ (0 when the auxv lacked it)
+pub fun relro_reprotect(relro_start: u64, relro_sz: u64, at_pagesz: u64) {
+    # AT_PAGESZ is a mandatory linux auxv entry; a 0 under a live RELRO region means a
+    # broken or nonstandard environment, not a page size to guess.
+    if (at_pagesz == 0) {
+        panic("std.runtime.linux.reloc: AT_PAGESZ absent with a PT_GNU_RELRO region (mandatory linux auxv entry missing)\n");
+    }
+    # the writer max-page-aligns segments (mach#1845), so p_vaddr and the page-rounded
+    # p_memsz are always whole runtime pages; a mismatch means the loaded image violated
+    # that layout contract (or ran on a kernel page larger than the build's max page).
+    if (relro_start % at_pagesz != 0 || relro_sz % at_pagesz != 0) {
+        panic("std.runtime.linux.reloc: PT_GNU_RELRO region not congruent with the runtime page (violated max-page layout contract; see mach#1845)\n");
+    }
+    # a failed re-protect leaves the relocated constants writable through `main`; refuse to
+    # run silently unhardened.
+    if (sys.protect(relro_start::usize::ptr, relro_sz::usize, sys.PROT_READ::u32) != 0) {
+        panic("std.runtime.linux.reloc: mprotect of the PT_GNU_RELRO region failed (cannot restore read-only hardening)\n");
     }
 }

--- a/test/relro/mach.toml
+++ b/test/relro/mach.toml
@@ -1,0 +1,36 @@
+[project]
+id      = "relroprobe"
+name    = "relroprobe"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+
+[bin.relro_happy]
+entry = "happy.mach"
+
+[bin.relro_fault]
+entry = "fault.mach"
+
+[deps.std]
+path = "dep/std"

--- a/test/relro/src/fault.mach
+++ b/test/relro/src/fault.mach
@@ -1,0 +1,16 @@
+# RELRO negative-path probe: force `relro_reprotect` down its congruence-invariant branch
+# and confirm it aborts loudly. A region size that is not a whole number of the runtime
+# page (0x1000 under a 0x4000 page) is exactly the large-page mismatch that was silently
+# skipped before #347; now it panics naming the invariant and dies by signal. The forced
+# inputs never reach the mprotect, so no live mapping is touched. verify.sh asserts the
+# panic message on stderr and death by signal.
+use std.runtime;
+use reloc: std.runtime.linux.reloc;
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    # 0x1000 % 0x4000 != 0: the region is not congruent with the runtime page.
+    reloc.relro_reprotect(0x1000, 0x1000, 0x4000);
+    # unreachable: relro_reprotect panics on the mismatch above.
+    ret 0;
+}

--- a/test/relro/src/happy.mach
+++ b/test/relro/src/happy.mach
@@ -1,0 +1,18 @@
+# RELRO happy-path probe: a --pie binary whose read-only data carries a relocated
+# constant pointer, so the writer emits a PT_GNU_RELRO region. `_rt_relocate` slides the
+# pointer and `relro_reprotect` restores the region read-only before `main`; reading
+# through the pointer proves relocation ran, and reaching `ret` proves re-protection
+# succeeded (no panic). verify.sh asserts the exit code.
+use std.runtime;
+
+# a mutable target and a read-only pointer to it: the pointer is a relocated constant, so
+# it lands in the RELRO region and forces PT_GNU_RELRO emission.
+var target: i64 = 42;
+val c_ptr: *i64 = ?target;
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    # read through the relocated constant pointer (proves self-relocation applied it) and
+    # return its value; `_rt_relocate` already re-protected the region read-only.
+    ret c_ptr[0];
+}

--- a/test/relro/verify.sh
+++ b/test/relro/verify.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# build the RELRO probes against this checkout's std and assert both paths of the
+# post-#347 re-protection contract:
+#   * happy   - a --pie binary with a relocated constant pointer runs fully hardened and
+#               returns 42 (self-relocation + re-protection succeeded, no panic).
+#   * fault   - forcing relro_reprotect down its congruence-invariant branch aborts loudly:
+#               the panic message reaches stderr and the process dies by signal.
+#
+# the fault path is compiler-independent (it calls relro_reprotect with forced incongruent
+# args), so it exercises the fatal branch even under a mach seed whose writer predates the
+# max-page layout - see the PR's CI-seed note.
+#
+# usage: verify.sh [path-to-mach] [target] [runner]
+#   target defaults to linux (native x86_64); runner wraps execution (e.g. qemu-aarch64).
+set -euo pipefail
+
+# the fault probe dies by signal (SIGTRAP/SIGSEGV from the panic trap); suppress the core
+# dump it would otherwise leave in the working tree.
+ulimit -c 0 2>/dev/null || true
+
+expect_happy=42
+
+mach="${1:-mach}"
+target="${2:-linux}"
+runner="${3:-}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+run()  { if [ -n "$runner" ]; then "$runner" "$@"; else "$@"; fi; }
+
+# vendor this checkout's std as the path dependency (dep/std -> repo root).
+mkdir -p dep
+ln -sfn "$(cd ../.. && pwd)" dep/std
+
+echo "building the RELRO probes --pie with $mach (target $target)"
+rm -rf out
+"$mach" build . --target "$target" --pie --profile debug
+happy="$(find out -name relro_happy -type f -print -quit)"
+fault="$(find out -name relro_fault -type f -print -quit)"
+[ -n "$happy" ] || fail "no relro_happy binary produced"
+[ -n "$fault" ] || fail "no relro_fault binary produced"
+
+echo "happy path: running $happy (expect exit $expect_happy, fully hardened)"
+set +e
+run "$happy"
+code=$?
+set -e
+[ "$code" -eq "$expect_happy" ] || fail "happy path exit $code, expected $expect_happy"
+echo "  OK: ran hardened, exit $expect_happy"
+
+echo "negative path: running $fault (expect panic on stderr + death by signal)"
+set +e
+err="$(run "$fault" 2>&1 1>/dev/null)"
+code=$?
+set -e
+# death by signal surfaces as exit 128+signo both natively and under qemu-user.
+[ "$code" -ge 128 ] || fail "fault path exit $code, expected death by signal (>=128)"
+echo "$err" | grep -q "not congruent with the runtime page" \
+    || fail "fault path missing the congruence panic message; got: $err"
+echo "  OK: died by signal (exit $code), panic named the invariant"
+
+echo "OK: RELRO re-protection is fatal on invariant breach and hardened on the happy path"


### PR DESCRIPTION
Closes #347. Completes the RELRO end-state trio (with mach#1844 + mach#1845, both merged).

## What

`_rt_relocate`'s PT_GNU_RELRO re-protection was best-effort — it skipped a region not congruent with the runtime page (the documented large-page degradation) and ignored the `mprotect` result. Now that the ELF writer aligns every segment to the target's max page (≥ any supported kernel page, mach#1845), the region is always a whole number of runtime pages, so neither escape is legitimate.

Extracted the step into `relro_reprotect`, which adopts the glibc stance — panic naming the violated invariant (matching `std.system.os.page_size`'s AT_PAGESZ precedent, #336/#343) in each case:
- AT_PAGESZ absent under a live RELRO region (mandatory linux auxv entry missing),
- RELRO region not congruent with the runtime page (violated max-page layout contract),
- `mprotect` failure (cannot restore read-only hardening).

No silent-unhardened path remains: a `--pie` binary either runs fully hardened or dies loudly naming the invariant.

## Acceptance status

- [x] happy path unchanged — `mach build .` + `mach test .` green (620/620) on the CI-seeded released mach
- [ ] negative path probe-verified (forced misalignment → panic on stderr + death by signal) — probe + CI job to follow in this PR
- [ ] happy path on aarch64/riscv64 qemu

## CI-seed note

mach-std CI seeds the released mach (v2.13.0), which predates mach#1844/#1845 — its `--pie` writer emits a 4 KiB-aligned whole-`.rodata` RELRO, which stays congruent on the 4 KiB CI runners (happy path). The new fatal branches are exercised by a direct-call probe (forced incongruent args), which is compiler-independent, so CI covers them without the new writer. The full new-writer layout is exercised once mach-std's pin bumps to the next mach release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)