### PR TITLE
release: arm64 CI lane, json decode + floats, fatal RELRO re-protect

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Test
         run: mach test .
 
+      - name: RELRO re-protection contract
+        run: bash test/relro/verify.sh
+
   cross-riscv64:
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +57,9 @@ jobs:
       - name: Cross-compile and run the riscv64 runtime smoke test
         run: bash test/riscv64/verify.sh
 
+      - name: RELRO re-protection contract (riscv64)
+        run: bash test/relro/verify.sh mach linux-riscv64 qemu-riscv64
+
   cross-arm64:
     runs-on: ubuntu-latest
     steps:
@@ -77,3 +83,6 @@ jobs:
 
       - name: Cross-build the test suite for aarch64 and run it under qemu
         run: mach test . --target linux-arm64 --runner qemu-aarch64
+
+      - name: RELRO re-protection contract (aarch64)
+        run: bash test/relro/verify.sh mach linux-arm64 qemu-aarch64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,27 @@ jobs:
 
       - name: Cross-compile and run the riscv64 runtime smoke test
         run: bash test/riscv64/verify.sh
+
+  cross-arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install mach and qemu
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-user
+          mkdir -p /tmp/machdl
+          gh release download --repo briar-systems/mach \
+            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
+          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
+          cp /tmp/machdl/mach /usr/local/bin/mach
+          chmod +x /usr/local/bin/mach
+          mach info
+
+      - name: Cross-build the test suite for aarch64 and run it under qemu
+        run: mach test . --target linux-arm64 --runner qemu-aarch64

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ cmach
 tmp
 output
 dep
+
+# core dumps from the RELRO fault probe (test/relro)
+*.core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- runtime/linux: RELRO re-protection is now fatal on any failure. `_rt_relocate`'s
+  `PT_GNU_RELRO` re-protection was best-effort — it skipped a region not congruent
+  with the runtime page and ignored the `mprotect` result. Now that the ELF writer
+  aligns every segment to the target's max page (≥ any supported kernel page,
+  mach#1845), the region is always a whole number of runtime pages, so an absent
+  `AT_PAGESZ`, a congruence mismatch, or a failed `mprotect` is a broken
+  environment or a violated layout contract. The extracted `relro_reprotect`
+  panics naming the violated invariant in each case — the glibc stance, matching
+  `os.page_size`'s `AT_PAGESZ` precedent (#336) — so a `--pie` binary either runs
+  fully hardened or dies loudly; no silent-unhardened path remains (#347).
 - system: `os.page_size` on linux now returns the runtime `AT_PAGESZ` the
   entrypoint captures from the auxiliary vector at startup, instead of a
   hardcoded 4096 — correct on aarch64 kernels configured for 16 KiB or 64 KiB

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,7 @@
+Copyright 2026 octalide
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “Software”), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/mach.toml
+++ b/mach.toml
@@ -16,6 +16,11 @@ isa = "x86_64"
 os  = "linux"
 abi = "sysv64"
 
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
 [os.windows]
 libs = ["kernel32.dll", "ws2_32.dll", "advapi32.dll", "api-ms-win-core-synch-l1-2-0.dll"]
 

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -28,12 +28,16 @@
 #     streaming emitter uses this so a machine consumer reads a stable, valid
 #     stream regardless of the bytes a test label or path carries.
 #
-# WARNING: parse and emit disagree on what a string's bytes mean. parse yields
-# raw wire bytes with escapes intact; emit treats str_val as logical bytes and
-# re-escapes '"', '\', and control bytes. so emitting a tree that came from
-# parse double-escapes any wire escapes it contained (parse "a\nb" -> str_val
-# a\nb -> emit "a\\nb"). build trees with make_string for emission; do not
-# round-trip parse -> emit for strings holding escapes. tracked in mach-std#340.
+# string bytes have two representations. parse stores the RAW on-wire bytes
+# between the quotes with escapes intact (value_string returns these, zero-copy);
+# emit treats str_val as LOGICAL bytes and escapes '"', '\', and control bytes.
+# the two meanings are bridged by value_string_decode, which resolves the wire
+# escapes of a parsed string into logical bytes at the point of consumption --
+# the inverse of the emit escaper, so decode(parse(emit(v))) recovers v's logical
+# bytes. a parsed tree must therefore be decoded before its strings are treated
+# as logical text: emitting a parsed str_val verbatim double-escapes any wire
+# escapes it held (parse "a\nb" -> raw a\nb -> emit "a\\nb"), so build trees with
+# make_string from already-logical bytes for emission. see mach-std#340.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -50,6 +54,7 @@ use std.memory.raw_copy;
 use allo:   std.allocator;
 use writer: std.io.writer;
 use fmt:    std.format;
+use utf8:   std.text.utf8;
 
 pub def Kind: u8;
 pub val NULL:   Kind = 0;
@@ -68,7 +73,8 @@ val USIZE_SIZE: usize = $size_of(usize);
 # kind:     type discriminator (NULL, BOOL, NUMBER, STRING, ARRAY, OBJECT)
 # bool_val: boolean value (1 = true, 0 = false) when kind == BOOL
 # num_val:  integer value when kind == NUMBER
-# str_val:  pointer into original input when kind == STRING
+# str_val:  pointer into original input when kind == STRING; the RAW on-wire
+#           bytes with escapes intact (use value_string_decode for logical bytes)
 # str_len:  byte length of string (not null-terminated)
 # children: heap-allocated array of child Values (ARRAY or OBJECT)
 # keys:     heap-allocated array of key strings (OBJECT only, parallel with children;
@@ -172,13 +178,49 @@ pub fun value_number(v: *Value) i64 {
     ret v.num_val;
 }
 
-# value_string: get the string pointer and length.
+# value_string: get the raw string pointer and length.
+#
+# for a parsed value these are the RAW on-wire bytes between the quotes, escapes
+# intact and zero-copy into the input (parse "a\nb" yields the 4 bytes a \ n b);
+# use value_string_decode to resolve the escapes into logical bytes.
 # ---
 # len: receives the byte length of the string
-# ret: pointer to the first byte of the string content
+# ret: pointer to the first byte of the raw string content
 pub fun value_string(v: *Value, len: *usize) *u8 {
     @len = v.str_len;
     ret v.str_val::*u8;
+}
+
+# value_string_decode: decode the raw wire bytes of a string value into logical
+# bytes, resolving JSON escapes into a caller buffer.
+#
+# the inverse of the emit escaper: '\"' '\\' '\/' become '"' '\' '/', '\b' '\f'
+# '\n' '\r' '\t' become their control bytes, and '\uXXXX' decodes to UTF-8 (a
+# high+low surrogate pair combines into one astral code point). unescaped bytes,
+# including raw UTF-8, pass through verbatim. the parser stores raw wire bytes
+# (see value_string), so this is where a parsed string becomes logical text.
+#
+# bytes are written into `buf` up to `len`; the full decoded length is always
+# returned, so a caller can size the buffer by passing len 0 (or a short buffer)
+# and calling again once `buf` is large enough (as with emit).
+# ---
+# v:   the value whose raw string bytes to decode (str_val/str_len)
+# buf: destination buffer for the decoded bytes
+# len: capacity of buf in bytes
+# ret: the decoded byte length on success (may exceed len), or an error message
+#      if the bytes hold a malformed escape (unknown escape, a '\u' without four
+#      hex digits, or an ill-formed surrogate pair)
+pub fun value_string_decode(v: *Value, buf: *u8, len: usize) Result[usize, str] {
+    var b: BufWriter;
+    b.data = buf;
+    b.cap  = len;
+    b.pos  = 0;
+    var w: writer.Writer;
+    w.ctx      = (?b)::ptr;
+    w.fn_write = bufw_write;
+    val dr: Result[bool, str] = decode_bytes(?w, v.str_val::*u8, v.str_len);
+    if (is_err[bool, str](dr)) { ret err[usize, str](unwrap_err[bool, str](dr)); }
+    ret ok[usize, str](b.pos);
 }
 
 # value_count: get the number of children (array elements or object entries).
@@ -761,6 +803,137 @@ fun write_u_hex(w: *writer.Writer, code: u32) {
 fun hex_digit(n: u32) u8 {
     if (n < 10) { ret n::u8 + '0'; }
     ret n::u8 - 10 + 'a';
+}
+
+# decode s[0..slen) -- the raw wire bytes of a JSON string body, escapes intact
+# -- into logical bytes written through w. See value_string_decode for the
+# escape matrix and the malformed-escape error contract.
+# ---
+# w:    the writer to emit decoded bytes through
+# s:    the raw string bytes
+# slen: the byte length of s
+# ret:  true on success, or an error message on a malformed escape
+fun decode_bytes(w: *writer.Writer, s: *u8, slen: usize) Result[bool, str] {
+    var i: usize = 0;
+    for (i < slen) {
+        val ir: Result[usize, str] = decode_unit(w, s, i, slen);
+        if (is_err[usize, str](ir)) { ret err[bool, str](unwrap_err[usize, str](ir)); }
+        i = unwrap_ok[usize, str](ir);
+    }
+    ret ok[bool, str](true);
+}
+
+# decode one unit of `s` starting at `i` -- a verbatim byte or an escape sequence
+# -- writing the logical bytes through w and returning the next byte index.
+# ---
+# w:    the writer to emit through
+# s:    the raw string bytes
+# i:    the byte index to decode
+# slen: the byte length of s
+# ret:  the index of the next byte, or an error message on a malformed escape
+fun decode_unit(w: *writer.Writer, s: *u8, i: usize, slen: usize) Result[usize, str] {
+    val c: u8 = s[i];
+    if (c != '\\') {
+        fmt.write_byte(w, c);
+        ret ok[usize, str](i + 1);
+    }
+    if (i + 1 >= slen) {
+        ret err[usize, str]("trailing backslash in string");
+    }
+    val e: u8 = s[i + 1];
+    if (e == '"')  { fmt.write_byte(w, '"');  ret ok[usize, str](i + 2); }
+    if (e == '\\') { fmt.write_byte(w, '\\'); ret ok[usize, str](i + 2); }
+    if (e == '/')  { fmt.write_byte(w, '/');  ret ok[usize, str](i + 2); }
+    if (e == 'b')  { fmt.write_byte(w, 0x08); ret ok[usize, str](i + 2); }
+    if (e == 'f')  { fmt.write_byte(w, 0x0c); ret ok[usize, str](i + 2); }
+    if (e == 'n')  { fmt.write_byte(w, 0x0a); ret ok[usize, str](i + 2); }
+    if (e == 'r')  { fmt.write_byte(w, 0x0d); ret ok[usize, str](i + 2); }
+    if (e == 't')  { fmt.write_byte(w, 0x09); ret ok[usize, str](i + 2); }
+    if (e == 'u')  { ret decode_u_escape(w, s, i, slen); }
+    ret err[usize, str]("invalid escape sequence");
+}
+
+# decode a '\uXXXX' escape at `i` (the backslash) into UTF-8 written through w,
+# combining a high+low surrogate pair into one astral code point. Returns the
+# index past the escape (or the pair), or an error on truncated/non-hex digits or
+# an ill-formed surrogate pair.
+# ---
+# w:    the writer to emit through
+# s:    the raw string bytes
+# i:    the index of the escape's backslash
+# slen: the byte length of s
+# ret:  the index of the next byte, or an error message
+fun decode_u_escape(w: *writer.Writer, s: *u8, i: usize, slen: usize) Result[usize, str] {
+    val hr: Result[u32, str] = read_hex4(s, i + 2, slen);
+    if (is_err[u32, str](hr)) { ret err[usize, str](unwrap_err[u32, str](hr)); }
+    val u: u32 = unwrap_ok[u32, str](hr);
+
+    if (u >= 0xD800 && u <= 0xDBFF) {
+        val j: usize = i + 6;
+        if (j + 1 >= slen || s[j] != '\\' || s[j + 1] != 'u') {
+            ret err[usize, str]("unpaired high surrogate");
+        }
+        val lr: Result[u32, str] = read_hex4(s, j + 2, slen);
+        if (is_err[u32, str](lr)) { ret err[usize, str](unwrap_err[u32, str](lr)); }
+        val lo: u32 = unwrap_ok[u32, str](lr);
+        if (lo < 0xDC00 || lo > 0xDFFF) {
+            ret err[usize, str]("invalid low surrogate");
+        }
+        val cp: u32 = 0x10000 + ((u - 0xD800) << 10) + (lo - 0xDC00);
+        write_utf8_bytes(w, cp);
+        ret ok[usize, str](j + 6);
+    }
+
+    if (u >= 0xDC00 && u <= 0xDFFF) {
+        ret err[usize, str]("unexpected low surrogate");
+    }
+
+    write_utf8_bytes(w, u);
+    ret ok[usize, str](i + 6);
+}
+
+# read the four hex digits of a '\uXXXX' escape starting at `i` (the first digit),
+# returning the 16-bit value.
+# ---
+# s:    the raw string bytes
+# i:    the index of the first hex digit
+# slen: the byte length of s
+# ret:  the decoded 16-bit value, or an error if truncated or non-hex
+fun read_hex4(s: *u8, i: usize, slen: usize) Result[u32, str] {
+    if (i + 4 > slen) {
+        ret err[u32, str]("truncated unicode escape");
+    }
+    var v: u32 = 0;
+    var k: usize = 0;
+    for (k < 4) {
+        val d: u32 = hex_nibble(s[i + k]);
+        if (d > 0xF) { ret err[u32, str]("invalid unicode escape hex"); }
+        v = (v << 4) | d;
+        k = k + 1;
+    }
+    ret ok[u32, str](v);
+}
+
+# map a hex ASCII digit to its 0-15 value, or 0x100 if the byte is not hex.
+# ---
+# c:   the candidate hex digit byte
+# ret: the nibble value, or 0x100 for a non-hex byte
+fun hex_nibble(c: u8) u32 {
+    if (c >= '0' && c <= '9') { ret (c - '0')::u32; }
+    if (c >= 'a' && c <= 'f') { ret (c - 'a' + 10)::u32; }
+    if (c >= 'A' && c <= 'F') { ret (c - 'A' + 10)::u32; }
+    ret 0x100;
+}
+
+# encode a validated scalar (never a surrogate, <= U+10FFFF) as UTF-8 bytes
+# written through w.
+# ---
+# w:  the writer to emit through
+# cp: the Unicode scalar value
+fun write_utf8_bytes(w: *writer.Writer, cp: u32) {
+    var tmp: [4]u8;
+    val n: usize = utf8.encode(cp::utf8.Codepoint, ?tmp[0], 4);
+    fmt.write_bytes(w, ?tmp[0], n);
 }
 
 fun emit_value(w: *writer.Writer, v: *Value) {

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -1865,3 +1865,202 @@ test "json: ndjson empty array" {
     if (!sink_is(?sink, want, wl)) { ret 1; }
     ret 0;
 }
+
+# decode a raw string body through value_string_decode and compare the result to
+# `want`.
+fun decode_check(raw: *u8, rawlen: usize, want: *u8, wantlen: usize) bool {
+    val v: Value = make_string((raw::usize)::str, rawlen);
+    var buf: [64]u8;
+    val dr: Result[usize, str] = value_string_decode(?v, ?buf[0], 64);
+    if (is_err[usize, str](dr)) { ret false; }
+    val n: usize = unwrap_ok[usize, str](dr);
+    if (n != wantlen) { ret false; }
+    var i: usize = 0;
+    for (i < n) {
+        if (buf[i] != want[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# whether value_string_decode rejects the given raw string body.
+fun decode_rejects(raw: *u8, rawlen: usize) bool {
+    val v: Value = make_string((raw::usize)::str, rawlen);
+    var buf: [64]u8;
+    val dr: Result[usize, str] = value_string_decode(?v, ?buf[0], 64);
+    ret is_err[usize, str](dr);
+}
+
+# a body with no escapes decodes to itself, raw UTF-8 included.
+test "json: decode verbatim" {
+    var raw:  [5]u8 = [5]u8{'a', 0xC3, 0xA9, 'z', '!'};
+    var want: [5]u8 = [5]u8{'a', 0xC3, 0xA9, 'z', '!'};
+    if (!decode_check(?raw[0], 5, ?want[0], 5)) { ret 1; }
+    ret 0;
+}
+
+# the short escapes decode to their literal bytes.
+test "json: decode short escapes" {
+    # \" \\ \/ \b \f \n \r \t
+    var raw:  [16]u8 = [16]u8{'\\', '"', '\\', '\\', '\\', '/', '\\', 'b', '\\', 'f', '\\', 'n', '\\', 'r', '\\', 't'};
+    var want: [8]u8 = [8]u8{'"', '\\', '/', 0x08, 0x0c, 0x0a, 0x0d, 0x09};
+    if (!decode_check(?raw[0], 16, ?want[0], 8)) { ret 1; }
+    ret 0;
+}
+
+# a \uXXXX BMP escape decodes to its UTF-8 bytes.
+test "json: decode unicode bmp" {
+    # é -> U+00E9 -> 0xC3 0xA9
+    var raw:  [6]u8 = [6]u8{'\\', 'u', '0', '0', 'e', '9'};
+    var want: [2]u8 = [2]u8{0xC3, 0xA9};
+    if (!decode_check(?raw[0], 6, ?want[0], 2)) { ret 1; }
+    ret 0;
+}
+
+# a \uXXXX escape in the ASCII range decodes to one byte.
+test "json: decode unicode ascii" {
+    # A -> 'A'
+    var raw:  [6]u8 = [6]u8{'\\', 'u', '0', '0', '4', '1'};
+    var want: [1]u8 = [1]u8{'A'};
+    if (!decode_check(?raw[0], 6, ?want[0], 1)) { ret 1; }
+    ret 0;
+}
+
+# uppercase hex digits decode identically to lowercase.
+test "json: decode unicode uppercase hex" {
+    # é -> U+00E9 -> 0xC3 0xA9
+    var raw:  [6]u8 = [6]u8{'\\', 'u', '0', '0', 'E', '9'};
+    var want: [2]u8 = [2]u8{0xC3, 0xA9};
+    if (!decode_check(?raw[0], 6, ?want[0], 2)) { ret 1; }
+    ret 0;
+}
+
+# a high+low surrogate pair decodes to one astral code point in UTF-8.
+test "json: decode surrogate pair" {
+    # 😀 -> U+1F600 -> 0xF0 0x9F 0x98 0x80
+    var raw:  [12]u8 = [12]u8{'\\', 'u', 'd', '8', '3', 'd', '\\', 'u', 'd', 'e', '0', '0'};
+    var want: [4]u8 = [4]u8{0xF0, 0x9F, 0x98, 0x80};
+    if (!decode_check(?raw[0], 12, ?want[0], 4)) { ret 1; }
+    ret 0;
+}
+
+# value_string_decode reports the full decoded length even when the buffer is too
+# small, so a caller can size then fill (as with emit).
+test "json: decode buffer sizing" {
+    # 😀 decodes to 4 bytes
+    var raw: [12]u8 = [12]u8{'\\', 'u', 'd', '8', '3', 'd', '\\', 'u', 'd', 'e', '0', '0'};
+    val v: Value = make_string(((?raw[0])::usize)::str, 12);
+
+    var probe: [1]u8;
+    val sr: Result[usize, str] = value_string_decode(?v, ?probe[0], 0);
+    if (is_err[usize, str](sr)) { ret 1; }
+    if (unwrap_ok[usize, str](sr) != 4) { ret 1; }
+
+    var buf: [4]u8;
+    val dr: Result[usize, str] = value_string_decode(?v, ?buf[0], 4);
+    if (is_err[usize, str](dr)) { ret 1; }
+    if (unwrap_ok[usize, str](dr) != 4) { ret 1; }
+    if (buf[0] != 0xF0 || buf[1] != 0x9F || buf[2] != 0x98 || buf[3] != 0x80) { ret 1; }
+    ret 0;
+}
+
+# an unknown escape character is rejected.
+test "json: decode rejects bad escape" {
+    var raw: [2]u8 = [2]u8{'\\', 'x'};
+    if (!decode_rejects(?raw[0], 2)) { ret 1; }
+    ret 0;
+}
+
+# a \u escape without four hex digits is rejected.
+test "json: decode rejects truncated unicode" {
+    var raw: [4]u8 = [4]u8{'\\', 'u', '1', '2'};
+    if (!decode_rejects(?raw[0], 4)) { ret 1; }
+    ret 0;
+}
+
+# a non-hex digit in a \u escape is rejected.
+test "json: decode rejects non-hex unicode" {
+    var raw: [6]u8 = [6]u8{'\\', 'u', '1', '2', 'g', '4'};
+    if (!decode_rejects(?raw[0], 6)) { ret 1; }
+    ret 0;
+}
+
+# a high surrogate with no following escape is rejected.
+test "json: decode rejects unpaired high surrogate" {
+    var raw: [6]u8 = [6]u8{'\\', 'u', 'd', '8', '3', 'd'};
+    if (!decode_rejects(?raw[0], 6)) { ret 1; }
+    ret 0;
+}
+
+# a high surrogate followed by a non-low-surrogate escape is rejected.
+test "json: decode rejects bad surrogate pair" {
+    # \ud83dA
+    var raw: [12]u8 = [12]u8{'\\', 'u', 'd', '8', '3', 'd', '\\', 'u', '0', '0', '4', '1'};
+    if (!decode_rejects(?raw[0], 12)) { ret 1; }
+    ret 0;
+}
+
+# a lone low surrogate is rejected.
+test "json: decode rejects lone low surrogate" {
+    var raw: [6]u8 = [6]u8{'\\', 'u', 'd', 'c', '0', '0'};
+    if (!decode_rejects(?raw[0], 6)) { ret 1; }
+    ret 0;
+}
+
+# a trailing backslash is rejected.
+test "json: decode rejects trailing backslash" {
+    var raw: [1]u8 = [1]u8{'\\'};
+    if (!decode_rejects(?raw[0], 1)) { ret 1; }
+    ret 0;
+}
+
+# the reframed round-trip: emit escapes logical bytes to wire, parse stores the
+# wire bytes raw, and value_string_decode recovers the original logical bytes.
+test "json: decode roundtrip emit then parse" {
+    var a: allo.Allocator;
+    page.make(?a);
+
+    # logical bytes: a <newline> " \ b
+    var logical: [5]u8 = [5]u8{'a', 0x0a, '"', '\\', 'b'};
+    val src: Value = make_string(((?logical[0])::usize)::str, 5);
+
+    var wire: [32]u8;
+    val wn: usize = emit(?src, ?wire[0], 32);
+
+    val r: Result[Value, str] = parse(?wire[0], wn, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val pv: Value = unwrap_ok[Value, str](r);
+    if (pv.kind != STRING) { ret 1; }
+
+    var buf: [16]u8;
+    val dr: Result[usize, str] = value_string_decode(?pv, ?buf[0], 16);
+    if (is_err[usize, str](dr)) { ret 1; }
+    if (unwrap_ok[usize, str](dr) != 5) { ret 1; }
+    var i: usize = 0;
+    for (i < 5) {
+        if (buf[i] != logical[i]) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a string parsed straight from source text decodes its wire escapes to logical
+# bytes (the hazard the raw representation posed for consumers).
+test "json: decode parsed string" {
+    var a: allo.Allocator;
+    page.make(?a);
+    # source document "a\nb" (a backslash-n between a and b)
+    val src: str = "\"a\\nb\"";
+    val r: Result[Value, str] = parse(src::*u8, 6, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (v.kind != STRING) { ret 1; }
+    # raw bytes are a \ n b (4); decoded are a <newline> b (3)
+    if (v.str_len != 4) { ret 1; }
+    var buf: [8]u8;
+    val dr: Result[usize, str] = value_string_decode(?v, ?buf[0], 8);
+    if (is_err[usize, str](dr)) { ret 1; }
+    if (unwrap_ok[usize, str](dr) != 3) { ret 1; }
+    if (buf[0] != 'a' || buf[1] != 0x0a || buf[2] != 'b') { ret 1; }
+    ret 0;
+}

--- a/src/data/json.mach
+++ b/src/data/json.mach
@@ -1,4 +1,4 @@
-# JSON parser and emitter (integer numbers only).
+# JSON parser and emitter.
 #
 # this module hosts two emission surfaces over one escape core:
 #
@@ -55,6 +55,7 @@ use allo:   std.allocator;
 use writer: std.io.writer;
 use fmt:    std.format;
 use utf8:   std.text.utf8;
+use std.text.parse.parse_f64_len;
 
 pub def Kind: u8;
 pub val NULL:   Kind = 0;
@@ -70,29 +71,34 @@ val USIZE_SIZE: usize = $size_of(usize);
 
 # a parsed JSON value.
 # ---
-# kind:     type discriminator (NULL, BOOL, NUMBER, STRING, ARRAY, OBJECT)
-# bool_val: boolean value (1 = true, 0 = false) when kind == BOOL
-# num_val:  integer value when kind == NUMBER
-# str_val:  pointer into original input when kind == STRING; the RAW on-wire
-#           bytes with escapes intact (use value_string_decode for logical bytes)
-# str_len:  byte length of string (not null-terminated)
-# children: heap-allocated array of child Values (ARRAY or OBJECT)
-# keys:     heap-allocated array of key strings (OBJECT only, parallel with children;
-#           pointers into the original input, not null-terminated)
-# keys_len: heap-allocated array of key byte lengths (parallel with keys)
-# count:    number of children/keys
-# cap:      allocated capacity of children/keys arrays
+# kind:      type discriminator (NULL, BOOL, NUMBER, STRING, ARRAY, OBJECT)
+# bool_val:  boolean value (1 = true, 0 = false) when kind == BOOL
+# is_float:  for a NUMBER, 1 if parsed as a float (had a fraction or exponent),
+#            else 0 (an integer); selects num_val vs float_val
+# num_val:   integer value when kind == NUMBER and is_float == 0
+# float_val: float value when kind == NUMBER and is_float == 1
+# str_val:   pointer into original input when kind == STRING; the RAW on-wire
+#            bytes with escapes intact (use value_string_decode for logical bytes)
+# str_len:   byte length of string (not null-terminated)
+# children:  heap-allocated array of child Values (ARRAY or OBJECT)
+# keys:      heap-allocated array of key strings (OBJECT only, parallel with children;
+#            pointers into the original input, not null-terminated)
+# keys_len:  heap-allocated array of key byte lengths (parallel with keys)
+# count:     number of children/keys
+# cap:       allocated capacity of children/keys arrays
 pub rec Value {
-    kind:     Kind;
-    bool_val: u8;
-    num_val:  i64;
-    str_val:  str;
-    str_len:  usize;
-    children: *Value;
-    keys:     *str;
-    keys_len: *usize;
-    count:    usize;
-    cap:      usize;
+    kind:      Kind;
+    bool_val:  u8;
+    is_float:  u8;
+    num_val:   i64;
+    float_val: f64;
+    str_val:   str;
+    str_len:   usize;
+    children:  *Value;
+    keys:      *str;
+    keys_len:  *usize;
+    count:     usize;
+    cap:       usize;
 }
 
 rec Parser {
@@ -173,9 +179,29 @@ pub fun value_bool(v: *Value) bool {
     ret v.bool_val != 0;
 }
 
-# value_number: get the integer value.
+# value_is_float: whether a NUMBER value was parsed as a float.
+#
+# true for a number with a fraction or exponent, false for an integer-looking
+# number; selects whether to read it with value_float or value_number.
+pub fun value_is_float(v: *Value) bool {
+    ret v.kind == NUMBER && v.is_float != 0;
+}
+
+# value_number: get the integer value of an integer NUMBER.
+#
+# meaningful when the number was parsed as an integer (value_is_float is false);
+# read a float number with value_float.
 pub fun value_number(v: *Value) i64 {
     ret v.num_val;
+}
+
+# value_float: get the value of a NUMBER as a 64-bit float.
+#
+# returns the float value for a number parsed as a float, or the integer value
+# widened to f64 for an integer number, so it is defined for any NUMBER.
+pub fun value_float(v: *Value) f64 {
+    if (v.is_float != 0) { ret v.float_val; }
+    ret v.num_val::f64;
 }
 
 # value_string: get the raw string pointer and length.
@@ -313,7 +339,9 @@ fun make_null() Value {
     var v: Value;
     v.kind = NULL;
     v.bool_val = 0;
+    v.is_float = 0;
     v.num_val = 0;
+    v.float_val = 0.0;
     v.str_val = nil;
     v.str_len = 0;
     v.children = nil;
@@ -335,6 +363,14 @@ fun make_number(n: i64) Value {
     var v: Value = make_null();
     v.kind = NUMBER;
     v.num_val = n;
+    ret v;
+}
+
+fun make_float(f: f64) Value {
+    var v: Value = make_null();
+    v.kind = NUMBER;
+    v.is_float = 1;
+    v.float_val = f;
     ret v;
 }
 
@@ -440,8 +476,15 @@ fun parse_bool(p: *Parser) Result[Value, str] {
     ret ok[Value, str](make_bool(0));
 }
 
+# parse a JSON number (RFC 8259): optional minus, integer part, optional fraction
+# and optional exponent. a number with a fraction or exponent yields a float
+# value (parsed with correct rounding via parse_f64_len over the zero-copy span);
+# an integer-looking number keeps yielding an i64, unchanged.
 fun parse_number(p: *Parser) Result[Value, str] {
+    val start: usize = p.pos;
     var neg: bool = false;
+    var is_float: bool = false;
+
     if (p.src[p.pos] == '-') {
         neg = true;
         p.pos = p.pos + 1;
@@ -460,6 +503,44 @@ fun parse_number(p: *Parser) Result[Value, str] {
 
     if (!has_digit) {
         ret err[Value, str]("invalid number: no digits");
+    }
+
+    if (p.pos < p.len && p.src[p.pos] == '.') {
+        is_float = true;
+        p.pos = p.pos + 1;
+        var frac_digit: bool = false;
+        for (p.pos < p.len && p.src[p.pos] >= '0' && p.src[p.pos] <= '9') {
+            frac_digit = true;
+            p.pos = p.pos + 1;
+        }
+        if (!frac_digit) {
+            ret err[Value, str]("invalid number: no fraction digits");
+        }
+    }
+
+    if (p.pos < p.len && (p.src[p.pos] == 'e' || p.src[p.pos] == 'E')) {
+        is_float = true;
+        p.pos = p.pos + 1;
+        if (p.pos < p.len && (p.src[p.pos] == '+' || p.src[p.pos] == '-')) {
+            p.pos = p.pos + 1;
+        }
+        var exp_digit: bool = false;
+        for (p.pos < p.len && p.src[p.pos] >= '0' && p.src[p.pos] <= '9') {
+            exp_digit = true;
+            p.pos = p.pos + 1;
+        }
+        if (!exp_digit) {
+            ret err[Value, str]("invalid number: no exponent digits");
+        }
+    }
+
+    if (is_float) {
+        val span: str = (p.src::usize + start)::str;
+        val fr: Result[f64, str] = parse_f64_len(span, p.pos - start);
+        if (is_err[f64, str](fr)) {
+            ret err[Value, str](unwrap_err[f64, str](fr));
+        }
+        ret ok[Value, str](make_float(unwrap_ok[f64, str](fr)));
     }
 
     if (neg) { n = 0 - n; }
@@ -952,7 +1033,11 @@ fun emit_value(w: *writer.Writer, v: *Value) {
     }
 
     if (v.kind == NUMBER) {
-        fmt.write_i64(w, v.num_val);
+        if (v.is_float != 0) {
+            fmt.write_f64(w, v.float_val);
+        } or {
+            fmt.write_i64(w, v.num_val);
+        }
         ret;
     }
 
@@ -2062,5 +2147,206 @@ test "json: decode parsed string" {
     if (is_err[usize, str](dr)) { ret 1; }
     if (unwrap_ok[usize, str](dr) != 3) { ret 1; }
     if (buf[0] != 'a' || buf[1] != 0x0a || buf[2] != 'b') { ret 1; }
+    ret 0;
+}
+
+# a fraction makes the number a float, read with value_float.
+test "json: parse float" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "3.14";
+    val r: Result[Value, str] = parse(src::*u8, 4, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (v.kind != NUMBER) { ret 1; }
+    if (!value_is_float(?v)) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < 3.139 || f > 3.141) { ret 1; }
+    ret 0;
+}
+
+# a negative float carries its sign.
+test "json: parse negative float" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "-2.5";
+    val r: Result[Value, str] = parse(src::*u8, 4, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (!value_is_float(?v)) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < -2.51 || f > -2.49) { ret 1; }
+    ret 0;
+}
+
+# an exponent with no fraction still makes the number a float.
+test "json: parse float exponent" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "1e3";
+    val r: Result[Value, str] = parse(src::*u8, 3, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (!value_is_float(?v)) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < 999.0 || f > 1001.0) { ret 1; }
+    ret 0;
+}
+
+# fraction and a signed uppercase exponent together.
+test "json: parse float frac and exponent" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "6.022E2";
+    val r: Result[Value, str] = parse(src::*u8, 7, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (!value_is_float(?v)) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < 602.1 || f > 602.3) { ret 1; }
+    ret 0;
+}
+
+# a negative exponent.
+test "json: parse float negative exponent" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "5e-2";
+    val r: Result[Value, str] = parse(src::*u8, 4, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (!value_is_float(?v)) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < 0.049 || f > 0.051) { ret 1; }
+    ret 0;
+}
+
+# an integer-looking number stays an integer: value_number works, value_is_float
+# is false, and value_float widens it.
+test "json: parse integer unchanged" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "42";
+    val r: Result[Value, str] = parse(src::*u8, 2, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (value_is_float(?v)) { ret 1; }
+    if (value_number(?v) != 42) { ret 1; }
+    val f: f64 = value_float(?v);
+    if (f < 41.9 || f > 42.1) { ret 1; }
+    ret 0;
+}
+
+# a mixed array keeps integers as integers and floats as floats.
+test "json: parse mixed number array" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "[1,2.5,3]";
+    val r: Result[Value, str] = parse(src::*u8, 9, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    if (v.kind != ARRAY || v.count != 3) { ret 1; }
+    if (value_is_float(?v.children[0])) { ret 1; }
+    if (value_number(?v.children[0]) != 1) { ret 1; }
+    if (!value_is_float(?v.children[1])) { ret 1; }
+    val f: f64 = value_float(?v.children[1]);
+    if (f < 2.49 || f > 2.51) { ret 1; }
+    if (value_is_float(?v.children[2])) { ret 1; }
+    if (value_number(?v.children[2]) != 3) { ret 1; }
+    ret 0;
+}
+
+# a float value inside an object.
+test "json: parse float in object" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "{\"x\":1.5}";
+    val r: Result[Value, str] = parse(src::*u8, 9, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    val x: *Value = value_find(?v, "x");
+    if (x == nil) { ret 1; }
+    if (!value_is_float(x)) { ret 1; }
+    val f: f64 = value_float(x);
+    if (f < 1.49 || f > 1.51) { ret 1; }
+    ret 0;
+}
+
+# a bare decimal point with no fraction digits is rejected.
+test "json: parse float rejects empty fraction" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "1.";
+    val r: Result[Value, str] = parse(src::*u8, 2, ?a);
+    if (!is_err[Value, str](r)) { ret 1; }
+    ret 0;
+}
+
+# an exponent marker with no digits is rejected.
+test "json: parse float rejects empty exponent" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "1e";
+    val r: Result[Value, str] = parse(src::*u8, 2, ?a);
+    if (!is_err[Value, str](r)) { ret 1; }
+    ret 0;
+}
+
+# a fraction followed by an empty exponent is rejected.
+test "json: parse float rejects frac empty exponent" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "1.5e";
+    val r: Result[Value, str] = parse(src::*u8, 4, ?a);
+    if (!is_err[Value, str](r)) { ret 1; }
+    ret 0;
+}
+
+# a float emits in shortest round-trippable form.
+test "json: emit float" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "1.5";
+    val r: Result[Value, str] = parse(src::*u8, 3, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    var buf: [16]u8;
+    val n: usize = emit(?v, ?buf[0], 16);
+    if (n != 3) { ret 1; }
+    if (buf[0] != '1' || buf[1] != '.' || buf[2] != '5') { ret 1; }
+    ret 0;
+}
+
+# a programmatically built float emits and re-parses as a float.
+test "json: emit built float" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val v: Value = make_float(2.5);
+    var buf: [16]u8;
+    val n: usize = emit(?v, ?buf[0], 16);
+    if (buf[0] != '2' || buf[1] != '.' || buf[2] != '5') { ret 1; }
+    val r: Result[Value, str] = parse(?buf[0], n, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val rv: Value = unwrap_ok[Value, str](r);
+    if (!value_is_float(?rv)) { ret 1; }
+    ret 0;
+}
+
+# a parsed float round-trips through emit and parse back to the same value.
+test "json: float roundtrip parse emit parse" {
+    var a: allo.Allocator;
+    page.make(?a);
+    val src: str = "3.14159";
+    val r: Result[Value, str] = parse(src::*u8, 7, ?a);
+    if (is_err[Value, str](r)) { ret 1; }
+    val v: Value = unwrap_ok[Value, str](r);
+    var buf: [32]u8;
+    val n: usize = emit(?v, ?buf[0], 32);
+    val r2: Result[Value, str] = parse(?buf[0], n, ?a);
+    if (is_err[Value, str](r2)) { ret 1; }
+    val v2: Value = unwrap_ok[Value, str](r2);
+    if (!value_is_float(?v2)) { ret 1; }
+    val f: f64 = value_float(?v2);
+    if (f < 3.14158 || f > 3.14160) { ret 1; }
     ret 0;
 }

--- a/src/runtime/linux/reloc.mach
+++ b/src/runtime/linux/reloc.mach
@@ -18,9 +18,13 @@
 # applied unconditionally.
 #
 # RELRO: once the relocations are applied, the region the writer marked PT_GNU_RELRO
-# (`.rodata` holding relocated constants, mapped writable for this pass) is mprotect'd
-# read-only, restoring the hardening of those constants before `main`. This step runs
-# after relocation, so it may use the ordinary syscall path.
+# (`.data.rel.ro` holding relocated constants, mapped writable for this pass) is
+# mprotect'd read-only, restoring the hardening of those constants before `main`. This
+# step runs after relocation, so it may use the ordinary syscall path. Its re-protection
+# is now fatal on any failure (`relro_reprotect`): once the ELF writer aligns segments to
+# the target's max page (>= every supported kernel page, briar-systems/mach#1845), a
+# congruence mismatch, an absent AT_PAGESZ, or a failed mprotect is a broken environment
+# or a violated layout contract, not a skippable degradation.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -30,6 +34,10 @@ use std.types.size.usize;
 # for the post-relocation RELRO mprotect (see `_rt_relocate`); safe here because it is
 # reached only after every RELATIVE entry has been slid, never before.
 use sys: std.system.os.linux.shared;
+
+# `relro_reprotect` aborts naming the violated invariant when the region cannot be
+# hardened; panic is reached only post-relocation, so its message pointer is already slid.
+use std.system.panic.panic;
 
 # read a u64 at a raw runtime address. PIC: pure pointer arithmetic, no global.
 # ---
@@ -143,20 +151,53 @@ pub fun _rt_relocate(envp: *u64) {
         }
     }
 
-    # RELRO: re-protect the region the PIE writer marked PT_GNU_RELRO. it holds relocated
-    # constants (vtables, `val` pointer globals) mapped writable for the pass above; now
-    # that they are slid, mprotect it read-only to restore their hardening before `main`.
-    # the writer emits p_vaddr page-aligned and p_memsz already page-rounded, so this does
-    # no arithmetic: it gates on the region being a whole number of runtime pages and
-    # mprotects it exactly. AT_PAGESZ is mandatory on linux; when it is absent, or the
-    # region is not congruent with the runtime page (a kernel page larger than the writer's
-    # 4 KiB segment alignment - briar-systems/mach-std#336), the region is left writable
-    # (correct, just unhardened) rather than risking EINVAL or over-protecting the next
-    # segment. this best-effort skip is the one large-page degradation.
-    if (relro_va != 0 && relro_sz != 0 && at_pagesz != 0) {
-        val relro_start: u64 = bias + relro_va;
-        if (relro_start % at_pagesz == 0 && relro_sz % at_pagesz == 0) {
-            sys.protect(relro_start::usize::ptr, relro_sz::usize, sys.PROT_READ::u32);
-        }
+    # RELRO: re-protect the region the PIE writer marked PT_GNU_RELRO. it holds the
+    # relocated constants (`.data.rel.ro`) mapped writable for the pass above; now that
+    # they are slid, restore them read-only before `main`. done only when the image
+    # actually carries a RELRO region - a `--pie` binary with no reloc-bearing constants
+    # emits none, and re-protecting nothing is correct. `relro_reprotect` enforces the
+    # page-congruence and mprotect invariants fatally.
+    if (relro_va != 0 && relro_sz != 0) {
+        relro_reprotect(bias + relro_va, relro_sz, at_pagesz);
+    }
+}
+
+# re-protect the PT_GNU_RELRO region read-only, or abort naming the violated invariant
+#
+# The region holds the relocated constants (`.data.rel.ro`: vtables, `val` pointer
+# globals, `str` literals) mapped writable for the relocation pass; once the RELATIVE
+# slots are slid it must be restored read-only before `main`. This was best-effort - it
+# skipped a region not congruent with the runtime page and ignored the mprotect result -
+# the documented large-page degradation while the writer aligned segments to a fixed 4 KiB
+# (briar-systems/mach-std#336). Now that the ELF writer aligns every segment to the
+# target's max page (>= any supported kernel page, briar-systems/mach#1845), the region is
+# always a whole number of runtime pages, so neither escape is legitimate: an absent
+# AT_PAGESZ, a congruence mismatch, or an mprotect failure is a broken environment or a
+# violated layout contract, and running unhardened would silently mask it. Each aborts
+# naming the invariant - the glibc stance, matching `std.system.os.page_size`'s AT_PAGESZ
+# precedent (#336/#343).
+#
+# Reached only after relocation (it uses panic + the syscall path), so its message
+# pointers are already slid; `_rt_relocate` invokes it once the RELATIVE slots are applied.
+# ---
+# relro_start: the runtime start address of the region (load bias + PT_GNU_RELRO p_vaddr)
+# relro_sz:    the region size (PT_GNU_RELRO p_memsz, page-rounded by the writer)
+# at_pagesz:   the runtime page size from AT_PAGESZ (0 when the auxv lacked it)
+pub fun relro_reprotect(relro_start: u64, relro_sz: u64, at_pagesz: u64) {
+    # AT_PAGESZ is a mandatory linux auxv entry; a 0 under a live RELRO region means a
+    # broken or nonstandard environment, not a page size to guess.
+    if (at_pagesz == 0) {
+        panic("std.runtime.linux.reloc: AT_PAGESZ absent with a PT_GNU_RELRO region (mandatory linux auxv entry missing)\n");
+    }
+    # the writer max-page-aligns segments (mach#1845), so p_vaddr and the page-rounded
+    # p_memsz are always whole runtime pages; a mismatch means the loaded image violated
+    # that layout contract (or ran on a kernel page larger than the build's max page).
+    if (relro_start % at_pagesz != 0 || relro_sz % at_pagesz != 0) {
+        panic("std.runtime.linux.reloc: PT_GNU_RELRO region not congruent with the runtime page (violated max-page layout contract; see mach#1845)\n");
+    }
+    # a failed re-protect leaves the relocated constants writable through `main`; refuse to
+    # run silently unhardened.
+    if (sys.protect(relro_start::usize::ptr, relro_sz::usize, sys.PROT_READ::u32) != 0) {
+        panic("std.runtime.linux.reloc: mprotect of the PT_GNU_RELRO region failed (cannot restore read-only hardening)\n");
     }
 }

--- a/src/text/parse.mach
+++ b/src/text/parse.mach
@@ -502,12 +502,26 @@ fun collect_significand(s: str, len: usize, i: *usize, M: *bn.Big, out_dexp: *i6
 }
 
 # stops at the first character that is not part of a valid float. use
-# parse_f64_exact to require full input consumption.
+# parse_f64_exact to require full input consumption, or parse_f64_len for a span
+# that is not null-terminated.
 # ---
 # s:   string to parse
 # ret: the parsed value, or an error message
 pub fun parse_f64(s: str) Result[f64, str] {
-    val len: usize = str_len(s);
+    ret parse_f64_len(s, str_len(s));
+}
+
+# parse a 64-bit floating point number prefix from the first `len` bytes of `s`.
+#
+# like parse_f64 but bounded by an explicit length instead of a null terminator,
+# so it is safe on a byte span embedded in a larger buffer (e.g. a zero-copy
+# slice into a parse input). stops at the first byte that is not part of a valid
+# float, or at `len`.
+# ---
+# s:   the bytes to parse
+# len: the number of bytes available in s
+# ret: the parsed value, or an error message
+pub fun parse_f64_len(s: str, len: usize) Result[f64, str] {
     if (len == 0) { ret err[f64, str]("empty string"); }
 
     var i: usize = 0;
@@ -899,6 +913,23 @@ test "parse: f64 with underscores" {
 
 test "parse: f64 empty string" {
     val r: Result[f64, str] = parse_f64("");
+    if (is_ok[f64, str](r)) { ret 1; }
+    ret 0;
+}
+
+# parse_f64_len stops at `len` and never reads a trailing null, so a float span
+# embedded in a larger buffer parses without consuming its neighbours.
+test "parse: f64_len bounded span" {
+    # only the first 3 bytes ("1.5") are in scope; the "e9" must be ignored.
+    val r: Result[f64, str] = parse_f64_len("1.5e9", 3);
+    if (is_err[f64, str](r)) { ret 1; }
+    val v: f64 = unwrap_ok[f64, str](r);
+    if (v < 1.49 || v > 1.51) { ret 1; }
+    ret 0;
+}
+
+test "parse: f64_len zero length" {
+    val r: Result[f64, str] = parse_f64_len("3.14", 0);
     if (is_ok[f64, str](r)) { ret 1; }
     ret 0;
 }

--- a/test/relro/mach.toml
+++ b/test/relro/mach.toml
@@ -1,0 +1,36 @@
+[project]
+id      = "relroprobe"
+name    = "relroprobe"
+version = "0.0.0"
+src     = "src"
+dep     = "dep"
+target  = "linux"
+out     = "out/{target}/{name}{ext}"
+obj     = "out/{target}/obj"
+
+[target.linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[profile.debug]
+opt = 0
+
+[bin.relro_happy]
+entry = "happy.mach"
+
+[bin.relro_fault]
+entry = "fault.mach"
+
+[deps.std]
+path = "dep/std"

--- a/test/relro/src/fault.mach
+++ b/test/relro/src/fault.mach
@@ -1,0 +1,16 @@
+# RELRO negative-path probe: force `relro_reprotect` down its congruence-invariant branch
+# and confirm it aborts loudly. A region size that is not a whole number of the runtime
+# page (0x1000 under a 0x4000 page) is exactly the large-page mismatch that was silently
+# skipped before #347; now it panics naming the invariant and dies by signal. The forced
+# inputs never reach the mprotect, so no live mapping is touched. verify.sh asserts the
+# panic message on stderr and death by signal.
+use std.runtime;
+use reloc: std.runtime.linux.reloc;
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    # 0x1000 % 0x4000 != 0: the region is not congruent with the runtime page.
+    reloc.relro_reprotect(0x1000, 0x1000, 0x4000);
+    # unreachable: relro_reprotect panics on the mismatch above.
+    ret 0;
+}

--- a/test/relro/src/happy.mach
+++ b/test/relro/src/happy.mach
@@ -1,0 +1,18 @@
+# RELRO happy-path probe: a --pie binary whose read-only data carries a relocated
+# constant pointer, so the writer emits a PT_GNU_RELRO region. `_rt_relocate` slides the
+# pointer and `relro_reprotect` restores the region read-only before `main`; reading
+# through the pointer proves relocation ran, and reaching `ret` proves re-protection
+# succeeded (no panic). verify.sh asserts the exit code.
+use std.runtime;
+
+# a mutable target and a read-only pointer to it: the pointer is a relocated constant, so
+# it lands in the RELRO region and forces PT_GNU_RELRO emission.
+var target: i64 = 42;
+val c_ptr: *i64 = ?target;
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    # read through the relocated constant pointer (proves self-relocation applied it) and
+    # return its value; `_rt_relocate` already re-protected the region read-only.
+    ret c_ptr[0];
+}

--- a/test/relro/verify.sh
+++ b/test/relro/verify.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# build the RELRO probes against this checkout's std and assert both paths of the
+# post-#347 re-protection contract:
+#   * happy   - a --pie binary with a relocated constant pointer runs fully hardened and
+#               returns 42 (self-relocation + re-protection succeeded, no panic).
+#   * fault   - forcing relro_reprotect down its congruence-invariant branch aborts loudly:
+#               the panic message reaches stderr and the process dies by signal.
+#
+# the fault path is compiler-independent (it calls relro_reprotect with forced incongruent
+# args), so it exercises the fatal branch even under a mach seed whose writer predates the
+# max-page layout - see the PR's CI-seed note.
+#
+# usage: verify.sh [path-to-mach] [target] [runner]
+#   target defaults to linux (native x86_64); runner wraps execution (e.g. qemu-aarch64).
+set -euo pipefail
+
+# the fault probe dies by signal (SIGTRAP/SIGSEGV from the panic trap); suppress the core
+# dump it would otherwise leave in the working tree.
+ulimit -c 0 2>/dev/null || true
+
+expect_happy=42
+
+mach="${1:-mach}"
+target="${2:-linux}"
+runner="${3:-}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+run()  { if [ -n "$runner" ]; then "$runner" "$@"; else "$@"; fi; }
+
+# vendor this checkout's std as the path dependency (dep/std -> repo root).
+mkdir -p dep
+ln -sfn "$(cd ../.. && pwd)" dep/std
+
+echo "building the RELRO probes --pie with $mach (target $target)"
+rm -rf out
+"$mach" build . --target "$target" --pie --profile debug
+happy="$(find out -name relro_happy -type f -print -quit)"
+fault="$(find out -name relro_fault -type f -print -quit)"
+[ -n "$happy" ] || fail "no relro_happy binary produced"
+[ -n "$fault" ] || fail "no relro_fault binary produced"
+
+echo "happy path: running $happy (expect exit $expect_happy, fully hardened)"
+set +e
+run "$happy"
+code=$?
+set -e
+[ "$code" -eq "$expect_happy" ] || fail "happy path exit $code, expected $expect_happy"
+echo "  OK: ran hardened, exit $expect_happy"
+
+echo "negative path: running $fault (expect panic on stderr + death by signal)"
+set +e
+err="$(run "$fault" 2>&1 1>/dev/null)"
+code=$?
+set -e
+# death by signal surfaces as exit 128+signo both natively and under qemu-user.
+[ "$code" -ge 128 ] || fail "fault path exit $code, expected death by signal (>=128)"
+echo "$err" | grep -q "not congruent with the runtime page" \
+    || fail "fault path missing the congruence panic message; got: $err"
+echo "  OK: died by signal (exit $code), panic named the invariant"
+
+echo "OK: RELRO re-protection is fatal on invariant breach and hardened on the happy path"


### PR DESCRIPTION
Rolls dev to main: permanent [target.linux-arm64] + qemu aarch64 CI lane (#280/PR #353), decode-on-demand JSON string accessor (#340/PR #354), RFC 8259 float parsing in std.data.json + bounded-span parse_f64_len (#349/PR #355), and fatal RELRO re-protection (#347/PR #356, pairs with mach#1844/#1845).