### PR TITLE
release: pin all windows imports with #[library]

### DIFF
--- a/src/runtime/windows/x86_64.mach
+++ b/src/runtime/windows/x86_64.mach
@@ -23,9 +23,11 @@ $if ($mach.build.arch != $mach.arch.x86_64) {
     $error("std.runtime.windows.x86_64: requires x86_64 target");
 }
 
-# the kernel32 imports the entrypoint binds — an `ext fun`'s bare name is its
-# foreign symbol, so it resolves to the kernel32 export directly.
+# the kernel32 imports the entrypoint binds, each pinned to kernel32.dll with a
+# `#[library]` decorator so the PE import directory attributes it explicitly.
+#[library("kernel32.dll")]
 ext fun GetCommandLineA() *u8;
+#[library("kernel32.dll")]
 ext fun ExitProcess(code: u32);
 
 val MAX_ARGS: usize = 256;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -3,10 +3,10 @@
 # windows has no stable syscall interface. all OS interaction goes through
 # kernel32.dll and ntdll.dll via ext fun declarations, plus ws2_32.dll for
 # sockets, advapi32.dll for RtlGenRandom, and api-ms-win-core-synch-l1-2-0.dll
-# for the wait-on-address family; these are pinned with a `#[library]` decorator so
-# the PE import directory attributes them to the right DLL rather than the first
-# dependency. a HANDLE-to-fd mapping table bridges the POSIX-style fd interface
-# used by os.mach.
+# for the wait-on-address family. every import carries an explicit `#[library]`
+# decorator naming its providing DLL, so the PE import directory attributes each
+# to the right DLL rather than the first dependency. a HANDLE-to-fd mapping table
+# bridges the POSIX-style fd interface used by os.mach.
 
 use std.types.size.usize;
 use std.types.size.isize;
@@ -174,53 +174,92 @@ val ENOTSOCK:      i64 = -88;
 
 # Win32 API imports (kernel32.dll)
 
+#[library("kernel32.dll")]
 ext fun ExitProcess(p0: u32);
+#[library("kernel32.dll")]
 ext fun GetLastError() u32;
+#[library("kernel32.dll")]
 ext fun SetLastError(p0: u32);
+#[library("kernel32.dll")]
 ext fun GetStdHandle(p0: u32) isize;
+#[library("kernel32.dll")]
 ext fun CloseHandle(p0: isize) i32;
+#[library("kernel32.dll")]
 ext fun GetModuleHandleA(p0: *u8) isize;
+#[library("kernel32.dll")]
 ext fun GetProcAddress(p0: isize, p1: *u8) ptr;
 
+#[library("kernel32.dll")]
 ext fun VirtualAlloc(p0: ptr, p1: usize, p2: u32, p3: u32) ptr;
+#[library("kernel32.dll")]
 ext fun VirtualFree(p0: ptr, p1: usize, p2: u32) i32;
+#[library("kernel32.dll")]
 ext fun VirtualProtect(p0: ptr, p1: usize, p2: u32, p3: *u32) i32;
+#[library("kernel32.dll")]
 ext fun VirtualLock(p0: ptr, p1: usize) i32;
+#[library("kernel32.dll")]
 ext fun VirtualUnlock(p0: ptr, p1: usize) i32;
+#[library("kernel32.dll")]
 ext fun GetProcessHeap() isize;
+#[library("kernel32.dll")]
 ext fun HeapAlloc(p0: isize, p1: u32, p2: usize) ptr;
+#[library("kernel32.dll")]
 ext fun HeapFree(p0: isize, p1: u32, p2: ptr) i32;
+#[library("kernel32.dll")]
 ext fun HeapReAlloc(p0: isize, p1: u32, p2: ptr, p3: usize) ptr;
+#[library("kernel32.dll")]
 ext fun GetSystemInfo(p0: *u8);
+#[library("kernel32.dll")]
 ext fun GetActiveProcessorCount(p0: u16) u32;
 
+#[library("kernel32.dll")]
 ext fun CreateFileA(p0: *u8, p1: u32, p2: u32, p3: ptr, p4: u32, p5: u32, p6: isize) isize;
+#[library("kernel32.dll")]
 ext fun ReadFile(p0: isize, p1: *u8, p2: u32, p3: *u32, p4: ptr) i32;
+#[library("kernel32.dll")]
 ext fun WriteFile(p0: isize, p1: *u8, p2: u32, p3: *u32, p4: ptr) i32;
+#[library("kernel32.dll")]
 ext fun SetFilePointerEx(p0: isize, p1: i64, p2: *i64, p3: u32) i32;
+#[library("kernel32.dll")]
 ext fun GetFileInformationByHandle(p0: isize, p1: *u8) i32;
+#[library("kernel32.dll")]
 ext fun CreateFileMappingA(p0: isize, p1: ptr, p2: u32, p3: u32, p4: u32, p5: ptr) isize;
+#[library("kernel32.dll")]
 ext fun MapViewOfFile(p0: isize, p1: u32, p2: u32, p3: u32, p4: usize) ptr;
+#[library("kernel32.dll")]
 ext fun UnmapViewOfFile(p0: ptr) i32;
+#[library("kernel32.dll")]
 ext fun FlushViewOfFile(p0: ptr, p1: usize) i32;
+#[library("kernel32.dll")]
 ext fun DeleteFileA(p0: *u8) i32;
+#[library("kernel32.dll")]
 ext fun MoveFileA(p0: *u8, p1: *u8) i32;
+#[library("kernel32.dll")]
 ext fun CreateDirectoryA(p0: *u8, p1: ptr) i32;
+#[library("kernel32.dll")]
 ext fun RemoveDirectoryA(p0: *u8) i32;
+#[library("kernel32.dll")]
 ext fun GetFileAttributesA(p0: *u8) u32;
+#[library("kernel32.dll")]
 ext fun FindFirstFileA(p0: *u8, p1: *u8) isize;
+#[library("kernel32.dll")]
 ext fun FindNextFileA(p0: isize, p1: *u8) i32;
+#[library("kernel32.dll")]
 ext fun FindClose(p0: isize) i32;
+#[library("kernel32.dll")]
 ext fun GetFinalPathNameByHandleA(p0: isize, p1: *u8, p2: u32, p3: u32) u32;
-# CreateSymbolicLinkA is exported by kernel32.dll (the first dependency), so
-# an unqualified import binds correctly without a `library` decorator (unlike
-# the synch-apiset functions of #253). it returns a BOOLEAN — a single byte.
+# CreateSymbolicLinkA returns a BOOLEAN — a single byte.
+#[library("kernel32.dll")]
 ext fun CreateSymbolicLinkA(p0: *u8, p1: *u8, p2: u32) u8;
 
+#[library("kernel32.dll")]
 ext fun GetSystemTimeAsFileTime(p0: *u8);
+#[library("kernel32.dll")]
 ext fun QueryPerformanceCounter(p0: *i64) i32;
+#[library("kernel32.dll")]
 ext fun QueryPerformanceFrequency(p0: *i64) i32;
 
+#[library("kernel32.dll")]
 ext fun CreateThread(p0: ptr, p1: usize, p2: usize, p3: ptr, p4: u32, p5: *u32) isize;
 
 # WaitOnAddress / WakeByAddressSingle live in the synch apiset DLL, not kernel32.
@@ -270,23 +309,41 @@ ext fun closesocket(p0: usize) i32;
 #[library("advapi32.dll")]
 ext fun SystemFunction036(p0: *u8, p1: u32) i32;
 
+#[library("kernel32.dll")]
 ext fun GetCurrentProcessId() u32;
+#[library("kernel32.dll")]
 ext fun TerminateProcess(p0: isize, p1: u32) i32;
+#[library("kernel32.dll")]
 ext fun CreateProcessA(p0: *u8, p1: *u8, p2: ptr, p3: ptr, p4: i32, p5: u32, p6: ptr, p7: ptr, p8: *u8, p9: *u8) i32;
+#[library("kernel32.dll")]
 ext fun WaitForSingleObject(p0: isize, p1: u32) u32;
+#[library("kernel32.dll")]
 ext fun WaitForMultipleObjects(p0: u32, p1: ptr, p2: i32, p3: u32) u32;
+#[library("kernel32.dll")]
 ext fun GetExitCodeProcess(p0: isize, p1: *u32) i32;
+#[library("kernel32.dll")]
 ext fun CreatePipe(p0: *isize, p1: *isize, p2: ptr, p3: u32) i32;
+#[library("kernel32.dll")]
 ext fun GetHandleInformation(p0: isize, p1: *u32) i32;
+#[library("kernel32.dll")]
 ext fun SetHandleInformation(p0: isize, p1: u32, p2: u32) i32;
+#[library("kernel32.dll")]
 ext fun InitializeProcThreadAttributeList(p0: ptr, p1: u32, p2: u32, p3: *usize) i32;
+#[library("kernel32.dll")]
 ext fun UpdateProcThreadAttribute(p0: ptr, p1: u32, p2: usize, p3: ptr, p4: usize, p5: ptr, p6: ptr) i32;
+#[library("kernel32.dll")]
 ext fun DeleteProcThreadAttributeList(p0: ptr);
+#[library("kernel32.dll")]
 ext fun Sleep(p0: u32);
+#[library("kernel32.dll")]
 ext fun GetCurrentDirectoryA(p0: u32, p1: *u8) u32;
+#[library("kernel32.dll")]
 ext fun GetTempPathA(p0: u32, p1: *u8) u32;
+#[library("kernel32.dll")]
 ext fun GetEnvironmentVariableA(p0: *u8, p1: *u8, p2: u32) u32;
+#[library("kernel32.dll")]
 ext fun GetEnvironmentStringsA() *u8;
+#[library("kernel32.dll")]
 ext fun FreeEnvironmentStringsA(p0: *u8) i32;
 
 # Win32 structures


### PR DESCRIPTION
Rolls dev to main: every windows import explicitly pinned (#334/PR #358) — prerequisite for mach#1800's unattributed-import hard link error.