### PR TITLE
chore: normalize test labels to the topic: behavior convention

### DIFF
--- a/src/log.mach
+++ b/src/log.mach
@@ -119,7 +119,7 @@ test "set_level: DEBUG enables all" {
     ret 0;
 }
 
-test "log functions: nil message does not crash" {
+test "log: nil message does not crash" {
     set_level(DEBUG);
     debug(nil);
     info(nil);

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -405,7 +405,7 @@ test "exec: repeated spawns stay correct" {
 
 var redir_buf: [64]u8;
 
-test "std.process.exec.spawn_redirected:pipes_child_stdout" {
+test "exec: spawn_redirected pipes child stdout" {
     var fds: [2]i32;
     if (os.pipe(?fds[0]) < 0) { ret 1; }
 
@@ -437,7 +437,7 @@ test "std.process.exec.spawn_redirected:pipes_child_stdout" {
     ret 0;
 }
 
-test "std.process.exec.wait_any:reaps_each_child_once" {
+test "exec: wait_any reaps each child once" {
     var argv_a: [4]usize = argv_ok();
     val ra: Result[Child, str] = spawn(prog_ok(), (?argv_a[0])::**u8, nil);
     if (is_err[Child, str](ra)) { ret 1; }
@@ -466,7 +466,7 @@ test "std.process.exec.wait_any:reaps_each_child_once" {
     ret 0;
 }
 
-test "std.process.exec.wait_any:errs_with_no_children" {
+test "exec: wait_any errs with no children" {
     var st: ExitStatus;
     st.raw = 0;
     val w: Result[Child, str] = wait_any(?st);

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -284,7 +284,7 @@ pub fun message(code: i64) str {
     ret impl.error_message(code);
 }
 
-test "std.system.os.cpu_count:at_least_one" {
+test "os: cpu_count at least one" {
     if (impl.cpu_count() < 1) { ret 1; }
     ret 0;
 }


### PR DESCRIPTION
Normalizes the handful of tests still using the compiler's fully-qualified `module.path.symbol:behavior` label style to the shorter `"topic: behavior"` convention used throughout mach-std.

Topics chosen to match each module's existing labels:

| Before | After |
| --- | --- |
| `std.process.exec.spawn_redirected:pipes_child_stdout` | `exec: spawn_redirected pipes child stdout` |
| `std.process.exec.wait_any:reaps_each_child_once` | `exec: wait_any reaps each child once` |
| `std.process.exec.wait_any:errs_with_no_children` | `exec: wait_any errs with no children` |
| `std.system.os.cpu_count:at_least_one` | `os: cpu_count at least one` |
| `log functions: nil message does not crash` | `log: nil message does not crash` |

The `exec:` and `os:` topics mirror how neighboring tests abbreviate their module to its leaf name; `log:` tightens the two-word `log functions` topic to match the single-token `set_level:` topic used by the other log tests.

Only label strings change. Test bodies and all other code are untouched, and labels are not referenced by code, so renaming is safe. `mach build .` and `mach test .` pass identically before and after (620 passed, 0 failed, 620 total).

Closes #364