### PR TITLE
chore(manifest): RFC-exact totality re-touch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- manifest: Re-touched the self-manifest to RFC-exact totality per mach#1964/mach#1979.
+
 ## [0.18.0] - 2026-07-07
 
 Overhauls the build manifest and test manifests to comply with the v2 build system schema.

--- a/mach.toml
+++ b/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "std"
-name = "Mach Standard Library"
-description = "Mach standard library"
 version = "0.18.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -18,9 +16,11 @@ abi = "aapcs64"
 
 [profile.debug]
 opt = 0
+debug = true
 
 [profile.release]
 opt = 2
+debug = false
 
 [artifact.std]
 kind = "static"
@@ -28,27 +28,36 @@ entry = "lib.mach"
 out = "lib/std"
 targets = ["*"]
 link = ["kernel32", "ws2_32", "advapi32", "synch"]
+need = []
 
 [link.kernel32]
 source = "system"
 name = "kernel32.dll"
 os = ["windows"]
+isa = "*"
+abi = "*"
 export = true
 
 [link.ws2_32]
 source = "system"
 name = "ws2_32.dll"
 os = ["windows"]
+isa = "*"
+abi = "*"
 export = true
 
 [link.advapi32]
 source = "system"
 name = "advapi32.dll"
 os = ["windows"]
+isa = "*"
+abi = "*"
 export = true
 
 [link.synch]
 source = "system"
 name = "api-ms-win-core-synch-l1-2-0.dll"
 os = ["windows"]
+isa = "*"
+abi = "*"
 export = true


### PR DESCRIPTION
Re-touches the self-manifest to RFC-exact totality under the now-strict parser.

- `[project]`: dropped `name`/`description` (only id/version/src/out permitted).
- `[profile.debug]`: added `debug = true`; `[profile.release]`: added `debug = false`.
- `[artifact.std]`: added `need = []`.
- Every `[link.X]`: added explicit `isa = "*"` / `abi = "*"` alongside existing `os`/`export`.

Verified with the strict compiler: parses as build root and builds green under both `--profile debug` and `--profile release`.

Refs briar-systems/mach#1979.