### PR TITLE
chore(manifest): add required simd = "scalarize" to profiles

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -17,10 +17,12 @@ abi = "aapcs64"
 [profile.debug]
 opt = 0
 debug = true
+simd = "scalarize"
 
 [profile.release]
 opt = 2
 debug = false
+simd = "scalarize"
 
 [artifact.std]
 kind = "static"

--- a/test/relro/mach.toml
+++ b/test/relro/mach.toml
@@ -23,6 +23,7 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+simd = "scalarize"
 
 [artifact.relro_happy]
 kind = "bin"

--- a/test/riscv64/mach.toml
+++ b/test/riscv64/mach.toml
@@ -13,6 +13,7 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+simd = "scalarize"
 
 [artifact.rvprobe]
 kind = "bin"


### PR DESCRIPTION
Sets the required `simd` profile key (default posture `scalarize`) on every declared `[profile.X]`, per the mach SIMD tier-1 required-key rollout (briar-systems/mach#2013 / #2017). No other manifest changes.

Verified: builds clean under both the 3.3.1 seed and a from-source current-dev mach.

Part of briar-systems/mach#2046.