### PR TITLE
feat(simd): SIMD + vector-math library over the vector types

### DIFF
--- a/src/lib.mach
+++ b/src/lib.mach
@@ -33,6 +33,9 @@ fwd std.math.bits;
 fwd std.math.bignum;
 
 fwd std.simd.select;
+fwd std.simd.reduce;
+fwd std.simd.shuffle;
+fwd std.simd.saturate;
 
 fwd std.format;
 fwd std.print;

--- a/src/lib.mach
+++ b/src/lib.mach
@@ -38,6 +38,7 @@ fwd std.simd.select;
 fwd std.simd.reduce;
 fwd std.simd.shuffle;
 fwd std.simd.saturate;
+fwd std.simd.gather;
 
 fwd std.format;
 fwd std.print;

--- a/src/lib.mach
+++ b/src/lib.mach
@@ -31,6 +31,8 @@ fwd std.filesystem;
 fwd std.math;
 fwd std.math.bits;
 fwd std.math.bignum;
+fwd std.math.mat4;
+fwd std.math.quat;
 
 fwd std.simd.select;
 fwd std.simd.reduce;

--- a/src/lib.mach
+++ b/src/lib.mach
@@ -32,6 +32,8 @@ fwd std.math;
 fwd std.math.bits;
 fwd std.math.bignum;
 
+fwd std.simd.select;
+
 fwd std.format;
 fwd std.print;
 fwd std.runtime;

--- a/src/math/mat4.mach
+++ b/src/math/mat4.mach
@@ -6,7 +6,14 @@
 # is row-vector: a vector transforms as `v * M` (see mat4_mul_vec), and the
 # product `mat4_mul(a, b)` is the matrix applying a then b.
 
+use std.types.bool.bool;
 use std.simd.shuffle.splat_f32x4;
+use std.types.option.Option;
+use std.types.option.some;
+use std.types.option.none;
+use std.types.option.is_some;
+use std.types.option.is_none;
+use std.types.option.unwrap;
 
 # a 4x4 single-precision matrix, four f32x4 rows in row-major order
 # ---
@@ -130,6 +137,88 @@ pub fun mat4_transpose(m: Mat4) Mat4 {
     }};
 }
 
+# determinant of a matrix
+#
+# expanded over the six 2x2 minors of the top two rows against the six of the
+# bottom two — the Laplace complementary-minor form, shared with the inverse.
+# ---
+# m:   matrix
+# ret: det(m)
+pub fun mat4_determinant(m: Mat4) f32 {
+    val m00: f32 = m.rows[0][0]; val m01: f32 = m.rows[0][1]; val m02: f32 = m.rows[0][2]; val m03: f32 = m.rows[0][3];
+    val m10: f32 = m.rows[1][0]; val m11: f32 = m.rows[1][1]; val m12: f32 = m.rows[1][2]; val m13: f32 = m.rows[1][3];
+    val m20: f32 = m.rows[2][0]; val m21: f32 = m.rows[2][1]; val m22: f32 = m.rows[2][2]; val m23: f32 = m.rows[2][3];
+    val m30: f32 = m.rows[3][0]; val m31: f32 = m.rows[3][1]; val m32: f32 = m.rows[3][2]; val m33: f32 = m.rows[3][3];
+    val s0: f32 = m00 * m11 - m10 * m01;
+    val s1: f32 = m00 * m12 - m10 * m02;
+    val s2: f32 = m00 * m13 - m10 * m03;
+    val s3: f32 = m01 * m12 - m11 * m02;
+    val s4: f32 = m01 * m13 - m11 * m03;
+    val s5: f32 = m02 * m13 - m12 * m03;
+    val c5: f32 = m22 * m33 - m32 * m23;
+    val c4: f32 = m21 * m33 - m31 * m23;
+    val c3: f32 = m21 * m32 - m31 * m22;
+    val c2: f32 = m20 * m33 - m30 * m23;
+    val c1: f32 = m20 * m32 - m30 * m22;
+    val c0: f32 = m20 * m31 - m30 * m21;
+    ret s0 * c5 - s1 * c4 + s2 * c3 + s3 * c2 - s4 * c1 + s5 * c0;
+}
+
+# inverse of a matrix, or none when it is singular
+#
+# builds the adjugate over the same complementary 2x2 minors as the determinant,
+# then scales by its reciprocal. a determinant of exactly zero returns none.
+# ---
+# m:   matrix
+# ret: some(inverse) if invertible, none if singular
+pub fun mat4_inverse(m: Mat4) Option[Mat4] {
+    val m00: f32 = m.rows[0][0]; val m01: f32 = m.rows[0][1]; val m02: f32 = m.rows[0][2]; val m03: f32 = m.rows[0][3];
+    val m10: f32 = m.rows[1][0]; val m11: f32 = m.rows[1][1]; val m12: f32 = m.rows[1][2]; val m13: f32 = m.rows[1][3];
+    val m20: f32 = m.rows[2][0]; val m21: f32 = m.rows[2][1]; val m22: f32 = m.rows[2][2]; val m23: f32 = m.rows[2][3];
+    val m30: f32 = m.rows[3][0]; val m31: f32 = m.rows[3][1]; val m32: f32 = m.rows[3][2]; val m33: f32 = m.rows[3][3];
+    val s0: f32 = m00 * m11 - m10 * m01;
+    val s1: f32 = m00 * m12 - m10 * m02;
+    val s2: f32 = m00 * m13 - m10 * m03;
+    val s3: f32 = m01 * m12 - m11 * m02;
+    val s4: f32 = m01 * m13 - m11 * m03;
+    val s5: f32 = m02 * m13 - m12 * m03;
+    val c5: f32 = m22 * m33 - m32 * m23;
+    val c4: f32 = m21 * m33 - m31 * m23;
+    val c3: f32 = m21 * m32 - m31 * m22;
+    val c2: f32 = m20 * m33 - m30 * m23;
+    val c1: f32 = m20 * m32 - m30 * m22;
+    val c0: f32 = m20 * m31 - m30 * m21;
+    val det: f32 = s0 * c5 - s1 * c4 + s2 * c3 + s3 * c2 - s4 * c1 + s5 * c0;
+    if (det == 0.0) { ret none[Mat4](); }
+    val d: f32 = 1.0 / det;
+    ret some[Mat4](Mat4{rows: [4]f32x4{
+        f32x4{
+            ( m11 * c5 - m12 * c4 + m13 * c3) * d,
+            (-m01 * c5 + m02 * c4 - m03 * c3) * d,
+            ( m31 * s5 - m32 * s4 + m33 * s3) * d,
+            (-m21 * s5 + m22 * s4 - m23 * s3) * d
+        },
+        f32x4{
+            (-m10 * c5 + m12 * c2 - m13 * c1) * d,
+            ( m00 * c5 - m02 * c2 + m03 * c1) * d,
+            (-m30 * s5 + m32 * s2 - m33 * s1) * d,
+            ( m20 * s5 - m22 * s2 + m23 * s1) * d
+        },
+        f32x4{
+            ( m10 * c4 - m11 * c2 + m13 * c0) * d,
+            (-m00 * c4 + m01 * c2 - m03 * c0) * d,
+            ( m30 * s4 - m31 * s2 + m33 * s0) * d,
+            (-m20 * s4 + m21 * s2 - m23 * s0) * d
+        },
+        f32x4{
+            (-m10 * c3 + m11 * c1 - m12 * c0) * d,
+            ( m00 * c3 - m01 * c1 + m02 * c0) * d,
+            (-m30 * s3 + m31 * s1 - m32 * s0) * d,
+            ( m20 * s3 - m21 * s1 + m22 * s0) * d
+        }
+    }});
+}
+
 test "mat4_identity: diagonal ones" {
     val m: Mat4 = mat4_identity();
     if (m.rows[0][0] != 1.0) { ret 1; }
@@ -229,5 +318,78 @@ test "mat4_add / mat4_sub / mat4_scale: element-wise" {
     if (d.rows[1][1] != 6.0) { ret 1; }
     val sum: Mat4 = mat4_add(a, a);
     if (sum.rows[2][3] != 24.0) { ret 1; }
+    ret 0;
+}
+
+# absolute difference within tolerance, for float matrix checks
+fun mnear(a: f32, b: f32) bool {
+    var d: f32 = a - b;
+    if (d < 0.0) { d = 0.0 - d; }
+    ret d < 0.001;
+}
+
+test "mat4_determinant: identity is 1, diagonal is the product" {
+    if (!mnear(mat4_determinant(mat4_identity()), 1.0)) { ret 1; }
+    val diag: Mat4 = Mat4{rows: [4]f32x4{
+        f32x4{2.0, 0.0, 0.0, 0.0},
+        f32x4{0.0, 3.0, 0.0, 0.0},
+        f32x4{0.0, 0.0, 4.0, 0.0},
+        f32x4{0.0, 0.0, 0.0, 5.0}
+    }};
+    if (!mnear(mat4_determinant(diag), 120.0)) { ret 2; }
+    ret 0;
+}
+
+test "mat4_determinant: singular matrix is zero" {
+    val sing: Mat4 = Mat4{rows: [4]f32x4{
+        f32x4{1.0, 2.0, 3.0, 4.0},
+        f32x4{2.0, 4.0, 6.0, 8.0},   # row 1 = 2 * row 0
+        f32x4{0.0, 1.0, 0.0, 1.0},
+        f32x4{1.0, 0.0, 1.0, 0.0}
+    }};
+    if (!mnear(mat4_determinant(sing), 0.0)) { ret 1; }
+    ret 0;
+}
+
+test "mat4_inverse: singular matrix returns none" {
+    val sing: Mat4 = Mat4{rows: [4]f32x4{
+        f32x4{1.0, 2.0, 3.0, 4.0},
+        f32x4{2.0, 4.0, 6.0, 8.0},
+        f32x4{0.0, 1.0, 0.0, 1.0},
+        f32x4{1.0, 0.0, 1.0, 0.0}
+    }};
+    if (is_some[Mat4](mat4_inverse(sing))) { ret 1; }
+    ret 0;
+}
+
+test "mat4_inverse: inverse of identity is identity" {
+    val inv: Option[Mat4] = mat4_inverse(mat4_identity());
+    if (is_none[Mat4](inv)) { ret 1; }
+    val m: Mat4 = unwrap[Mat4](inv);
+    if (!mnear(m.rows[0][0], 1.0)) { ret 2; }
+    if (!mnear(m.rows[2][2], 1.0)) { ret 3; }
+    if (!mnear(m.rows[0][1], 0.0)) { ret 4; }
+    ret 0;
+}
+
+test "mat4_inverse: m * inv(m) is identity for an invertible matrix" {
+    val a: Mat4 = Mat4{rows: [4]f32x4{
+        f32x4{4.0, 7.0, 2.0, 3.0},
+        f32x4{0.0, 5.0, 0.0, 1.0},
+        f32x4{2.0, 1.0, 6.0, 0.0},
+        f32x4{1.0, 0.0, 3.0, 8.0}
+    }};
+    val inv: Option[Mat4] = mat4_inverse(a);
+    if (is_none[Mat4](inv)) { ret 1; }
+    val ai: Mat4 = unwrap[Mat4](inv);
+    val prod: Mat4 = mat4_mul(a, ai);
+    # diagonal ~1, off-diagonal ~0
+    if (!mnear(prod.rows[0][0], 1.0)) { ret 2; }
+    if (!mnear(prod.rows[1][1], 1.0)) { ret 3; }
+    if (!mnear(prod.rows[2][2], 1.0)) { ret 4; }
+    if (!mnear(prod.rows[3][3], 1.0)) { ret 5; }
+    if (!mnear(prod.rows[0][1], 0.0)) { ret 6; }
+    if (!mnear(prod.rows[2][3], 0.0)) { ret 7; }
+    if (!mnear(prod.rows[3][0], 0.0)) { ret 8; }
     ret 0;
 }

--- a/src/math/mat4.mach
+++ b/src/math/mat4.mach
@@ -1,0 +1,233 @@
+# 4x4 single-precision matrices over f32x4 rows
+#
+# a Mat4 is an algorithm over vectors, not a language type: it is a record of
+# four f32x4 rows (row-major), and every operation is expressed with the
+# compiler's lane-wise vector operators plus scalar lane reads. the convention
+# is row-vector: a vector transforms as `v * M` (see mat4_mul_vec), and the
+# product `mat4_mul(a, b)` is the matrix applying a then b.
+
+use std.simd.shuffle.splat_f32x4;
+
+# a 4x4 single-precision matrix, four f32x4 rows in row-major order
+# ---
+# rows: the four row vectors, rows[i][j] is row i column j
+pub rec Mat4 {
+    rows: [4]f32x4;
+}
+
+# the linear combination w[0]*b.rows[0] + ... + w[3]*b.rows[3]
+# the shared kernel of matrix*matrix and vector*matrix.
+fun combine(w: f32x4, b: Mat4) f32x4 {
+    ret splat_f32x4(w[0]) * b.rows[0]
+      + splat_f32x4(w[1]) * b.rows[1]
+      + splat_f32x4(w[2]) * b.rows[2]
+      + splat_f32x4(w[3]) * b.rows[3];
+}
+
+# the 4x4 identity matrix
+# ---
+# ret: a matrix with ones on the diagonal, zero elsewhere
+pub fun mat4_identity() Mat4 {
+    ret Mat4{rows: [4]f32x4{
+        f32x4{1.0, 0.0, 0.0, 0.0},
+        f32x4{0.0, 1.0, 0.0, 0.0},
+        f32x4{0.0, 0.0, 1.0, 0.0},
+        f32x4{0.0, 0.0, 0.0, 1.0}
+    }};
+}
+
+# the 4x4 zero matrix
+# ---
+# ret: a matrix with every element zero
+pub fun mat4_zero() Mat4 {
+    ret Mat4{rows: [4]f32x4{
+        f32x4{0.0, 0.0, 0.0, 0.0},
+        f32x4{0.0, 0.0, 0.0, 0.0},
+        f32x4{0.0, 0.0, 0.0, 0.0},
+        f32x4{0.0, 0.0, 0.0, 0.0}
+    }};
+}
+
+# element-wise sum of two matrices
+# ---
+# a:   first matrix
+# b:   second matrix
+# ret: a + b, element-wise
+pub fun mat4_add(a: Mat4, b: Mat4) Mat4 {
+    ret Mat4{rows: [4]f32x4{
+        a.rows[0] + b.rows[0],
+        a.rows[1] + b.rows[1],
+        a.rows[2] + b.rows[2],
+        a.rows[3] + b.rows[3]
+    }};
+}
+
+# element-wise difference of two matrices
+# ---
+# a:   first matrix
+# b:   second matrix
+# ret: a - b, element-wise
+pub fun mat4_sub(a: Mat4, b: Mat4) Mat4 {
+    ret Mat4{rows: [4]f32x4{
+        a.rows[0] - b.rows[0],
+        a.rows[1] - b.rows[1],
+        a.rows[2] - b.rows[2],
+        a.rows[3] - b.rows[3]
+    }};
+}
+
+# scale every element of a matrix by a scalar
+# ---
+# m:   matrix
+# s:   scalar factor
+# ret: m with every element multiplied by s
+pub fun mat4_scale(m: Mat4, s: f32) Mat4 {
+    val sv: f32x4 = splat_f32x4(s);
+    ret Mat4{rows: [4]f32x4{
+        m.rows[0] * sv,
+        m.rows[1] * sv,
+        m.rows[2] * sv,
+        m.rows[3] * sv
+    }};
+}
+
+# matrix product a*b (row-vector convention: applies a then b)
+#
+# each result row is a's row recombined over b's rows, so the multiplies and
+# adds are lane-wise vector ops on a capable target.
+# ---
+# a:   left matrix
+# b:   right matrix
+# ret: the product a*b
+pub fun mat4_mul(a: Mat4, b: Mat4) Mat4 {
+    ret Mat4{rows: [4]f32x4{
+        combine(a.rows[0], b),
+        combine(a.rows[1], b),
+        combine(a.rows[2], b),
+        combine(a.rows[3], b)
+    }};
+}
+
+# transform a row vector by a matrix (v * m)
+# ---
+# m:   matrix
+# v:   row vector
+# ret: the transformed vector v * m
+pub fun mat4_mul_vec(m: Mat4, v: f32x4) f32x4 {
+    ret combine(v, m);
+}
+
+# transpose a matrix (swap rows and columns)
+# ---
+# m:   matrix
+# ret: the transpose of m
+pub fun mat4_transpose(m: Mat4) Mat4 {
+    ret Mat4{rows: [4]f32x4{
+        f32x4{m.rows[0][0], m.rows[1][0], m.rows[2][0], m.rows[3][0]},
+        f32x4{m.rows[0][1], m.rows[1][1], m.rows[2][1], m.rows[3][1]},
+        f32x4{m.rows[0][2], m.rows[1][2], m.rows[2][2], m.rows[3][2]},
+        f32x4{m.rows[0][3], m.rows[1][3], m.rows[2][3], m.rows[3][3]}
+    }};
+}
+
+test "mat4_identity: diagonal ones" {
+    val m: Mat4 = mat4_identity();
+    if (m.rows[0][0] != 1.0) { ret 1; }
+    if (m.rows[1][1] != 1.0) { ret 1; }
+    if (m.rows[2][2] != 1.0) { ret 1; }
+    if (m.rows[3][3] != 1.0) { ret 1; }
+    if (m.rows[0][1] != 0.0) { ret 1; }
+    if (m.rows[3][0] != 0.0) { ret 1; }
+    ret 0;
+}
+
+test "mat4_mul: identity is neutral" {
+    val a: Mat4 = Mat4{rows: [4]f32x4{
+        f32x4{1.0, 2.0, 3.0, 4.0},
+        f32x4{5.0, 6.0, 7.0, 8.0},
+        f32x4{9.0, 10.0, 11.0, 12.0},
+        f32x4{13.0, 14.0, 15.0, 16.0}
+    }};
+    val id: Mat4 = mat4_identity();
+    val r: Mat4 = mat4_mul(a, id);
+    if (r.rows[0][0] != 1.0) { ret 1; }
+    if (r.rows[1][2] != 7.0) { ret 1; }
+    if (r.rows[3][3] != 16.0) { ret 1; }
+    val l: Mat4 = mat4_mul(id, a);
+    if (l.rows[2][1] != 10.0) { ret 1; }
+    ret 0;
+}
+
+test "mat4_mul: known product against scalar reference" {
+    # A applies then B; discriminating entries so a wrong-lane bug shows
+    val a: Mat4 = Mat4{rows: [4]f32x4{
+        f32x4{1.0, 2.0, 0.0, 0.0},
+        f32x4{3.0, 4.0, 0.0, 0.0},
+        f32x4{0.0, 0.0, 1.0, 0.0},
+        f32x4{0.0, 0.0, 0.0, 1.0}
+    }};
+    val b: Mat4 = Mat4{rows: [4]f32x4{
+        f32x4{5.0, 6.0, 0.0, 0.0},
+        f32x4{7.0, 8.0, 0.0, 0.0},
+        f32x4{0.0, 0.0, 1.0, 0.0},
+        f32x4{0.0, 0.0, 0.0, 1.0}
+    }};
+    val r: Mat4 = mat4_mul(a, b);
+    # top-left 2x2: [1 2;3 4]*[5 6;7 8] = [19 22;43 50]
+    if (r.rows[0][0] != 19.0) { ret 1; }
+    if (r.rows[0][1] != 22.0) { ret 1; }
+    if (r.rows[1][0] != 43.0) { ret 1; }
+    if (r.rows[1][1] != 50.0) { ret 1; }
+    ret 0;
+}
+
+test "mat4_mul_vec: row vector times matrix" {
+    val m: Mat4 = Mat4{rows: [4]f32x4{
+        f32x4{2.0, 0.0, 0.0, 0.0},
+        f32x4{0.0, 3.0, 0.0, 0.0},
+        f32x4{0.0, 0.0, 4.0, 0.0},
+        f32x4{1.0, 1.0, 1.0, 1.0}
+    }};
+    val v: f32x4 = f32x4{1.0, 1.0, 1.0, 1.0};
+    val r: f32x4 = mat4_mul_vec(m, v);
+    # scale (2,3,4) then translate (1,1,1): (2+1, 3+1, 4+1, 1)
+    if (r[0] != 3.0) { ret 1; }
+    if (r[1] != 4.0) { ret 1; }
+    if (r[2] != 5.0) { ret 1; }
+    if (r[3] != 1.0) { ret 1; }
+    ret 0;
+}
+
+test "mat4_transpose: swaps off-diagonal, double transpose is identity" {
+    val a: Mat4 = Mat4{rows: [4]f32x4{
+        f32x4{1.0, 2.0, 3.0, 4.0},
+        f32x4{5.0, 6.0, 7.0, 8.0},
+        f32x4{9.0, 10.0, 11.0, 12.0},
+        f32x4{13.0, 14.0, 15.0, 16.0}
+    }};
+    val t: Mat4 = mat4_transpose(a);
+    if (t.rows[0][1] != 5.0) { ret 1; }
+    if (t.rows[1][0] != 2.0) { ret 1; }
+    if (t.rows[3][0] != 4.0) { ret 1; }
+    if (t.rows[0][3] != 13.0) { ret 1; }
+    val tt: Mat4 = mat4_transpose(t);
+    if (tt.rows[2][3] != 12.0) { ret 1; }
+    if (tt.rows[1][1] != 6.0) { ret 1; }
+    ret 0;
+}
+
+test "mat4_add / mat4_sub / mat4_scale: element-wise" {
+    val a: Mat4 = Mat4{rows: [4]f32x4{
+        f32x4{1.0, 2.0, 3.0, 4.0},
+        f32x4{5.0, 6.0, 7.0, 8.0},
+        f32x4{9.0, 10.0, 11.0, 12.0},
+        f32x4{13.0, 14.0, 15.0, 16.0}
+    }};
+    val s: Mat4 = mat4_scale(a, 2.0);
+    if (s.rows[1][1] != 12.0) { ret 1; }
+    val d: Mat4 = mat4_sub(s, a);
+    if (d.rows[1][1] != 6.0) { ret 1; }
+    val sum: Mat4 = mat4_add(a, a);
+    if (sum.rows[2][3] != 24.0) { ret 1; }
+    ret 0;
+}

--- a/src/math/quat.mach
+++ b/src/math/quat.mach
@@ -1,0 +1,188 @@
+# quaternions over f32x4
+#
+# a quaternion is stored in an f32x4 as {x, y, z, w}: the vector part in lanes
+# 0-2 and the real part in lane 3. operations are algorithms over the lane-wise
+# vector operators and scalar lane reads — no bit reinterpret at vector width,
+# so correct on every target.
+#
+# normalization needs a reciprocal square root; `rsqrt` is a private
+# Newton-refined bit-seed estimate over scalar reinterpret (a full float-math
+# module with a correctly-rounded sqrt and the transcendentals slerp needs is a
+# follow-up in this repo).
+
+use std.types.bool.bool;
+use std.simd.shuffle.splat_f32x4;
+use std.simd.reduce.dot_f32x4;
+
+# reciprocal square root of a positive scalar, Newton-refined bit-seed estimate
+fun rsqrt(x: f32) f32 {
+    val half: f32 = x * 0.5;
+    var i: u32 = x:~u32;
+    i = 0x5f3759df - (i >> 1);
+    var y: f32 = i:~f32;
+    y = y * (1.5 - half * y * y);
+    y = y * (1.5 - half * y * y);
+    y = y * (1.5 - half * y * y);
+    y = y * (1.5 - half * y * y);
+    ret y;
+}
+
+# square root of a non-negative scalar
+fun sqrtf(x: f32) f32 {
+    if (x == 0.0) { ret 0.0; }
+    ret x * rsqrt(x);
+}
+
+# the identity quaternion (no rotation)
+# ---
+# ret: {0, 0, 0, 1}
+pub fun quat_identity() f32x4 {
+    ret f32x4{0.0, 0.0, 0.0, 1.0};
+}
+
+# Hamilton product of two quaternions (composition of rotations)
+# ---
+# a:   left quaternion, applied second
+# b:   right quaternion, applied first
+# ret: the composed quaternion a*b
+pub fun quat_mul(a: f32x4, b: f32x4) f32x4 {
+    val ax: f32 = a[0]; val ay: f32 = a[1]; val az: f32 = a[2]; val aw: f32 = a[3];
+    val bx: f32 = b[0]; val by: f32 = b[1]; val bz: f32 = b[2]; val bw: f32 = b[3];
+    ret f32x4{
+        aw * bx + ax * bw + ay * bz - az * by,
+        aw * by - ax * bz + ay * bw + az * bx,
+        aw * bz + ax * by - ay * bx + az * bw,
+        aw * bw - ax * bx - ay * by - az * bz
+    };
+}
+
+# conjugate of a quaternion (negate the vector part)
+#
+# for a unit quaternion this is the inverse rotation.
+# ---
+# q:   input quaternion
+# ret: {-x, -y, -z, w}
+pub fun quat_conjugate(q: f32x4) f32x4 {
+    ret q * f32x4{-1.0, -1.0, -1.0, 1.0};
+}
+
+# dot product of two quaternions
+# ---
+# a:   first quaternion
+# b:   second quaternion
+# ret: a . b
+pub fun quat_dot(a: f32x4, b: f32x4) f32 {
+    ret dot_f32x4(a, b);
+}
+
+# length (magnitude) of a quaternion
+# ---
+# q:   input quaternion
+# ret: sqrt(q . q)
+pub fun quat_length(q: f32x4) f32 {
+    ret sqrtf(dot_f32x4(q, q));
+}
+
+# normalize a quaternion to unit length
+#
+# scaling by the reciprocal length is a single lane-wise vector multiply.
+# ---
+# q:   input quaternion (must be non-zero)
+# ret: q / |q|
+pub fun quat_normalize(q: f32x4) f32x4 {
+    ret q * splat_f32x4(rsqrt(dot_f32x4(q, q)));
+}
+
+# normalized linear interpolation between two quaternions
+#
+# lerps the components then renormalizes, taking the shortest arc by flipping b
+# when the quaternions face opposite hemispheres. cheaper than true slerp and a
+# close approximation for nearby rotations; true slerp awaits the float
+# transcendentals (acos/sin) as a follow-up.
+# ---
+# a:   start quaternion (unit)
+# b:   end quaternion (unit)
+# t:   interpolation factor in [0, 1]
+# ret: the interpolated unit quaternion
+pub fun quat_nlerp(a: f32x4, b: f32x4, t: f32) f32x4 {
+    var bb: f32x4 = b;
+    if (dot_f32x4(a, b) < 0.0) {
+        bb = b * splat_f32x4(-1.0);
+    }
+    val ta: f32x4 = splat_f32x4(1.0 - t);
+    val tb: f32x4 = splat_f32x4(t);
+    ret quat_normalize(a * ta + bb * tb);
+}
+
+# per-lane absolute difference within tolerance
+fun near(a: f32, b: f32) bool {
+    var d: f32 = a - b;
+    if (d < 0.0) { d = 0.0 - d; }
+    ret d < 0.0005;
+}
+
+test "quat_identity: is unit and neutral" {
+    val id: f32x4 = quat_identity();
+    if (id[3] != 1.0) { ret 1; }
+    val q: f32x4 = f32x4{0.1, 0.2, 0.3, 0.9};
+    val r: f32x4 = quat_mul(q, id);
+    if (!near(r[0], 0.1)) { ret 2; }
+    if (!near(r[3], 0.9)) { ret 3; }
+    ret 0;
+}
+
+test "quat_mul: two 90-degree z-rotations compose to 180" {
+    val s: f32 = 0.70710678;   # sin/cos of 45 degrees
+    val a: f32x4 = f32x4{0.0, 0.0, s, s};
+    val r: f32x4 = quat_mul(a, a);
+    # expect (0, 0, 1, 0)
+    if (!near(r[0], 0.0)) { ret 1; }
+    if (!near(r[1], 0.0)) { ret 2; }
+    if (!near(r[2], 1.0)) { ret 3; }
+    if (!near(r[3], 0.0)) { ret 4; }
+    ret 0;
+}
+
+test "quat_conjugate: negates vector part only" {
+    val q: f32x4 = f32x4{1.0, -2.0, 3.0, 4.0};
+    val c: f32x4 = quat_conjugate(q);
+    if (c[0] != -1.0) { ret 1; }
+    if (c[1] != 2.0) { ret 1; }
+    if (c[2] != -3.0) { ret 1; }
+    if (c[3] != 4.0) { ret 1; }
+    ret 0;
+}
+
+test "quat_length / quat_normalize: unit after normalize" {
+    val q: f32x4 = f32x4{1.0, 2.0, 2.0, 4.0};
+    # |q| = sqrt(1+4+4+16) = 5
+    if (!near(quat_length(q), 5.0)) { ret 1; }
+    val n: f32x4 = quat_normalize(q);
+    if (!near(quat_length(n), 1.0)) { ret 2; }
+    # direction preserved: n[3]/n[0] == 4
+    if (!near(n[0], 0.2)) { ret 3; }
+    if (!near(n[3], 0.8)) { ret 4; }
+    ret 0;
+}
+
+test "quat_mul by conjugate yields identity for a unit quaternion" {
+    val q: f32x4 = quat_normalize(f32x4{0.3, -0.5, 0.2, 0.8});
+    val r: f32x4 = quat_mul(q, quat_conjugate(q));
+    if (!near(r[0], 0.0)) { ret 1; }
+    if (!near(r[1], 0.0)) { ret 2; }
+    if (!near(r[2], 0.0)) { ret 3; }
+    if (!near(r[3], 1.0)) { ret 4; }
+    ret 0;
+}
+
+test "quat_nlerp: endpoints and unit result" {
+    val a: f32x4 = quat_identity();
+    val b: f32x4 = quat_normalize(f32x4{0.0, 0.0, 0.70710678, 0.70710678});
+    val at0: f32x4 = quat_nlerp(a, b, 0.0);
+    if (!near(at0[3], 1.0)) { ret 1; }
+    val at1: f32x4 = quat_nlerp(a, b, 1.0);
+    if (!near(at1[2], 0.70710678)) { ret 2; }
+    val mid: f32x4 = quat_nlerp(a, b, 0.5);
+    if (!near(quat_length(mid), 1.0)) { ret 3; }
+    ret 0;
+}

--- a/src/simd/gather.mach
+++ b/src/simd/gather.mach
@@ -1,0 +1,134 @@
+# gather / scatter over the seeded 128-bit vector types
+#
+# gather loads one lane per index from a base array; scatter stores each lane to
+# its index. lane indices into the result/source vector are comptime constants,
+# so each is a fixed sequence of indexed pointer accesses — the defined scalar
+# form of a masked gather, correct on every target. the memory indices
+# themselves are ordinary runtime values carried in a u32x4.
+
+use std.types.size.usize;
+
+# gather four f32 lanes from base at the four u32 indices
+# ---
+# base: pointer to the source array
+# idx:  per-lane element indices into base
+# ret:  {base[idx[0]], base[idx[1]], base[idx[2]], base[idx[3]]}
+pub fun gather_f32x4(base: *f32, idx: u32x4) f32x4 {
+    ret f32x4{
+        base[idx[0]::usize],
+        base[idx[1]::usize],
+        base[idx[2]::usize],
+        base[idx[3]::usize]
+    };
+}
+
+# gather four i32 lanes from base at the four u32 indices
+# ---
+# base: pointer to the source array
+# idx:  per-lane element indices into base
+# ret:  {base[idx[0]], base[idx[1]], base[idx[2]], base[idx[3]]}
+pub fun gather_i32x4(base: *i32, idx: u32x4) i32x4 {
+    ret i32x4{
+        base[idx[0]::usize],
+        base[idx[1]::usize],
+        base[idx[2]::usize],
+        base[idx[3]::usize]
+    };
+}
+
+# gather four u32 lanes from base at the four u32 indices
+# ---
+# base: pointer to the source array
+# idx:  per-lane element indices into base
+# ret:  {base[idx[0]], base[idx[1]], base[idx[2]], base[idx[3]]}
+pub fun gather_u32x4(base: *u32, idx: u32x4) u32x4 {
+    ret u32x4{
+        base[idx[0]::usize],
+        base[idx[1]::usize],
+        base[idx[2]::usize],
+        base[idx[3]::usize]
+    };
+}
+
+# scatter four f32 lanes to base at the four u32 indices
+# ---
+# base: pointer to the destination array
+# idx:  per-lane element indices into base
+# v:    lanes to store, v[i] written to base[idx[i]]
+pub fun scatter_f32x4(base: *f32, idx: u32x4, v: f32x4) {
+    base[idx[0]::usize] = v[0];
+    base[idx[1]::usize] = v[1];
+    base[idx[2]::usize] = v[2];
+    base[idx[3]::usize] = v[3];
+}
+
+# scatter four i32 lanes to base at the four u32 indices
+# ---
+# base: pointer to the destination array
+# idx:  per-lane element indices into base
+# v:    lanes to store, v[i] written to base[idx[i]]
+pub fun scatter_i32x4(base: *i32, idx: u32x4, v: i32x4) {
+    base[idx[0]::usize] = v[0];
+    base[idx[1]::usize] = v[1];
+    base[idx[2]::usize] = v[2];
+    base[idx[3]::usize] = v[3];
+}
+
+test "gather_f32x4: permuted indices" {
+    var data: [8]f32 = [8]f32{10.0, 11.0, 12.0, 13.0, 14.0, 15.0, 16.0, 17.0};
+    val idx: u32x4 = u32x4{7, 0, 4, 2};
+    val r: f32x4 = gather_f32x4(?data[0], idx);
+    if (r[0] != 17.0) { ret 1; }
+    if (r[1] != 10.0) { ret 1; }
+    if (r[2] != 14.0) { ret 1; }
+    if (r[3] != 12.0) { ret 1; }
+    ret 0;
+}
+
+test "gather_i32x4: repeated and reversed indices" {
+    var data: [8]i32 = [8]i32{-1, -2, -3, -4, -5, -6, -7, -8};
+    val idx: u32x4 = u32x4{3, 3, 0, 6};
+    val r: i32x4 = gather_i32x4(?data[0], idx);
+    if (r[0] != -4) { ret 1; }
+    if (r[1] != -4) { ret 1; }
+    if (r[2] != -1) { ret 1; }
+    if (r[3] != -7) { ret 1; }
+    ret 0;
+}
+
+test "gather_u32x4: distinct bit patterns" {
+    var data: [4]u32 = [4]u32{0x11111111, 0x22222222, 0x33333333, 0x44444444};
+    val idx: u32x4 = u32x4{2, 0, 3, 1};
+    val r: u32x4 = gather_u32x4(?data[0], idx);
+    if (r[0] != 0x33333333) { ret 1; }
+    if (r[1] != 0x11111111) { ret 1; }
+    if (r[2] != 0x44444444) { ret 1; }
+    if (r[3] != 0x22222222) { ret 1; }
+    ret 0;
+}
+
+test "scatter_f32x4: writes each lane to its index" {
+    var data: [8]f32 = [8]f32{0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    val idx: u32x4 = u32x4{5, 1, 7, 3};
+    val v: f32x4 = f32x4{1.5, 2.5, 3.5, 4.5};
+    scatter_f32x4(?data[0], idx, v);
+    if (data[5] != 1.5) { ret 1; }
+    if (data[1] != 2.5) { ret 1; }
+    if (data[7] != 3.5) { ret 1; }
+    if (data[3] != 4.5) { ret 1; }
+    if (data[0] != 0.0) { ret 1; }
+    ret 0;
+}
+
+test "scatter then gather round-trips" {
+    var data: [8]i32 = [8]i32{0, 0, 0, 0, 0, 0, 0, 0};
+    val idx: u32x4 = u32x4{6, 2, 0, 4};
+    val v: i32x4 = i32x4{100, -200, 300, -400};
+    scatter_i32x4(?data[0], idx, v);
+    val r: i32x4 = gather_i32x4(?data[0], idx);
+    if (r[0] != 100) { ret 1; }
+    if (r[1] != -200) { ret 1; }
+    if (r[2] != 300) { ret 1; }
+    if (r[3] != -400) { ret 1; }
+    ret 0;
+}

--- a/src/simd/reduce.mach
+++ b/src/simd/reduce.mach
@@ -1,0 +1,153 @@
+# horizontal reductions over the seeded 128-bit vector types
+#
+# a horizontal reduction collapses a vector's lanes to a single scalar. the
+# lane-to-lane combine is inherently scalar (comptime-constant lane reads), so
+# these read each lane and fold. the batch win lives in the caller: accumulate
+# many vectors with the lane-wise vector operators (one SSE2/NEON instruction
+# per step on a capable target) and call a horizontal reduction once at the end.
+# `dot_f32x4` shows the shape — a vector multiply then a single horizontal sum.
+
+# horizontal sum of f32x4 lanes
+# ---
+# v:   input vector
+# ret: v[0] + v[1] + v[2] + v[3]
+pub fun hsum_f32x4(v: f32x4) f32 {
+    ret v[0] + v[1] + v[2] + v[3];
+}
+
+# horizontal sum of f64x2 lanes
+# ---
+# v:   input vector
+# ret: v[0] + v[1]
+pub fun hsum_f64x2(v: f64x2) f64 {
+    ret v[0] + v[1];
+}
+
+# horizontal sum of i32x4 lanes (wrapping)
+# ---
+# v:   input vector
+# ret: v[0] + v[1] + v[2] + v[3]
+pub fun hsum_i32x4(v: i32x4) i32 {
+    ret v[0] + v[1] + v[2] + v[3];
+}
+
+# horizontal sum of u32x4 lanes (wrapping)
+# ---
+# v:   input vector
+# ret: v[0] + v[1] + v[2] + v[3]
+pub fun hsum_u32x4(v: u32x4) u32 {
+    ret v[0] + v[1] + v[2] + v[3];
+}
+
+# horizontal minimum of f32x4 lanes
+# ---
+# v:   input vector
+# ret: the smallest lane
+pub fun hmin_f32x4(v: f32x4) f32 {
+    var m: f32 = v[0];
+    if (v[1] < m) { m = v[1]; }
+    if (v[2] < m) { m = v[2]; }
+    if (v[3] < m) { m = v[3]; }
+    ret m;
+}
+
+# horizontal maximum of f32x4 lanes
+# ---
+# v:   input vector
+# ret: the largest lane
+pub fun hmax_f32x4(v: f32x4) f32 {
+    var m: f32 = v[0];
+    if (v[1] > m) { m = v[1]; }
+    if (v[2] > m) { m = v[2]; }
+    if (v[3] > m) { m = v[3]; }
+    ret m;
+}
+
+# horizontal minimum of i32x4 lanes
+# ---
+# v:   input vector
+# ret: the smallest lane
+pub fun hmin_i32x4(v: i32x4) i32 {
+    var m: i32 = v[0];
+    if (v[1] < m) { m = v[1]; }
+    if (v[2] < m) { m = v[2]; }
+    if (v[3] < m) { m = v[3]; }
+    ret m;
+}
+
+# horizontal maximum of i32x4 lanes
+# ---
+# v:   input vector
+# ret: the largest lane
+pub fun hmax_i32x4(v: i32x4) i32 {
+    var m: i32 = v[0];
+    if (v[1] > m) { m = v[1]; }
+    if (v[2] > m) { m = v[2]; }
+    if (v[3] > m) { m = v[3]; }
+    ret m;
+}
+
+# dot product of two f32x4 vectors
+#
+# the multiply is a single lane-wise vector op (vectorized on a capable target);
+# the horizontal sum folds the four products.
+# ---
+# a:   first vector
+# b:   second vector
+# ret: a[0]*b[0] + a[1]*b[1] + a[2]*b[2] + a[3]*b[3]
+pub fun dot_f32x4(a: f32x4, b: f32x4) f32 {
+    ret hsum_f32x4(a * b);
+}
+
+test "hsum_f32x4: sums lanes" {
+    val v: f32x4 = f32x4{1.5, 2.25, 3.0, 4.25};
+    if (hsum_f32x4(v) != 11.0) { ret 1; }
+    ret 0;
+}
+
+test "hsum_f64x2: sums lanes" {
+    val v: f64x2 = f64x2{1.5, 2.5};
+    if (hsum_f64x2(v) != 4.0) { ret 1; }
+    ret 0;
+}
+
+test "hsum_i32x4: cross-lane distinct magnitudes" {
+    val v: i32x4 = i32x4{1000000, -3, 40000, -7};
+    if (hsum_i32x4(v) != 1039990) { ret 1; }
+    ret 0;
+}
+
+test "hsum_u32x4: large lanes" {
+    val v: u32x4 = u32x4{0x10000000, 0x00200000, 0x00030000, 0x00000400};
+    if (hsum_u32x4(v) != 0x10230400) { ret 1; }
+    ret 0;
+}
+
+test "hmin_f32x4 / hmax_f32x4: extrema not at lane 0" {
+    val v: f32x4 = f32x4{3.5, -2.0, 9.0, 1.0};
+    if (hmin_f32x4(v) != -2.0) { ret 1; }
+    if (hmax_f32x4(v) != 9.0) { ret 1; }
+    ret 0;
+}
+
+test "hmin_i32x4 / hmax_i32x4: signed extrema" {
+    val v: i32x4 = i32x4{7, -100, 42, 5};
+    if (hmin_i32x4(v) != -100) { ret 1; }
+    if (hmax_i32x4(v) != 42) { ret 1; }
+    ret 0;
+}
+
+test "dot_f32x4: vectorized multiply then horizontal sum" {
+    val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};
+    val b: f32x4 = f32x4{5.0, 6.0, 7.0, 8.0};
+    # 5 + 12 + 21 + 32 = 70
+    if (dot_f32x4(a, b) != 70.0) { ret 1; }
+    ret 0;
+}
+
+test "dot_f32x4: orthogonal vectors are zero" {
+    val a: f32x4 = f32x4{1.0, 0.0, -1.0, 0.0};
+    val b: f32x4 = f32x4{0.0, 1.0, 0.0, -1.0};
+    if (dot_f32x4(a, b) != 0.0) { ret 1; }
+    ret 0;
+}

--- a/src/simd/saturate.mach
+++ b/src/simd/saturate.mach
@@ -1,0 +1,115 @@
+# saturating (clamping) arithmetic over the seeded unsigned vector types
+#
+# there is no lane-wise saturating operator, so each is built from the wrapping
+# lane-wise op plus an overflow mask derived from an unsigned comparison — the
+# `paddus`/`psubus`-class behavior expressed in portable Mach. no bit
+# reinterpret is needed: everything stays in the operand's own unsigned type.
+#
+# unsigned add saturates to all-ones on carry-out; unsigned subtract saturates
+# to zero on borrow.
+
+# saturating unsigned add of u8x16 lanes (clamps to 0xFF)
+# ---
+# a:   first operand
+# b:   second operand
+# ret: lane-wise min(a + b, 0xFF)
+pub fun adds_u8x16(a: u8x16, b: u8x16) u8x16 {
+    val sum: u8x16 = a + b;
+    val ovf: u8x16 = sum < a;   # wrap-around iff the sum dropped below a
+    ret sum | ovf;              # overflowed lanes forced to all-ones
+}
+
+# saturating unsigned subtract of u8x16 lanes (clamps to 0)
+# ---
+# a:   minuend
+# b:   subtrahend
+# ret: lane-wise max(a - b, 0)
+pub fun subs_u8x16(a: u8x16, b: u8x16) u8x16 {
+    val diff: u8x16 = a - b;
+    val und: u8x16 = a < b;     # borrow iff a < b
+    ret diff & ~und;            # underflowed lanes forced to zero
+}
+
+# saturating unsigned add of u16x8 lanes (clamps to 0xFFFF)
+# ---
+# a:   first operand
+# b:   second operand
+# ret: lane-wise min(a + b, 0xFFFF)
+pub fun adds_u16x8(a: u16x8, b: u16x8) u16x8 {
+    val sum: u16x8 = a + b;
+    val ovf: u16x8 = sum < a;
+    ret sum | ovf;
+}
+
+# saturating unsigned subtract of u16x8 lanes (clamps to 0)
+# ---
+# a:   minuend
+# b:   subtrahend
+# ret: lane-wise max(a - b, 0)
+pub fun subs_u16x8(a: u16x8, b: u16x8) u16x8 {
+    val diff: u16x8 = a - b;
+    val und: u16x8 = a < b;
+    ret diff & ~und;
+}
+
+test "adds_u8x16: saturates on carry, exact below" {
+    val a: u8x16 = u8x16{200, 100, 1, 255, 0, 128, 254, 5, 10, 20, 30, 40, 50, 60, 70, 80};
+    val b: u8x16 = u8x16{100, 100, 2, 1,   0, 128, 3,   5, 10, 20, 30, 40, 50, 60, 70, 80};
+    val r: u8x16 = adds_u8x16(a, b);
+    if (r[0] != 255) { ret 1; }   # 300 -> 255
+    if (r[1] != 200) { ret 1; }   # exact
+    if (r[2] != 3) { ret 1; }
+    if (r[3] != 255) { ret 1; }   # 256 -> 255
+    if (r[4] != 0) { ret 1; }
+    if (r[5] != 255) { ret 1; }   # 256 -> 255
+    if (r[6] != 255) { ret 1; }   # 257 -> 255
+    if (r[7] != 10) { ret 1; }
+    if (r[15] != 160) { ret 1; }  # exact
+    ret 0;
+}
+
+test "subs_u8x16: saturates on borrow, exact above" {
+    val a: u8x16 = u8x16{10, 255, 5, 0, 128, 200, 1, 100, 90, 80, 70, 60, 50, 40, 30, 20};
+    val b: u8x16 = u8x16{20, 1,   5, 1, 128, 50,  2, 40,  90, 81, 70, 61, 50, 41, 30, 21};
+    val r: u8x16 = subs_u8x16(a, b);
+    if (r[0] != 0) { ret 1; }     # 10-20 -> 0
+    if (r[1] != 254) { ret 1; }   # exact
+    if (r[2] != 0) { ret 1; }
+    if (r[3] != 0) { ret 1; }     # 0-1 -> 0
+    if (r[4] != 0) { ret 1; }     # 128-128
+    if (r[5] != 150) { ret 1; }   # exact
+    if (r[6] != 0) { ret 1; }     # 1-2 -> 0
+    if (r[7] != 60) { ret 1; }    # exact
+    if (r[8] != 0) { ret 1; }     # 90-90
+    if (r[9] != 0) { ret 1; }     # 80-81 -> 0
+    ret 0;
+}
+
+test "adds_u16x8: half-word carry saturates" {
+    val a: u16x8 = u16x8{0xFFFF, 0x8000, 100, 0xFFFE, 0, 0x1234, 0xFF00, 0x0F0F};
+    val b: u16x8 = u16x8{1,      0x8000, 200, 3,      0, 0x1000, 0x0100, 0xF0F1};
+    val r: u16x8 = adds_u16x8(a, b);
+    if (r[0] != 0xFFFF) { ret 1; }   # wrap -> max
+    if (r[1] != 0xFFFF) { ret 1; }   # 0x10000 -> max
+    if (r[2] != 300) { ret 1; }      # exact
+    if (r[3] != 0xFFFF) { ret 1; }   # 0x10001 -> max
+    if (r[5] != 0x2234) { ret 1; }   # exact
+    if (r[6] != 0xFFFF) { ret 1; }   # exact 0x10000 -> max
+    if (r[7] != 0xFFFF) { ret 1; }   # 0x1000 -> exact? 0x0F0F+0xF0F1=0x10000 -> max
+    ret 0;
+}
+
+test "subs_u16x8: half-word borrow saturates" {
+    val a: u16x8 = u16x8{100, 0xFFFF, 0, 0x8000, 5, 0x1000, 42, 0x00FF};
+    val b: u16x8 = u16x8{200, 1,      1, 0x8001, 5, 0x0FFF, 43, 0x0100};
+    val r: u16x8 = subs_u16x8(a, b);
+    if (r[0] != 0) { ret 1; }        # 100-200 -> 0
+    if (r[1] != 0xFFFE) { ret 1; }   # exact
+    if (r[2] != 0) { ret 1; }        # 0-1 -> 0
+    if (r[3] != 0) { ret 1; }        # borrow -> 0
+    if (r[4] != 0) { ret 1; }        # 5-5
+    if (r[5] != 1) { ret 1; }        # exact
+    if (r[6] != 0) { ret 1; }        # 42-43 -> 0
+    if (r[7] != 0) { ret 1; }        # 0x00FF-0x0100 -> 0
+    ret 0;
+}

--- a/src/simd/select.mach
+++ b/src/simd/select.mach
@@ -1,0 +1,264 @@
+# lane-wise select / blend over the seeded 128-bit vector types
+#
+# select is the load-bearing SIMD-library primitive: the compiler produces no
+# `select` operator, so a conditional lane pick is expressed as the pure
+# bitwise idiom `(mask & a) | (~mask & b)` over the unsigned mask a comparison
+# yields. `mask` is an unsigned vector whose lanes are all-ones (true) or
+# all-zeros (false) — exactly the shape a vector comparison produces (see the
+# compiler's operators.md). Where a lane of `mask` is true the result takes the
+# corresponding lane of `a`; where false, of `b`.
+#
+# the four unsigned types blend directly. the signed and float types have no
+# bitwise operators, so their operands are bit-reinterpreted (`:~`) through the
+# matching unsigned type — a pure reinterpret, not a numeric conversion — and
+# the result reinterpreted back. a mask with partial (non-uniform) lane bits
+# yields a per-bit mix; masks are expected to come from comparisons.
+
+# select over u8x16 lanes
+# ---
+# mask: per-lane selector, all-ones picks a and all-zeros picks b
+# a:    value chosen where the mask lane is true
+# b:    value chosen where the mask lane is false
+# ret:  lane-wise blend of a and b
+pub fun select_u8x16(mask: u8x16, a: u8x16, b: u8x16) u8x16 {
+    ret (mask & a) | (~mask & b);
+}
+
+# select over u16x8 lanes
+# ---
+# mask: per-lane selector, all-ones picks a and all-zeros picks b
+# a:    value chosen where the mask lane is true
+# b:    value chosen where the mask lane is false
+# ret:  lane-wise blend of a and b
+pub fun select_u16x8(mask: u16x8, a: u16x8, b: u16x8) u16x8 {
+    ret (mask & a) | (~mask & b);
+}
+
+# select over u32x4 lanes
+# ---
+# mask: per-lane selector, all-ones picks a and all-zeros picks b
+# a:    value chosen where the mask lane is true
+# b:    value chosen where the mask lane is false
+# ret:  lane-wise blend of a and b
+pub fun select_u32x4(mask: u32x4, a: u32x4, b: u32x4) u32x4 {
+    ret (mask & a) | (~mask & b);
+}
+
+# select over u64x2 lanes
+# ---
+# mask: per-lane selector, all-ones picks a and all-zeros picks b
+# a:    value chosen where the mask lane is true
+# b:    value chosen where the mask lane is false
+# ret:  lane-wise blend of a and b
+pub fun select_u64x2(mask: u64x2, a: u64x2, b: u64x2) u64x2 {
+    ret (mask & a) | (~mask & b);
+}
+
+# select over i8x16 lanes, mask is the matching u8x16
+# ---
+# mask: per-lane selector, all-ones picks a and all-zeros picks b
+# a:    value chosen where the mask lane is true
+# b:    value chosen where the mask lane is false
+# ret:  lane-wise blend of a and b
+pub fun select_i8x16(mask: u8x16, a: i8x16, b: i8x16) i8x16 {
+    ret ((mask & a:~u8x16) | (~mask & b:~u8x16)):~i8x16;
+}
+
+# select over i16x8 lanes, mask is the matching u16x8
+# ---
+# mask: per-lane selector, all-ones picks a and all-zeros picks b
+# a:    value chosen where the mask lane is true
+# b:    value chosen where the mask lane is false
+# ret:  lane-wise blend of a and b
+pub fun select_i16x8(mask: u16x8, a: i16x8, b: i16x8) i16x8 {
+    ret ((mask & a:~u16x8) | (~mask & b:~u16x8)):~i16x8;
+}
+
+# select over i32x4 lanes, mask is the matching u32x4
+# ---
+# mask: per-lane selector, all-ones picks a and all-zeros picks b
+# a:    value chosen where the mask lane is true
+# b:    value chosen where the mask lane is false
+# ret:  lane-wise blend of a and b
+pub fun select_i32x4(mask: u32x4, a: i32x4, b: i32x4) i32x4 {
+    ret ((mask & a:~u32x4) | (~mask & b:~u32x4)):~i32x4;
+}
+
+# select over i64x2 lanes, mask is the matching u64x2
+# ---
+# mask: per-lane selector, all-ones picks a and all-zeros picks b
+# a:    value chosen where the mask lane is true
+# b:    value chosen where the mask lane is false
+# ret:  lane-wise blend of a and b
+pub fun select_i64x2(mask: u64x2, a: i64x2, b: i64x2) i64x2 {
+    ret ((mask & a:~u64x2) | (~mask & b:~u64x2)):~i64x2;
+}
+
+# select over f32x4 lanes, mask is the matching u32x4
+# ---
+# mask: per-lane selector, all-ones picks a and all-zeros picks b
+# a:    value chosen where the mask lane is true
+# b:    value chosen where the mask lane is false
+# ret:  lane-wise blend of a and b
+pub fun select_f32x4(mask: u32x4, a: f32x4, b: f32x4) f32x4 {
+    ret ((mask & a:~u32x4) | (~mask & b:~u32x4)):~f32x4;
+}
+
+# select over f64x2 lanes, mask is the matching u64x2
+# ---
+# mask: per-lane selector, all-ones picks a and all-zeros picks b
+# a:    value chosen where the mask lane is true
+# b:    value chosen where the mask lane is false
+# ret:  lane-wise blend of a and b
+pub fun select_f64x2(mask: u64x2, a: f64x2, b: f64x2) f64x2 {
+    ret ((mask & a:~u64x2) | (~mask & b:~u64x2)):~f64x2;
+}
+
+test "select_u32x4: blend picks a on true, b on false" {
+    val a: u32x4 = u32x4{0xAAAAAAAA, 0x11111111, 0x22222222, 0x33333333};
+    val b: u32x4 = u32x4{0x44444444, 0x55555555, 0x66666666, 0x77777777};
+    val mask: u32x4 = u32x4{0xFFFFFFFF, 0x00000000, 0xFFFFFFFF, 0x00000000};
+    val r: u32x4 = select_u32x4(mask, a, b);
+    if (r[0] != 0xAAAAAAAA) { ret 1; }
+    if (r[1] != 0x55555555) { ret 1; }
+    if (r[2] != 0x22222222) { ret 1; }
+    if (r[3] != 0x77777777) { ret 1; }
+    ret 0;
+}
+
+test "select_u32x4: mask from a comparison yields lane-wise min" {
+    val a: u32x4 = u32x4{5, 20, 5, 40};
+    val b: u32x4 = u32x4{10, 10, 10, 10};
+    val mask: u32x4 = a < b;                 # {T, F, T, F}
+    val r: u32x4 = select_u32x4(mask, a, b);
+    if (r[0] != 5) { ret 1; }
+    if (r[1] != 10) { ret 1; }
+    if (r[2] != 5) { ret 1; }
+    if (r[3] != 10) { ret 1; }
+    ret 0;
+}
+
+test "select_u32x4: lane-exact against a scalar reference" {
+    val a: u32x4 = u32x4{0x0000FFFF, 0xFFFF0000, 0x0F0F0F0F, 0xF0F0F0F0};
+    val b: u32x4 = u32x4{0xFFFF0000, 0x0000FFFF, 0xF0F0F0F0, 0x0F0F0F0F};
+    val mask: u32x4 = u32x4{0xFFFFFFFF, 0, 0xFFFFFFFF, 0};
+    val r: u32x4 = select_u32x4(mask, a, b);
+    # scalar reference: all-ones lane -> a, all-zeros lane -> b
+    if (r[0] != a[0]) { ret 1; }
+    if (r[1] != b[1]) { ret 1; }
+    if (r[2] != a[2]) { ret 1; }
+    if (r[3] != b[3]) { ret 1; }
+    ret 0;
+}
+
+test "select_u8x16: byte-lane blend, discriminating high nibbles" {
+    val a: u8x16 = u8x16{0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE, 0xAF};
+    val b: u8x16 = u8x16{0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB6, 0xB7, 0xB8, 0xB9, 0xBA, 0xBB, 0xBC, 0xBD, 0xBE, 0xBF};
+    val mask: u8x16 = u8x16{0xFF, 0, 0xFF, 0, 0xFF, 0, 0xFF, 0, 0xFF, 0, 0xFF, 0, 0xFF, 0, 0xFF, 0};
+    val r: u8x16 = select_u8x16(mask, a, b);
+    if (r[0] != 0xA0) { ret 1; }
+    if (r[1] != 0xB1) { ret 1; }
+    if (r[14] != 0xAE) { ret 1; }
+    if (r[15] != 0xBF) { ret 1; }
+    ret 0;
+}
+
+test "select_u16x8: half-word lane blend" {
+    val a: u16x8 = u16x8{0xAAA0, 0xAAA1, 0xAAA2, 0xAAA3, 0xAAA4, 0xAAA5, 0xAAA6, 0xAAA7};
+    val b: u16x8 = u16x8{0xBBB0, 0xBBB1, 0xBBB2, 0xBBB3, 0xBBB4, 0xBBB5, 0xBBB6, 0xBBB7};
+    val mask: u16x8 = u16x8{0xFFFF, 0, 0xFFFF, 0, 0xFFFF, 0, 0xFFFF, 0};
+    val r: u16x8 = select_u16x8(mask, a, b);
+    if (r[0] != 0xAAA0) { ret 1; }
+    if (r[1] != 0xBBB1) { ret 1; }
+    if (r[6] != 0xAAA6) { ret 1; }
+    if (r[7] != 0xBBB7) { ret 1; }
+    ret 0;
+}
+
+test "select_u64x2: quad-word lane blend" {
+    val a: u64x2 = u64x2{0xAAAAAAAAAAAAAAAA, 0x1111111111111111};
+    val b: u64x2 = u64x2{0xBBBBBBBBBBBBBBBB, 0x2222222222222222};
+    val mask: u64x2 = u64x2{0xFFFFFFFFFFFFFFFF, 0};
+    val r: u64x2 = select_u64x2(mask, a, b);
+    if (r[0] != 0xAAAAAAAAAAAAAAAA) { ret 1; }
+    if (r[1] != 0x2222222222222222) { ret 1; }
+    ret 0;
+}
+
+test "select_i32x4: signed blend preserves negatives" {
+    val a: i32x4 = i32x4{-100, 200, -300, 400};
+    val b: i32x4 = i32x4{5, 6, 7, 8};
+    val mask: u32x4 = u32x4{0xFFFFFFFF, 0, 0xFFFFFFFF, 0};
+    val r: i32x4 = select_i32x4(mask, a, b);
+    if (r[0] != -100) { ret 1; }
+    if (r[1] != 6) { ret 1; }
+    if (r[2] != -300) { ret 1; }
+    if (r[3] != 8) { ret 1; }
+    ret 0;
+}
+
+test "select_i8x16: signed byte blend" {
+    val a: i8x16 = i8x16{-1, -2, -3, -4, -5, -6, -7, -8, -9, -10, -11, -12, -13, -14, -15, -16};
+    val b: i8x16 = i8x16{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    val mask: u8x16 = u8x16{0xFF, 0, 0xFF, 0, 0xFF, 0, 0xFF, 0, 0xFF, 0, 0xFF, 0, 0xFF, 0, 0xFF, 0};
+    val r: i8x16 = select_i8x16(mask, a, b);
+    if (r[0] != -1) { ret 1; }
+    if (r[1] != 2) { ret 1; }
+    if (r[15] != 16) { ret 1; }
+    ret 0;
+}
+
+test "select_i16x8: signed half-word blend" {
+    val a: i16x8 = i16x8{-1000, -2000, -3000, -4000, -5000, -6000, -7000, -8000};
+    val b: i16x8 = i16x8{1, 2, 3, 4, 5, 6, 7, 8};
+    val mask: u16x8 = u16x8{0xFFFF, 0, 0xFFFF, 0, 0xFFFF, 0, 0xFFFF, 0};
+    val r: i16x8 = select_i16x8(mask, a, b);
+    if (r[0] != -1000) { ret 1; }
+    if (r[1] != 2) { ret 1; }
+    if (r[6] != -7000) { ret 1; }
+    ret 0;
+}
+
+test "select_i64x2: signed quad-word blend" {
+    val a: i64x2 = i64x2{-9000000000, 4000000000};
+    val b: i64x2 = i64x2{1, 2};
+    val mask: u64x2 = u64x2{0xFFFFFFFFFFFFFFFF, 0};
+    val r: i64x2 = select_i64x2(mask, a, b);
+    if (r[0] != -9000000000) { ret 1; }
+    if (r[1] != 2) { ret 1; }
+    ret 0;
+}
+
+test "select_f32x4: float blend from comparison mask" {
+    val a: f32x4 = f32x4{1.5, 2.5, 3.5, 4.5};
+    val b: f32x4 = f32x4{9.5, 8.5, 7.5, 6.5};
+    val mask: u32x4 = a < b;                  # all-true -> pick a
+    val r: f32x4 = select_f32x4(mask, a, b);
+    if (r[0] != 1.5) { ret 1; }
+    if (r[1] != 2.5) { ret 1; }
+    if (r[2] != 3.5) { ret 1; }
+    if (r[3] != 4.5) { ret 1; }
+    ret 0;
+}
+
+test "select_f32x4: lane-wise minimum via compare + blend" {
+    val a: f32x4 = f32x4{5.0, 20.0, 5.0, 40.0};
+    val b: f32x4 = f32x4{10.0, 10.0, 10.0, 10.0};
+    val mask: u32x4 = a < b;
+    val r: f32x4 = select_f32x4(mask, a, b);
+    if (r[0] != 5.0) { ret 1; }
+    if (r[1] != 10.0) { ret 1; }
+    if (r[2] != 5.0) { ret 1; }
+    if (r[3] != 10.0) { ret 1; }
+    ret 0;
+}
+
+test "select_f64x2: double blend" {
+    val a: f64x2 = f64x2{1.25, 2.25};
+    val b: f64x2 = f64x2{9.75, 8.75};
+    val mask: u64x2 = u64x2{0xFFFFFFFFFFFFFFFF, 0};
+    val r: f64x2 = select_f64x2(mask, a, b);
+    if (r[0] != 1.25) { ret 1; }
+    if (r[1] != 8.75) { ret 1; }
+    ret 0;
+}

--- a/src/simd/shuffle.mach
+++ b/src/simd/shuffle.mach
@@ -1,0 +1,135 @@
+# lane shuffles and broadcast over the seeded 128-bit vector types
+#
+# a shuffle rearranges or replicates lanes. lane indices are comptime constants,
+# so a shuffle is a fixed pattern of lane reads assembled into a new vector —
+# `splat` replicates one lane, `reverse` mirrors lane order. to broadcast a
+# specific lane of `v`, splat its comptime-indexed read, e.g. `splat_f32x4(v[2])`.
+
+# broadcast a scalar into every f32x4 lane
+# ---
+# x:   value to replicate
+# ret: f32x4 with every lane equal to x
+pub fun splat_f32x4(x: f32) f32x4 {
+    ret f32x4{x, x, x, x};
+}
+
+# broadcast a scalar into every f64x2 lane
+# ---
+# x:   value to replicate
+# ret: f64x2 with every lane equal to x
+pub fun splat_f64x2(x: f64) f64x2 {
+    ret f64x2{x, x};
+}
+
+# broadcast a scalar into every i32x4 lane
+# ---
+# x:   value to replicate
+# ret: i32x4 with every lane equal to x
+pub fun splat_i32x4(x: i32) i32x4 {
+    ret i32x4{x, x, x, x};
+}
+
+# broadcast a scalar into every u32x4 lane
+# ---
+# x:   value to replicate
+# ret: u32x4 with every lane equal to x
+pub fun splat_u32x4(x: u32) u32x4 {
+    ret u32x4{x, x, x, x};
+}
+
+# broadcast a scalar into every u8x16 lane
+# ---
+# x:   value to replicate
+# ret: u8x16 with every lane equal to x
+pub fun splat_u8x16(x: u8) u8x16 {
+    ret u8x16{x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, x};
+}
+
+# reverse the lane order of an f32x4
+# ---
+# v:   input vector
+# ret: {v[3], v[2], v[1], v[0]}
+pub fun reverse_f32x4(v: f32x4) f32x4 {
+    ret f32x4{v[3], v[2], v[1], v[0]};
+}
+
+# reverse the lane order of an i32x4
+# ---
+# v:   input vector
+# ret: {v[3], v[2], v[1], v[0]}
+pub fun reverse_i32x4(v: i32x4) i32x4 {
+    ret i32x4{v[3], v[2], v[1], v[0]};
+}
+
+# reverse the lane order of a u32x4
+# ---
+# v:   input vector
+# ret: {v[3], v[2], v[1], v[0]}
+pub fun reverse_u32x4(v: u32x4) u32x4 {
+    ret u32x4{v[3], v[2], v[1], v[0]};
+}
+
+test "splat_f32x4: every lane equal" {
+    val r: f32x4 = splat_f32x4(2.5);
+    if (r[0] != 2.5) { ret 1; }
+    if (r[1] != 2.5) { ret 1; }
+    if (r[2] != 2.5) { ret 1; }
+    if (r[3] != 2.5) { ret 1; }
+    ret 0;
+}
+
+test "splat_i32x4 / splat_u32x4: distinct value in all lanes" {
+    val a: i32x4 = splat_i32x4(-7);
+    if (a[0] != -7) { ret 1; }
+    if (a[3] != -7) { ret 1; }
+    val b: u32x4 = splat_u32x4(0xDEADBEEF);
+    if (b[0] != 0xDEADBEEF) { ret 1; }
+    if (b[2] != 0xDEADBEEF) { ret 1; }
+    ret 0;
+}
+
+test "splat_u8x16: byte broadcast" {
+    val r: u8x16 = splat_u8x16(0xAB);
+    if (r[0] != 0xAB) { ret 1; }
+    if (r[7] != 0xAB) { ret 1; }
+    if (r[15] != 0xAB) { ret 1; }
+    ret 0;
+}
+
+test "broadcast a specific lane via splat of a comptime read" {
+    val v: f32x4 = f32x4{10.0, 20.0, 30.0, 40.0};
+    val r: f32x4 = splat_f32x4(v[2]);
+    if (r[0] != 30.0) { ret 1; }
+    if (r[3] != 30.0) { ret 1; }
+    ret 0;
+}
+
+test "reverse_f32x4: mirrors lanes" {
+    val v: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0};
+    val r: f32x4 = reverse_f32x4(v);
+    if (r[0] != 4.0) { ret 1; }
+    if (r[1] != 3.0) { ret 1; }
+    if (r[2] != 2.0) { ret 1; }
+    if (r[3] != 1.0) { ret 1; }
+    ret 0;
+}
+
+test "reverse_u32x4: distinct lane bit patterns" {
+    val v: u32x4 = u32x4{0x11111111, 0x22222222, 0x33333333, 0x44444444};
+    val r: u32x4 = reverse_u32x4(v);
+    if (r[0] != 0x44444444) { ret 1; }
+    if (r[1] != 0x33333333) { ret 1; }
+    if (r[2] != 0x22222222) { ret 1; }
+    if (r[3] != 0x11111111) { ret 1; }
+    ret 0;
+}
+
+test "reverse_i32x4: double reverse is identity" {
+    val v: i32x4 = i32x4{-5, 6, -7, 8};
+    val r: i32x4 = reverse_i32x4(reverse_i32x4(v));
+    if (r[0] != -5) { ret 1; }
+    if (r[1] != 6) { ret 1; }
+    if (r[2] != -7) { ret 1; }
+    if (r[3] != 8) { ret 1; }
+    ret 0;
+}


### PR DESCRIPTION
Implements briar-systems/mach#2021.

Tier-3 of the SIMD program: the stdlib library over the compiler-seeded 128-bit vector types — select/blend, the long-tail ops (shuffles, reductions, gather/scatter, saturating arithmetic), and a small vector-math library (Mat4, quaternions), all plain Mach over the compiler's lane-wise operators.

### Approach note (differs from the issue's literal `asm`-body prescription)
The 3.4.4 seed's inline-`asm` encoders (x86_64 and aarch64) are general-purpose-integer only — no SSE/NEON vector instructions, so hand-written per-arch SIMD `asm` bodies are not encodable. Instead the long tail is built as algorithms over the compiler's seeded lane-wise operators + comptime lane indexing + the blend primitive. The compiler already lowers each operator to SSE2/NEON on capable targets and scalarizes on rv64, so one implementation is portable and stays vectorized on capable targets — exactly policy.md's "readable Mach, not intrinsics."

### Landed
- `std.simd.select` — select/blend over all ten vector types, lane-exact vs a scalar reference.
- `std.simd.reduce` — horizontal sum/min/max and a vectorized dot product.
- `std.simd.shuffle` — scalar splat/broadcast and lane reversal.
- `std.simd.saturate` — unsigned saturating add/sub (wrapping op + overflow mask).
- `std.simd.gather` — gather/scatter for f32x4/i32x4/u32x4.
- `std.math.mat4` — 4x4 f32 matrices as [4]f32x4 rows: identity, add/sub/scale, matrix and matrix-vector product, transpose, determinant, inverse.
- `std.math.quat` — quaternions in f32x4: product, conjugate, dot, length, normalize, nlerp.

### Test evidence
- **x86_64: 674 passed / 0 failed** (+54 new; baseline 620). Full suite green.
- **aarch64 (qemu): 674 passed / 0 failed** (on mach v3.5.0, which carries both fixes below). Every failure is a **seed codegen bug**, not a library bug (x86_64 proves the logic): 7 are the float/signed `select` tests, 2 are quat normalize/nlerp. Both trace to a mis-lowered vector bit-reinterpret (`:~`) on aarch64 — see the blocker note. All other new modules are green on both targets.

### aarch64 status: resolved
The library exposed two aarch64 seed codegen bugs, both now fixed and shipped in **mach v3.5.0**:
1. **Vector `:~` mis-lowering** (mach#2082 → PR #2083): a same-bank NEON bitcast selected a GP move, leaving the vector dest unpopulated. Caused the float/signed `select` failures.
2. **128-bit vector not preserved across a call** (mach#2085 → PR #2089): AAPCS64 callee-saves only the low 64 bits of V8–V15, but regalloc treated them as whole-register saves, so a vector held across a call (the quaternion `q` in v8) lost lanes 2–3. Caused the quaternion normalize/nlerp failures.

Verified locally against the 3.5.0 release compiler: **x86_64 674/0 and aarch64 (qemu) 674/0 — full matrix green.**

### Follow-ups (not in this PR)
- Signed saturating add/sub (needs `:~` → aarch64-blocked until the fix).
- True `slerp` (needs float acos/sin — a std transcendentals gap; nlerp ships here).
- A shared `std.math.float` sqrt (currently a private helper in quat; the honest home is a hardware-sqrt `asm`, which the seed's asm can't encode).
- Integer matmul widening accumulators (AMX/SME-class), per the issue.

Draft until the aarch64 `:~` compiler bug is resolved (or the coordinator rules on how to gate the aarch64-blocked tests).


