### PR TITLE
chore(test): bring relro/riscv64 fixture manifests to the V2 schema

### DIFF
--- a/test/relro/mach.toml
+++ b/test/relro/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "relroprobe"
-name = "relroprobe"
-description = "RELRO probe test"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -23,6 +21,7 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = true
 simd = "scalarize"
 
 [artifact.relro_happy]
@@ -30,12 +29,16 @@ kind = "bin"
 entry = "happy.mach"
 out = "bin/relro_happy"
 targets = ["*"]
+link = []
+need = []
 
 [artifact.relro_fault]
 kind = "bin"
 entry = "fault.mach"
 out = "bin/relro_fault"
 targets = ["*"]
+link = []
+need = []
 
 [dep.std]
 path = "dep/std"

--- a/test/riscv64/mach.toml
+++ b/test/riscv64/mach.toml
@@ -1,7 +1,5 @@
 [project]
 id = "rvprobe"
-name = "rvprobe"
-description = "RISCV64 probe test"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
@@ -13,6 +11,7 @@ abi = "lp64"
 
 [profile.debug]
 opt = 0
+debug = true
 simd = "scalarize"
 
 [artifact.rvprobe]
@@ -20,6 +19,8 @@ kind = "bin"
 entry = "main.mach"
 out = "bin/rvprobe"
 targets = ["*"]
+link = []
+need = []
 
 [dep.std]
 path = "dep/std"


### PR DESCRIPTION
Closes #374.

The V2 manifest sweep updated the root manifest but missed `test/relro/mach.toml` and `test/riscv64/mach.toml`. Under the current released `mach` they fail to parse (dead `[project]` `name`/`description`) or validate (missing per-artifact `link`/`need` and per-profile `debug`), which reddens the `build` (RELRO step) and `cross-riscv64` CI jobs on **every** PR to dev — surfaced while validating #2021.

Changes, matching the swept root manifest schema:
- drop `name` / `description` from `[project]`
- add `debug = true` to `[profile.debug]`
- add `link = []` / `need = []` to each artifact

Verified locally: `bash test/relro/verify.sh` and `bash test/riscv64/verify.sh` both pass (exit 0).