### PR TITLE
chore: sweep main into dev (hotfix/2104 bsdthread entry ABI)

### DIFF
--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -995,8 +995,20 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
 
 var thread_registered: i64 = 0;
 
-# called by the kernel for each new thread created via bsdthread_create
-fun thread_start(self: usize, kport: usize, func: usize, arg: usize, stacksize: usize, pflags: usize) {
+# the bsdthread body: run the user function, flag completion, wake a joiner, and
+# terminate the thread (releasing its stack). the kernel never reaches this
+# directly - `thread_start` below is the registered entry and tails in through a
+# `call`/`b`, so the platform function-entry ABI (notably x86_64 stack alignment)
+# holds before any real work runs.
+# ---
+# self:      kernel thread self pointer (unused)
+# kport:     mach thread port, passed to bsdthread_terminate
+# func:      user function to run on the thread
+# arg:       pointer to the [done, stack_base, stack_size] context at the stack base
+# stacksize: kernel stack size (unused; the real size travels in the context)
+# pflags:    kernel pthread flags (unused)
+#[symbol("_std_darwin_thread_start_impl")]
+fun thread_start_impl(self: usize, kport: usize, func: usize, arg: usize, stacksize: usize, pflags: usize) {
     val ctx: *usize = arg::*usize;
     val done_addr: usize = ctx[0];
     val stack_base: usize = ctx[1];
@@ -1009,6 +1021,34 @@ fun thread_start(self: usize, kport: usize, func: usize, arg: usize, stacksize: 
     syscall4(SYS_BSDTHREAD_TERMINATE, stack_base, stack_size, kport, 0);
 }
 
+# the bsdthread_create kernel entry point (registered via bsdthread_register)
+#
+# the kernel JUMPS here with the six thread arguments in registers and the thread's
+# initial stack pointer set to the stack top passed to bsdthread_create - it does
+# not `call`, so on x86_64 the stack lands 16-aligned rather than the (rsp+8)%16==0
+# the SysV ABI guarantees at a function entry (the return address a `call` would
+# have pushed). a compiled body would then run every stack access, and the user
+# function it calls, on a stack skewed by 8, so the first 16-byte-aligned SSE spill
+# faults. realign the stack and enter the compiled body through a `call`, which
+# restores the entry contract - the same fixup `_start` applies. aarch64 keeps SP
+# 16-aligned across a branch (a return address never lands on the stack), so it
+# tails straight into the body. naked: the inline asm owns the stack, no prologue.
+#[symbol("_std_darwin_thread_start")]
+fun thread_start() {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            and rsp, -16
+            call _std_darwin_thread_start_impl
+            hlt
+        }
+    }
+    $or ($mach.build.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            b _std_darwin_thread_start_impl
+        }
+    }
+}
+
 # workqueue thread callback (unused, required by bsdthread_register)
 fun thread_wq_start(self: usize, kport: usize, saddr: usize, arg: usize, cnt: usize, flags: usize) {
     syscall4(SYS_BSDTHREAD_TERMINATE, 0, 0, 0, 0);
@@ -1018,7 +1058,7 @@ fun ensure_thread_registered() {
     if (atomic.load(?thread_registered) != 0) { ret; }
     var expected: i64 = 0;
     if (!atomic.cas(?thread_registered, ?expected, 1)) { ret; }
-    val start: fun(usize, usize, usize, usize, usize, usize) = thread_start;
+    val start: fun() = thread_start;
     val wq: fun(usize, usize, usize, usize, usize, usize) = thread_wq_start;
     syscall6(SYS_BSDTHREAD_REGISTER, start::usize, wq::usize, 64, 0, 0, 0);
 }


### PR DESCRIPTION
Hotfix sweep per the branch model: PR #377 (x86_64 bsdthread stack-entry ABI trampoline) merged to main; this carries it into dev so the next release train includes it. Refs briar-systems/mach#2104.