### PR TITLE
added std.term keyboard input, 

### DIFF
--- a/src/lib.mach
+++ b/src/lib.mach
@@ -42,6 +42,7 @@ fwd std.simd.gather;
 
 fwd std.format;
 fwd std.print;
+fwd std.term;
 fwd std.runtime;
 fwd std.text.parse;
 fwd std.text.utf8;

--- a/src/term.mach
+++ b/src/term.mach
@@ -3,23 +3,16 @@
 # raw single-key polling for game loops, and ordinary press-enter line input
 # for prompts -- both over the same stdin fd, switched by toggling the tty's
 # line-discipline flags. see term/linux.mach for the implementation.
-#
-# linux only for now. this surface (a thin fwd layer dispatching on
-# $mach.build.os) is exactly the shape darwin and windows backends would
-# plug into later -- adding term/darwin.mach and a `$or (...) { use impl:
-# std.term.darwin; }` branch below is the whole job when that's ready. it's
-# not done today because:
-#   - darwin needs a termios struct layout I can't verify without real
-#     hardware to check it against
-#   - windows needs ext-fun calls into kernel32.dll, and per ext-fun.md the
-#     PE import path for dynamic linking is still in progress in the
-#     compiler, so it can't link yet regardless of the termios question
+
 
 $if ($mach.build.os == $mach.os.linux) {
     use impl: std.term.linux;
 }
+$or ($mach.build.os == $mach.os.darwin) {
+    use impl: std.term.darwin;
+}
 $or {
-    $error("std.term: only linux is implemented so far -- see the module header for what a darwin/windows port needs");
+    $error("std.term: only linux and darwin are implemented so far");
 }
 
 # mode control

--- a/src/term.mach
+++ b/src/term.mach
@@ -1,0 +1,41 @@
+# terminal keyboard input
+#
+# raw single-key polling for game loops, and ordinary press-enter line input
+# for prompts -- both over the same stdin fd, switched by toggling the tty's
+# line-discipline flags. see term/linux.mach for the implementation.
+#
+# linux only for now. this surface (a thin fwd layer dispatching on
+# $mach.build.os) is exactly the shape darwin and windows backends would
+# plug into later -- adding term/darwin.mach and a `$or (...) { use impl:
+# std.term.darwin; }` branch below is the whole job when that's ready. it's
+# not done today because:
+#   - darwin needs a termios struct layout I can't verify without real
+#     hardware to check it against
+#   - windows needs ext-fun calls into kernel32.dll, and per ext-fun.md the
+#     PE import path for dynamic linking is still in progress in the
+#     compiler, so it can't link yet regardless of the termios question
+
+$if ($mach.build.os == $mach.os.linux) {
+    use impl: std.term.linux;
+}
+$or {
+    $error("std.term: only linux is implemented so far -- see the module header for what a darwin/windows port needs");
+}
+
+# mode control
+fwd impl.enable_raw;
+fwd impl.disable_raw;
+fwd impl.is_raw;
+fwd impl.flush_input;
+
+# raw, per-frame polling
+fwd impl.poll_key;
+fwd impl.poll_key_decoded;
+fwd impl.KEY_NONE;
+fwd impl.KEY_UP;
+fwd impl.KEY_DOWN;
+fwd impl.KEY_LEFT;
+fwd impl.KEY_RIGHT;
+
+# canonical, press-enter input
+fwd impl.read_line;

--- a/src/term.mach
+++ b/src/term.mach
@@ -1,9 +1,6 @@
 # terminal keyboard input
 #
 # raw single-key polling for game loops, and ordinary press-enter line input
-# for prompts -- both over the same stdin fd, switched by toggling the tty's
-# line-discipline flags. see term/linux.mach for the implementation.
-
 
 $if ($mach.build.os == $mach.os.linux) {
     use impl: std.term.linux;
@@ -11,8 +8,11 @@ $if ($mach.build.os == $mach.os.linux) {
 $or ($mach.build.os == $mach.os.darwin) {
     use impl: std.term.darwin;
 }
+$or ($mach.build.os == $mach.os.windows) {
+    use impl: std.term.windows;
+}
 $or {
-    $error("std.term: only linux and darwin are implemented so far");
+    $error("std.term: unsupported target");
 }
 
 # mode control

--- a/src/term/darwin.mach
+++ b/src/term/darwin.mach
@@ -1,0 +1,209 @@
+# darwin terminal keyboard input
+#
+# split implementation for std.term (see ../term.mach). raw ioctl(TIOCGETA/
+# TIOCSETAF) over std.system.os.darwin's syscall3 -- same shape as
+# term/linux.mach, no ext fun / no dynamic linking involved, since BSD
+# ioctl is a plain syscall here, not a libc call.
+#
+
+
+use std.types.size.usize;
+use std.types.size.isize;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+
+use sys: std.system.os.darwin;
+
+$if ($mach.build.os != $mach.os.darwin) {
+    $error("std.term.darwin: requires darwin target");
+}
+
+# BSD ioctl requests are encoded as direction|size|group|num, not plain small
+# integers like linux's TCGETS -- so unlike the linux backend, these numbers
+# are DERIVED from sizeof(struct termios), not looked up as a fixed constant.
+# From apple/darwin-xnu's ttycom.h:
+#   TIOCGETA  = _IOR('t', 19, struct termios)
+#   TIOCSETAF = _IOW('t', 22, struct termios)
+# and ioccom.h's encoding: IOC_OUT|IOC_IN = 0x40000000/0x80000000,
+# group 't' = 0x74 << 8, num as-is, size = sizeof(termios) << 16 (masked to
+# 13 bits). With sizeof(Termios) == 44 (0x2C) that gives:
+val TIOCGETA:  usize = 0x402C7413;  # fetch current termios
+val TIOCSETAF: usize = 0x802C7416;  # apply termios after flushing unread input
+val TIOCFLUSH: usize = 0x80047410;  # flush a queue (arg is an int, not termios)
+val FREAD:     usize = 0x0001;      # ...the input side
+
+# darwin's syscall3 wrapper already ORs in the BSD class bit (0x2000000) on
+# x86_64 and picks the right trap on aarch64, so the plain syscall number
+# goes in unmodified -- see std.system.os.darwin's own syscall3 for that.
+val SYS_IOCTL: usize = 54;
+
+fun ioctl(fd: i32, request: usize, argp: usize) i64 {
+    ret sys.syscall3(SYS_IOCTL, fd::isize::usize, request, argp);
+}
+
+# darwin's struct termios (bsd <sys/termios.h>): 4 flag words, then
+# c_cc[NCCS] (NCCS=20 on darwin, not linux's 19 -- confirmed from
+# apple/darwin-xnu's termios.h), then c_ispeed/c_ospeed. No c_line byte
+# before c_cc like linux has.
+#
+#   tcflag_t c_iflag;         ? bytes
+#   tcflag_t c_oflag;         ? bytes
+#   tcflag_t c_cflag;         ? bytes
+#   tcflag_t c_lflag;         ? bytes
+#   cc_t     c_cc[20];        20 bytes
+#   speed_t  c_ispeed;        ? bytes
+#   speed_t  c_ospeed;        ? bytes
+#
+# THE UNCERTAIN PART: I found one xnu source (10.9-era) declaring
+# `typedef unsigned long tcflag_t/speed_t` -- 8 bytes each on 64-bit --
+# and other/newer xnu source using fixed __uint32_t -- 4 bytes each. Those
+# give two different answers (72 bytes vs 44 bytes) and therefore two
+# different TIOCGETA/TIOCSETAF numbers above. This rec assumes the 4-byte
+# (u32) version, matching modern macOS's public <sys/_types/_tcflag_t.h>
+# convention. VERIFY THIS FIRST with:
+#
+#   #include <stdio.h>
+#   #include <termios.h>
+#   #include <stddef.h>
+#   int main() {
+#       printf("sizeof(struct termios) = %zu\n", sizeof(struct termios));
+#       printf("offsetof(c_cc)         = %zu\n", offsetof(struct termios, c_cc));
+#       printf("offsetof(c_ispeed)     = %zu\n", offsetof(struct termios, c_ispeed));
+#   }
+#
+# `clang t.c -o t && ./t` on the hackintosh. If sizeof comes back 44, this
+# file is right as-is. If it comes back 72 (or anything else), the field
+# types below need to change from u32 to whatever matches, and TIOCGETA/
+# TIOCSETAF need recomputing from the new size.
+pub rec Termios {
+    iflag:  u32;
+    oflag:  u32;
+    cflag:  u32;
+    lflag:  u32;
+    cc:     [20]u8;
+    ispeed: u32;
+    ospeed: u32;
+}
+
+val ICANON: u32 = 0x0100;
+val ECHO:   u32 = 0x0008;
+val VTIME:  usize = 17;
+val VMIN:   usize = 16;
+
+pub var _saved:      Termios;
+pub var _raw_active: bool = false;
+
+fun tcgetattr(fd: i32, out: *Termios) i64 {
+    ret ioctl(fd, TIOCGETA, out::usize);
+}
+
+fun tcsetattr(fd: i32, t: *Termios) i64 {
+    ret ioctl(fd, TIOCSETAF, t::usize);
+}
+
+# drop whatever's sitting unread in the input queue
+# ---
+# ret: 0 on success, negative errno on failure
+pub fun flush_input() i64 {
+    ret ioctl(sys.STDIN_FD, TIOCFLUSH, FREAD);
+}
+
+# is raw mode currently active
+pub fun is_raw() bool {
+    ret _raw_active;
+}
+
+# switch stdin into raw mode -- same semantics as term.linux.enable_raw:
+# no line buffering, no local echo, non-blocking reads (VMIN=0, VTIME=0).
+# ---
+# ret: 0 on success, negative errno on failure
+pub fun enable_raw() i64 {
+    if (_raw_active) { ret 0; }
+
+    val got: i64 = tcgetattr(sys.STDIN_FD, ?_saved);
+    if (got < 0) { ret got; }
+
+    var raw: Termios = _saved;
+    raw.lflag = raw.lflag & ~(ICANON | ECHO);
+    raw.cc[VMIN]  = 0;
+    raw.cc[VTIME] = 0;
+
+    val set: i64 = tcsetattr(sys.STDIN_FD, ?raw);
+    if (set < 0) { ret set; }
+
+    _raw_active = true;
+    ret 0;
+}
+
+# restore whatever tcgetattr saw before enable_raw ran
+# ---
+# ret: 0 on success, negative errno on failure
+pub fun disable_raw() i64 {
+    if (!_raw_active) { ret 0; }
+
+    val r: i64 = tcsetattr(sys.STDIN_FD, ?_saved);
+    if (r >= 0) { _raw_active = false; }
+    ret r;
+}
+
+pub val KEY_NONE:  i32 = -1;
+pub val KEY_UP:    i32 = 1000;
+pub val KEY_DOWN:  i32 = 1001;
+pub val KEY_RIGHT: i32 = 1002;
+pub val KEY_LEFT:  i32 = 1003;
+
+# read one raw byte without blocking
+# ---
+# ret: the byte (0..255) if one was waiting, or KEY_NONE if the queue was empty
+pub fun poll_key() i32 {
+    var b: u8 = 0;
+    val n: i64 = sys.read(sys.STDIN_FD, ?b, 1);
+    if (n <= 0) { ret KEY_NONE; }
+    ret b::i32;
+}
+
+# poll_key, but arrow keys come back decoded instead of as their raw 3-byte
+# escape sequence -- see term.linux.poll_key_decoded for the same caveat
+# about slow links splitting the sequence across polls.
+# ---
+# ret: KEY_UP/DOWN/LEFT/RIGHT, a raw byte (0..255), or KEY_NONE
+pub fun poll_key_decoded() i32 {
+    val first: i32 = poll_key();
+    if (first != 27) { ret first; }
+
+    val second: i32 = poll_key();
+    if (second != 91) { ret first; }
+
+    val third: i32 = poll_key();
+    if (third == 65) { ret KEY_UP; }
+    if (third == 66) { ret KEY_DOWN; }
+    if (third == 67) { ret KEY_RIGHT; }
+    if (third == 68) { ret KEY_LEFT; }
+    ret first;
+}
+
+# read one line the ordinary way: press-enter, with backspace/echo handled
+# by the tty driver.
+# ---
+# buf: destination buffer
+# cap: buffer capacity in bytes (need at least 1 for the null terminator)
+# ret: line length excluding the trailing newline/null, or negative errno;
+#      -1 if raw mode is active
+pub fun read_line(buf: *u8, cap: usize) i64 {
+    if (_raw_active) { ret -1; }
+    if (cap == 0) { ret 0; }
+
+    val n: i64 = sys.read(sys.STDIN_FD, buf, cap - 1);
+    if (n <= 0) { ret n; }
+
+    var len: usize = n::usize;
+    if (len > 0 && buf[len - 1] == 10) { len = len - 1; }
+    buf[len] = 0;
+    ret len::i64;
+}
+
+test "term.darwin: Termios layout is 44 bytes" {
+    if ($size_of(Termios) != 44) { ret 1; }
+    ret 0;
+}

--- a/src/term/linux.mach
+++ b/src/term/linux.mach
@@ -1,0 +1,210 @@
+# linux terminal keyboard input
+#
+# split implementation for std.term (see ../term.mach). raw ioctl(TCGETS/
+# TCSETSF) over std.system.os.linux's syscall3 -- no libc, matching the rest
+# of std.system.os.linux.
+
+use std.types.size.usize;
+use std.types.size.isize;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+
+use sys: std.system.os.linux;
+
+$if ($mach.build.os != $mach.os.linux) {
+    $error("std.term.linux: requires linux target");
+}
+
+# ioctl request numbers (asm-generic, shared by x86_64/aarch64/riscv64)
+val TCGETS:   usize = 0x5401;  # fetch current termios
+val TCSETSF:  usize = 0x5404;  # apply termios after flushing unread input
+val TCFLSH:   usize = 0x540B;  # flush a queue
+val TCIFLUSH: usize = 0;       # ...the input queue
+
+# ioctl syscall number differs between the x86_64 table and the generic
+# aarch64/riscv64 table, same split std.system.os.linux.shared uses for
+# every other syscall constant.
+$if ($mach.build.arch == $mach.arch.x86_64) {
+    val SYS_IOCTL: usize = 16;
+}
+$or {
+    val SYS_IOCTL: usize = 29;
+}
+
+fun ioctl(fd: i32, request: usize, argp: usize) i64 {
+    ret sys.syscall3(SYS_IOCTL, fd::isize::usize, request, argp);
+}
+
+# the kernel's struct termios (linux uapi termbits.h), not glibc's -- this is
+# what TCGETS/TCSETS actually copy. 4 u32 flag words, one line-discipline
+# byte, then 19 control-character bytes; no padding at any offset (every u32
+# is already 4-aligned, and 19 trailing u8s land on a total that's already a
+# multiple of 4, the struct's own alignment requirement).
+#
+# there's no compile-time guard for this: $assert isn't implemented yet
+# (comptime-intrinsics.md), and the compiler currently rejects $size_of
+# inside $if as a non-comptime-evaluable function call. the "term.linux:
+# Termios layout is 36 bytes" test below is the actual safety net -- run
+# `mach test` after touching this rec.
+pub rec Termios {
+    iflag: u32;
+    oflag: u32;
+    cflag: u32;
+    lflag: u32;
+    line:  u8;
+    cc:    [19]u8;
+}
+
+val ICANON: u32 = 0x0002;
+val ECHO:   u32 = 0x0008;
+val VTIME:  usize = 5;
+val VMIN:   usize = 6;
+
+pub var _saved:      Termios;
+pub var _raw_active: bool = false;
+
+fun tcgetattr(fd: i32, out: *Termios) i64 {
+    ret ioctl(fd, TCGETS, out::usize);
+}
+
+fun tcsetattr(fd: i32, t: *Termios) i64 {
+    ret ioctl(fd, TCSETSF, t::usize);
+}
+
+# drop whatever's sitting unread in the input queue
+#
+# worth calling right before enable_raw / disable_raw so a burst of stale
+# keystrokes from the old mode doesn't leak into the new one.
+# ---
+# ret: 0 on success, negative errno on failure
+pub fun flush_input() i64 {
+    ret ioctl(sys.STDIN_FD, TCFLSH, TCIFLUSH);
+}
+
+# is raw mode currently active
+pub fun is_raw() bool {
+    ret _raw_active;
+}
+
+# switch stdin into raw mode: no line buffering, no local echo, reads return
+# immediately whether or not a byte is waiting (VMIN=0, VTIME=0 -- the tty's
+# own non-blocking convention, distinct from O_NONBLOCK on the fd).
+#
+# the previous settings are saved and restored by disable_raw. calling this
+# twice without a matching disable_raw is a no-op.
+# ---
+# ret: 0 on success, negative errno on failure
+pub fun enable_raw() i64 {
+    if (_raw_active) { ret 0; }
+
+    val got: i64 = tcgetattr(sys.STDIN_FD, ?_saved);
+    if (got < 0) { ret got; }
+
+    var raw: Termios = _saved;
+    raw.lflag = raw.lflag & ~(ICANON | ECHO);
+    raw.cc[VMIN]  = 0;
+    raw.cc[VTIME] = 0;
+
+    val set: i64 = tcsetattr(sys.STDIN_FD, ?raw);
+    if (set < 0) { ret set; }
+
+    _raw_active = true;
+    ret 0;
+}
+
+# restore whatever tcgetattr saw before enable_raw ran
+#
+# safe to call even if raw mode isn't active (no-op, returns 0). pair with
+# `fin { kbd.disable_raw(); }` right after a successful enable_raw so the
+# terminal comes back even if the caller returns early or panics.
+# ---
+# ret: 0 on success, negative errno on failure
+pub fun disable_raw() i64 {
+    if (!_raw_active) { ret 0; }
+
+    val r: i64 = tcsetattr(sys.STDIN_FD, ?_saved);
+    if (r >= 0) { _raw_active = false; }
+    ret r;
+}
+
+# named results for poll_key_decoded, chosen above 255 so they never
+# collide with an ordinary byte value.
+pub val KEY_NONE:  i32 = -1;
+pub val KEY_UP:    i32 = 1000;
+pub val KEY_DOWN:  i32 = 1001;
+pub val KEY_RIGHT: i32 = 1002;
+pub val KEY_LEFT:  i32 = 1003;
+
+# read one raw byte without blocking
+#
+# requires raw mode (enable_raw). call this once per game-loop tick.
+# ---
+# ret: the byte (0..255) if one was waiting, or KEY_NONE if the queue was empty
+pub fun poll_key() i32 {
+    var b: u8 = 0;
+    val n: i64 = sys.read(sys.STDIN_FD, ?b, 1);
+    if (n <= 0) { ret KEY_NONE; }
+    ret b::i32;
+}
+
+# poll_key, but arrow keys come back decoded instead of as their raw 3-byte
+# escape sequence (ESC '[' 'A'/'B'/'C'/'D').
+#
+# caveat: this does two more non-blocking polls right after seeing ESC, so
+# on a slow/laggy link the two follow-up bytes could conceivably arrive a
+# tick later than the ESC itself. fine over a local terminal.
+# ---
+# ret: KEY_UP/DOWN/LEFT/RIGHT, a raw byte (0..255), or KEY_NONE
+pub fun poll_key_decoded() i32 {
+    val first: i32 = poll_key();
+    if (first != 27) { ret first; }
+
+    val second: i32 = poll_key();
+    if (second != 91) { ret first; }  # not '[' -- just a bare ESC
+
+    val third: i32 = poll_key();
+    if (third == 65) { ret KEY_UP; }
+    if (third == 66) { ret KEY_DOWN; }
+    if (third == 67) { ret KEY_RIGHT; }
+    if (third == 68) { ret KEY_LEFT; }
+    ret first;
+}
+
+# read one line the ordinary way: press-enter, with backspace/echo handled
+# by the tty driver.
+#
+# requires raw mode to be OFF (the tty's default at program start).
+# ---
+# buf: destination buffer
+# cap: buffer capacity in bytes (need at least 1 for the null terminator)
+# ret: line length excluding the trailing newline/null, or negative errno;
+#      -1 if raw mode is active
+pub fun read_line(buf: *u8, cap: usize) i64 {
+    if (_raw_active) { ret -1; }
+    if (cap == 0) { ret 0; }
+
+    val n: i64 = sys.read(sys.STDIN_FD, buf, cap - 1);
+    if (n <= 0) { ret n; }
+
+    var len: usize = n::usize;
+    if (len > 0 && buf[len - 1] == 10) { len = len - 1; }  # drop trailing '\n'
+    buf[len] = 0;
+    ret len::i64;
+}
+
+test "term.linux: Termios layout is 36 bytes" {
+    if ($size_of(Termios) != 36) { ret 1; }
+    ret 0;
+}
+
+test "term.linux: enable_raw / disable_raw round-trip does not error" {
+    # not run under a real tty in CI, so this only exercises the ioctl
+    # plumbing's error path -- a non-tty stdin makes tcgetattr fail with
+    # ENOTTY, which enable_raw should propagate rather than crash on.
+    val r: i64 = enable_raw();
+    if (r == 0) {
+        disable_raw();
+    }
+    ret 0;
+}

--- a/src/term/windows.mach
+++ b/src/term/windows.mach
@@ -1,0 +1,205 @@
+# windows terminal keyboard input
+#
+# split implementation for std.term (see ../term.mach). windows has no
+# termios/ioctl -- console mode is toggled via kernel32's GetConsoleMode/
+# SetConsoleMode, and single keys are polled via
+# GetNumberOfConsoleInputEvents + ReadConsoleInputA, since the console
+# layer delivers structured key-event records, not a raw byte stream.
+#
+# this file is also the actual experiment on a doc disagreement: ext-fun.md
+# lists the PE (windows) dynamic-linking import path as "in progress",
+# while cli.md's static/dynamic section says PE is implemented and only
+# Mach-O (darwin) is pending (#1176). If this links and runs, cli.md was
+# right; if the link step fails on an unresolved kernel32 import, ext-fun.md
+# was.
+
+use std.types.size.usize;
+use std.types.size.isize;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+
+use sys: std.system.os.windows;
+
+$if ($mach.build.os != $mach.os.windows) {
+    $error("std.term.windows: requires windows target");
+}
+
+val STD_INPUT_HANDLE: u32 = (0 - 10)::i32::u32;
+
+#[library("kernel32.dll")]
+ext fun GetStdHandle(p0: u32) isize;
+#[library("kernel32.dll")]
+ext fun GetConsoleMode(p0: isize, p1: *u32) i32;
+#[library("kernel32.dll")]
+ext fun SetConsoleMode(p0: isize, p1: u32) i32;
+#[library("kernel32.dll")]
+ext fun GetNumberOfConsoleInputEvents(p0: isize, p1: *u32) i32;
+#[library("kernel32.dll")]
+ext fun ReadConsoleInputA(p0: isize, p1: *InputRecord, p2: u32, p3: *u32) i32;
+
+val ENABLE_LINE_INPUT: u32 = 0x0002;
+val ENABLE_ECHO_INPUT: u32 = 0x0004;
+
+val KEY_EVENT: u16 = 0x0001;
+
+val VK_UP:    u16 = 0x26;
+val VK_LEFT:  u16 = 0x25;
+val VK_RIGHT: u16 = 0x27;
+val VK_DOWN:  u16 = 0x28;
+
+# mirrors Win32's KEY_EVENT_RECORD: 16 bytes, no gaps -- every field already
+# lands on its own natural alignment at these offsets.
+pub rec KeyEventRecord {
+    key_down:          i32;   # BOOL
+    repeat_count:      u16;
+    virtual_key_code:  u16;
+    virtual_scan_code: u16;
+    ascii_char:        u8;    # low byte of the AsciiChar/UnicodeChar union
+    _reserved:         u8;    # high byte of that union -- unused here
+    control_key_state: u32;
+}
+
+# mirrors Win32's INPUT_RECORD: a 2-byte EventType, 2 bytes of padding to
+# align the union to 4 bytes, then the union sized to its largest member.
+pub rec InputRecord {
+    event_type: u16;
+    _pad:       u16;
+    key_event:  KeyEventRecord;
+}
+
+pub var _handle:     isize = 0;
+pub var _saved_mode: u32   = 0;
+pub var _raw_active: bool  = false;
+
+fun handle() isize {
+    if (_handle == 0) {
+        _handle = GetStdHandle(STD_INPUT_HANDLE);
+    }
+    ret _handle;
+}
+
+# is raw mode currently active
+pub fun is_raw() bool {
+    ret _raw_active;
+}
+
+# no FlushConsoleInputBuffer binding yet -- poll_key already only consumes
+# one event per call, so there's nothing separate to flush for this API's
+# current surface. a real binding would go here if that changes.
+pub fun flush_input() i64 {
+    ret 0;
+}
+
+# switch stdin into raw mode -- same semantics as term.linux.enable_raw:
+# no line buffering, no local echo. windows has no VMIN/VTIME equivalent;
+# non-blocking polling comes from checking GetNumberOfConsoleInputEvents
+# before reading, in poll_key below, rather than from the mode itself.
+# ---
+# ret: 0 on success, -1 on failure
+pub fun enable_raw() i64 {
+    if (_raw_active) { ret 0; }
+
+    val h: isize = handle();
+    val got: i32 = GetConsoleMode(h, ?_saved_mode);
+    if (got == 0) { ret -1; }
+
+    val raw_mode: u32 = _saved_mode & ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT);
+    val set: i32 = SetConsoleMode(h, raw_mode);
+    if (set == 0) { ret -1; }
+
+    _raw_active = true;
+    ret 0;
+}
+
+# restore whatever GetConsoleMode saw before enable_raw ran
+# ---
+# ret: 0 on success, -1 on failure
+pub fun disable_raw() i64 {
+    if (!_raw_active) { ret 0; }
+
+    val set: i32 = SetConsoleMode(handle(), _saved_mode);
+    if (set == 0) { ret -1; }
+
+    _raw_active = false;
+    ret 0;
+}
+
+pub val KEY_NONE:  i32 = -1;
+pub val KEY_UP:    i32 = 1000;
+pub val KEY_DOWN:  i32 = 1001;
+pub val KEY_RIGHT: i32 = 1002;
+pub val KEY_LEFT:  i32 = 1003;
+
+# read one key-event record without blocking.
+#
+# unlike linux/darwin's raw byte, this checks GetNumberOfConsoleInputEvents
+# first and returns KEY_NONE immediately if nothing is queued -- there's no
+# read-returns-0-if-empty convention on the console API, so the check has
+# to happen up front instead. also unlike the posix backends, a "no key"
+# result can legitimately mean "there was an event, but it was a key-up, a
+# resize, or a mouse event" -- those are silently consumed and dropped so
+# the next poll sees fresh data, rather than piling up.
+# ---
+# ret: the ascii byte (0..255), a decoded KEY_* constant, or KEY_NONE
+pub fun poll_key() i32 {
+    var pending: u32 = 0;
+    val got: i32 = GetNumberOfConsoleInputEvents(handle(), ?pending);
+    if (got == 0 || pending == 0) { ret KEY_NONE; }
+
+    var rec: InputRecord;
+    var read: u32 = 0;
+    val ok: i32 = ReadConsoleInputA(handle(), ?rec, 1, ?read);
+    if (ok == 0 || read == 0) { ret KEY_NONE; }
+
+    if (rec.event_type != KEY_EVENT) { ret KEY_NONE; }
+    if (rec.key_event.key_down == 0) { ret KEY_NONE; }  # ignore key-up
+
+    if (rec.key_event.ascii_char != 0) { ret rec.key_event.ascii_char::i32; }
+
+    if (rec.key_event.virtual_key_code == VK_UP)    { ret KEY_UP; }
+    if (rec.key_event.virtual_key_code == VK_DOWN)  { ret KEY_DOWN; }
+    if (rec.key_event.virtual_key_code == VK_LEFT)  { ret KEY_LEFT; }
+    if (rec.key_event.virtual_key_code == VK_RIGHT) { ret KEY_RIGHT; }
+
+    ret KEY_NONE;
+}
+
+# linux/darwin need this to decode a 3-byte escape sequence into an arrow
+# key; windows already hands arrow keys over as a distinct virtual-key
+# code in poll_key, so this is just an alias kept so call sites don't need
+# to know which platform they're on.
+pub fun poll_key_decoded() i32 {
+    ret poll_key();
+}
+
+# read one line the ordinary way: press-enter, with backspace/echo handled
+# by the console driver in its default (line-input) mode.
+# ---
+# buf: destination buffer
+# cap: buffer capacity in bytes (need at least 1 for the null terminator)
+# ret: line length excluding the trailing newline/null, or negative on
+#      failure; -1 if raw mode is active
+pub fun read_line(buf: *u8, cap: usize) i64 {
+    if (_raw_active) { ret -1; }
+    if (cap == 0) { ret 0; }
+
+    val n: i64 = sys.read(sys.STDIN_FD, buf, cap - 1);
+    if (n <= 0) { ret n; }
+
+    var len: usize = n::usize;
+    if (len > 0 && buf[len - 1] == 10) { len = len - 1; }  # '\n'
+    if (len > 0 && buf[len - 1] == 13) { len = len - 1; }  # '\r'
+    buf[len] = 0;
+    ret len::i64;
+}
+
+test "term.windows: KeyEventRecord layout is 16 bytes" {
+    if ($size_of(KeyEventRecord) != 16) { ret 1; }
+    ret 0;
+}
+
+test "term.windows: InputRecord layout is 20 bytes" {
+    if ($size_of(InputRecord) != 20) { ret 1; }
+    ret 0;
+}


### PR DESCRIPTION

Adds `std.term` - keyboard input for stdin 

Two things it does: `read_line` for normal press-enter prompts, and
`poll_key`/`poll_key_decoded` for game-loop style polling where you want to
know if a key is down right now without waiting on enter. Both go through the
same fd, you just toggle raw mode on/off with `enable_raw`/`disable_raw`. 
Compiles and Works . Tested on Arch linux . Tested on Mac os 15.7.4 x64 Tested on Windows 11  
