### PR TITLE
feat(derive): generic eq/hash/fmt helpers over $fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- derive: generic, macro-free derive helpers over `$fields` — `eq[T]` (structural equality), `hash[T]` (FNV-1a fold, `eq`-consistent), and `fmt[T]` (debug `{name=value, ...}`), each walking a record's fields at comptime via `$each`/`v.[f]`. Eligible fields are scalar numerics (integers of any width and floats, plus defs like `bool`/`char`); any other field type is rejected at comptime with a clear `$error` (PR #388, mach-std#285).
 - terminal: raw single-key keyboard input for game loops — `enable_raw`/`disable_raw`/`is_raw`/`flush_input` mode control and `poll_key`/`poll_key_decoded` per-frame polling over a tagged `Key` type, with linux, darwin, and windows backends (PR #379).
 - input: canonical stdin line input — `read_line`/`read_line_from` strip a trailing newline, null-terminate, and error on overflow rather than truncating silently (PR #379).
 - crypto: SHA-3 family (FIPS 202) — Keccak-f[1600] permutation and byte-oriented sponge (`crypto/hash/keccak`), plus SHA3-256, SHA3-512, and the SHAKE128/SHAKE256 XOFs, each pinned to NIST known-answer vectors (PR #385).

--- a/src/derive.mach
+++ b/src/derive.mach
@@ -1,0 +1,277 @@
+# generic derive helpers over a record's fields
+#
+# these are macro-free, generic functions that walk a record type's fields at
+# comptime with `$each f in $fields(T)` and act on each field through the
+# projection `v.[f]`. one definition serves every record shape: the `$each`
+# unroll is deferred to instantiation, so `T` is a concrete record by the time a
+# field descriptor's type gates fold.
+#
+# a field is eligible when its type is a scalar numeric -- a signed or unsigned
+# integer of any width, or a float. a `def` over such a scalar counts (its
+# underlying type is what the gate sees), so `bool` and `char` fields qualify.
+# any other field type -- a pointer, a `str`, a nested record or union, an array,
+# or a vector -- is rejected at comptime with a clear `$error`, since a
+# well-defined value operation over those needs caller-chosen semantics (address
+# vs. deep, and recursion the compiler cannot yet express generically). every
+# helper here shares this one rule.
+#
+# equality and hashing follow IEEE-754 through `!=` and a canonical bit fold:
+# `-0.0` and `+0.0` are equal and hash alike, while a field holding NaN makes a
+# record never equal to itself (NaN compares unequal to everything).
+
+use R: std.types.result;
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.io.writer;
+use std.format;
+
+# FNV-1a 64-bit offset basis
+val FNV_OFFSET: u64 = 14695981039346656037;
+
+# FNV-1a 64-bit prime
+val FNV_PRIME: u64 = 1099511628211;
+
+# fold the eight bytes of `word` into an FNV-1a accumulator
+# ---
+# h:    running hash accumulator
+# word: the field value packed into a u64
+# ret:  the updated accumulator
+fun fold(h: u64, word: u64) u64 {
+    var x: u64 = h;
+    var w: u64 = word;
+    var i: i64 = 0;
+    for (i < 8) {
+        x = (x ^ (w & 0xff)) * FNV_PRIME;
+        w = w >> 8;
+        i = i + 1;
+    }
+    ret x;
+}
+
+# structural equality over a record's scalar fields
+#
+# compares `a` and `b` field by field and returns false at the first mismatch. a
+# record with no fields compares equal. every field must be an eligible scalar
+# (see the module note); a pointer, `str`, or aggregate field is a comptime
+# `$error`.
+# ---
+# a:   first record
+# b:   second record
+# ret: true when every field compares equal
+pub fun eq[T](a: *T, b: *T) bool {
+    $each f in $fields(T) {
+        $if (f.type == i8  || f.type == i16 || f.type == i32 || f.type == i64
+          || f.type == u8  || f.type == u16 || f.type == u32 || f.type == u64
+          || f.type == f32 || f.type == f64) {
+            if (a.[f] != b.[f]) { ret false; }
+        }
+        $or {
+            $error("derive.eq: field type is not a scalar numeric; pointer, str, and aggregate fields need caller-chosen equality");
+        }
+    }
+    ret true;
+}
+
+# FNV-1a hash over a record's scalar fields
+#
+# folds each field's value into a 64-bit accumulator in declaration order. two
+# records that compare `eq` hash alike, since both fold the same scalar fields.
+# eligibility matches `eq`: every field must be a scalar numeric, or the call is
+# a comptime `$error`.
+# ---
+# v:   the record to hash
+# ret: the 64-bit hash
+pub fun hash[T](v: *T) u64 {
+    var h: u64 = FNV_OFFSET;
+    $each f in $fields(T) {
+        $if (f.type == i8 || f.type == i16 || f.type == i32 || f.type == i64
+          || f.type == u8 || f.type == u16 || f.type == u32 || f.type == u64) {
+            h = fold(h, (v.[f])::u64);
+        }
+        # canonicalize -0.0 to +0.0 (additive identity is exact for every other
+        # value), then fold the bit pattern so equal floats hash alike.
+        $or (f.type == f64) { h = fold(h, (v.[f] + 0.0):~ u64); }
+        $or (f.type == f32) { h = fold(h, ((v.[f])::f64 + 0.0):~ u64); }
+        $or {
+            $error("derive.hash: field type is not a scalar numeric; pointer, str, and aggregate fields need caller-chosen hashing");
+        }
+    }
+    ret h;
+}
+
+# write a record as `{field=value, ...}` to a writer
+#
+# renders each scalar field as `name=value` in declaration order, separated by
+# `, `, delegating value formatting to `format`. the record's own type name is
+# not available at comptime, so only the fields are shown. eligibility matches
+# `eq` and `hash`: every field must be a scalar numeric, or the call is a
+# comptime `$error`.
+# ---
+# w:   target writer
+# v:   the record to render
+# ret: total bytes written, or an error message
+pub fun fmt[T](w: *writer.Writer, v: *T) R.Result[usize, str] {
+    var total: usize = 0;
+
+    val open: R.Result[usize, str] = format.write_byte(w, '{');
+    if (R.is_err[usize, str](open)) { ret open; }
+    total = total + R.unwrap_ok[usize, str](open);
+
+    var first: bool = true;
+    $each f in $fields(T) {
+        $if (f.type == i8  || f.type == i16 || f.type == i32 || f.type == i64
+          || f.type == u8  || f.type == u16 || f.type == u32 || f.type == u64
+          || f.type == f32 || f.type == f64) {
+            var r: R.Result[usize, str];
+            if (first) { r = format.format(w, "{}={}", f.name, v.[f]); }
+            or         { r = format.format(w, ", {}={}", f.name, v.[f]); }
+            first = false;
+            if (R.is_err[usize, str](r)) { ret r; }
+            total = total + R.unwrap_ok[usize, str](r);
+        }
+        $or {
+            $error("derive.fmt: field type is not a scalar numeric; pointer, str, and aggregate fields need caller-chosen formatting");
+        }
+    }
+
+    val close: R.Result[usize, str] = format.write_byte(w, '}');
+    if (R.is_err[usize, str](close)) { ret close; }
+    total = total + R.unwrap_ok[usize, str](close);
+
+    ret R.ok[usize, str](total);
+}
+
+use std.types.string.str_equals;
+use std.types.char.char;
+use std.memory;
+
+rec DV2 { x: i64; y: i64; }
+rec DMix { i: i32; u: u16; f: f64; g: f32; }
+rec DFlags { on: bool; c: char; n: u8; }
+rec DEmpty {}
+
+test "eq: homogeneous equal and unequal" {
+    var a: DV2; a.x = 3; a.y = 7;
+    var b: DV2; b.x = 3; b.y = 7;
+    if (!eq[DV2](?a, ?b)) { ret 1; }
+    b.y = 8;
+    if (eq[DV2](?a, ?b)) { ret 1; }
+    b.y = 7; b.x = 4;
+    if (eq[DV2](?a, ?b)) { ret 1; }
+    ret 0;
+}
+
+test "eq: heterogeneous fields" {
+    var a: DMix; a.i = -2; a.u = 9; a.f = 1.5; a.g = 2.5;
+    var b: DMix; b.i = -2; b.u = 9; b.f = 1.5; b.g = 2.5;
+    if (!eq[DMix](?a, ?b)) { ret 1; }
+    b.f = 1.6;
+    if (eq[DMix](?a, ?b)) { ret 1; }
+    ret 0;
+}
+
+test "eq: def fields (bool, char)" {
+    var a: DFlags; a.on = true; a.c = 'z'; a.n = 5;
+    var b: DFlags; b.on = true; b.c = 'z'; b.n = 5;
+    if (!eq[DFlags](?a, ?b)) { ret 1; }
+    b.c = 'y';
+    if (eq[DFlags](?a, ?b)) { ret 1; }
+    ret 0;
+}
+
+test "eq: empty record is always equal" {
+    var a: DEmpty;
+    var b: DEmpty;
+    if (!eq[DEmpty](?a, ?b)) { ret 1; }
+    ret 0;
+}
+
+test "eq: signed zero compares equal, NaN never equal" {
+    var negz: u64 = 0x8000000000000000;
+    var a: DMix; a.i = 0; a.u = 0; a.g = 0.0;
+    memory.raw_copy(?a.f, ?negz, 8);
+    var b: DMix; b.i = 0; b.u = 0; b.g = 0.0; b.f = 0.0;
+    if (!eq[DMix](?a, ?b)) { ret 1; }
+
+    var nan: u64 = 0x7FF8000000000000;
+    var c: DMix; c.i = 0; c.u = 0; c.g = 0.0;
+    memory.raw_copy(?c.f, ?nan, 8);
+    if (eq[DMix](?c, ?c)) { ret 1; }
+    ret 0;
+}
+
+test "hash: equal records hash alike, determinism" {
+    var a: DMix; a.i = -2; a.u = 9; a.f = 1.5; a.g = 2.5;
+    var b: DMix; b.i = -2; b.u = 9; b.f = 1.5; b.g = 2.5;
+    if (hash[DMix](?a) != hash[DMix](?b)) { ret 1; }
+    if (hash[DMix](?a) != hash[DMix](?a)) { ret 1; }
+    ret 0;
+}
+
+test "hash: distinct records hash differently" {
+    var a: DV2; a.x = 1; a.y = 2;
+    var b: DV2; b.x = 2; b.y = 1;
+    if (hash[DV2](?a) == hash[DV2](?b)) { ret 1; }
+    ret 0;
+}
+
+test "hash: signed zero hashes alike" {
+    var negz: u64 = 0x8000000000000000;
+    var a: DMix; a.i = 0; a.u = 0; a.g = 0.0;
+    memory.raw_copy(?a.f, ?negz, 8);
+    var b: DMix; b.i = 0; b.u = 0; b.g = 0.0; b.f = 0.0;
+    if (hash[DMix](?a) != hash[DMix](?b)) { ret 1; }
+    ret 0;
+}
+
+test "eq/hash contract: eq implies equal hash" {
+    var a: DFlags; a.on = true; a.c = 'q'; a.n = 200;
+    var b: DFlags; b.on = true; b.c = 'q'; b.n = 200;
+    if (!eq[DFlags](?a, ?b)) { ret 1; }
+    if (hash[DFlags](?a) != hash[DFlags](?b)) { ret 1; }
+    ret 0;
+}
+
+rec DCap { data: *u8; len: usize; cap: usize; }
+
+fun cap_write(ctx: ptr, p: *u8, len: usize) R.Result[usize, str] {
+    val b: *DCap = ctx::*DCap;
+    var i: usize = 0;
+    for (i < len) {
+        if (b.len >= b.cap) { ret R.err[usize, str]("capture overflow"); }
+        b.data[b.len] = p[i];
+        b.len = b.len + 1;
+        i = i + 1;
+    }
+    ret R.ok[usize, str](len);
+}
+
+test "fmt: renders name=value pairs" {
+    var scratch: [128]u8;
+    var cap: DCap; cap.data = ?scratch[0]; cap.len = 0; cap.cap = 128;
+    var w: writer.Writer; w.ctx = (?cap)::ptr; w.f_write = cap_write;
+
+    var v: DV2; v.x = 1; v.y = 2;
+    val r: R.Result[usize, str] = fmt[DV2](?w, ?v);
+    if (R.is_err[usize, str](r)) { ret 1; }
+    scratch[cap.len] = 0;
+    if (!str_equals(?scratch[0], "{x=1, y=2}")) { ret 1; }
+    ret 0;
+}
+
+test "fmt: empty record renders empty braces" {
+    var scratch: [16]u8;
+    var cap: DCap; cap.data = ?scratch[0]; cap.len = 0; cap.cap = 16;
+    var w: writer.Writer; w.ctx = (?cap)::ptr; w.f_write = cap_write;
+
+    var v: DEmpty;
+    val r: R.Result[usize, str] = fmt[DEmpty](?w, ?v);
+    if (R.is_err[usize, str](r)) { ret 1; }
+    scratch[cap.len] = 0;
+    if (!str_equals(?scratch[0], "{}")) { ret 1; }
+    ret 0;
+}

--- a/src/lib/libstd.mach
+++ b/src/lib/libstd.mach
@@ -42,6 +42,7 @@ fwd std.simd.saturate;
 fwd std.simd.gather;
 
 fwd std.format;
+fwd std.derive;
 fwd std.print;
 fwd std.input;
 fwd std.terminal;


### PR DESCRIPTION
Closes #285.

Adds `std.derive`, a set of macro-free generic helpers built on `$each f in $fields(T)` + the `v.[f]` field projection. One definition serves every record shape — the `$each` unroll is deferred to instantiation (mach#1523 landed in 4.x), so `T` is a concrete record by the time the field-type gates fold.

## Helpers
- `eq[T](a: *T, b: *T) bool` — structural equality, field by field, short-circuiting on the first mismatch.
- `hash[T](v: *T) u64` — FNV-1a fold over the fields; `eq`-consistent (equal records hash alike).
- `fmt[T](w: *writer.Writer, v: *T) Result[usize, str]` — debug-renders `{name=value, ...}`, delegating value formatting to `std.format`.

## Eligibility (one uniform rule)
A field is eligible when its type is a **scalar numeric** — a signed/unsigned integer of any width, or a float. A `def` over such a scalar counts (the gate sees the underlying type), so `bool` and `char` fields qualify. Any other field type — pointer, `str`, nested record/union, array, vector — is rejected **at comptime with a clear `$error`** naming the helper, since a well-defined value operation over those needs caller-chosen semantics.

Floats follow IEEE-754: `-0.0`/`+0.0` compare equal and hash alike (canonical bit fold), and a NaN field makes a record never equal to itself.

## Tests
11 inline tests (`std.derive`, suite 637 → 648, 0 failed): homogeneous, heterogeneous, def-field (bool/char), and empty records; the eq/hash contract; signed-zero and NaN float behavior; and `fmt` golden output via a buffer-backed writer. The negative path (a pointer/aggregate field → clean `$error`) was verified out-of-tree.

## Follow-ups (compiler-gated, not worked around)
Richer derive is blocked on comptime type introspection the compiler does not yet expose:
- no comptime "is record" / "is pointer" predicate → no recursive derive over nested records, and pointer/`str` fields cannot be handled generically (a single `ptr` gate matches only the untyped `ptr`, not typed pointers).
- no `$type_name(T)` intrinsic → `fmt` cannot print the record's own type name (`{...}` only).