### PR TITLE
test(crypto): say what the dirty-operand guard actually catches now

### DIFF
--- a/src/crypto/ct.mach
+++ b/src/crypto/ct.mach
@@ -759,11 +759,21 @@ test "ct: zeroize of a zero-length span touches nothing" {
 }
 
 test "ct: comparisons answer for the value, not for stray high bits" {
-    # a narrow arithmetic result carries stray high bits on the current compiler
-    # (briar-systems/mach#2357), and `mask_*` produces one by construction. the
-    # comparisons must still answer for the 8-bit VALUE, which is what the
-    # operators' operand zero-extension buys and what a hand-rolled shift of the
-    # same expression would not.
+    # a narrow arithmetic result still carries stray high bits, and `mask_*` produces
+    # one by construction: briar-systems/mach#2357 canonicalized the SHIFT consumers,
+    # not the producers, so `0 - x` at u8 still leaves a full 32-bit register
+    # (`sub eax, edi`, no truncation). the comparisons must answer for the 8-bit
+    # VALUE, which is what the operators' operand zero-extension buys.
+    #
+    # WHAT THIS CATCHES, checked by mutation against a post-#2357 compiler: writing
+    # these over an explicit `::^u32` widening instead of the operators. a
+    # secret-to-secret cast lowers to a bitcast rather than a zext
+    # (briar-systems/mach#2373), so the stray bits survive into the wider
+    # computation and the answer is wrong. that form fails this test.
+    #
+    # WHAT IT NO LONGER CATCHES: the older masked-shift form. #2357 fixed the
+    # truncation that form depended on, so it now passes. this test is not a guard
+    # against it, and should not be cited as one.
     val neg: ^u8 = mask_u8(1);
     if (is_zero_u8(neg):^ != 0) { ret 1; }
     if (eq_u8(neg, 0xFF):^  != 1) { ret 1; }


### PR DESCRIPTION
Follow-up to #391. Two things, both about making `crypto.ct` say what is actually true. No behaviour change — comments and one new test.

1. A guard whose comment named a hazard that no longer applies.
2. **A correctness contingency nobody could see from the source**, now guarded.

`ct: comparisons answer for the value, not for stray high bits` still passes and still asserts something true — but after briar-systems/mach#2362 it **stopped catching the thing its comment says it catches**. That is the green-signal-that-could-not-be-red shape, so it is worth fixing even though nothing is failing.

## Mutation-checked, against a from-source compiler at mach `38ddef46`

| mutation | before #2362 | now |
|---|---|---|
| revert `is_zero_u8` / `lt_u8` to the **masked-shift** form | FAILED (5 tests) | **PASSES 16/16** |
| write them over an explicit **`::^u32` widening** | failed | **FAILS** (this test, alone) |

So the guard has not gone slack — it has changed what it guards, and the comment was left pointing at the old hazard.

## The premise still holds — I checked rather than assuming

mach#2362 canonicalized the **shift consumers**, not the producers. A narrow arithmetic result still carries stray high bits:

```
# _M5m23734mainN10dirty_flag:      # `0 - a` at ^u8
  mov eax, 0
  sub eax, edi                     # 32-bit, no truncation -> register holds 0xFFFFFFFF
  ret
```

and `mask_u8` still produces one by construction (`and edi, 1` / `mov eax, 0` / `sub eax, edi`). So the test still feeds a genuinely dirty operand — it is not vacuous, which was the thing worth ruling out.

## What the comment now says

Three things, separated so the next reader is not misled:

- **the premise** — producers are still not canonicalized, with the reason #2357 does not cover it;
- **what it catches** — the `::^u32` widening, which lowers to a `bitcast` rather than a `zext` (briar-systems/mach#2373), so stray bits survive into the wider computation;
- **what it no longer catches** — the masked-shift form, explicitly, *"and should not be cited as one."*

## 2. The four `mask_*` casts depend on a backend property, and nothing said so

`mask_u16/u32/u64/usize` all do `val one: ^uN = (c & 1)::^uN;`. That cast **does not zero-extend** — a secret-to-secret `::` lowers to a width-changing `bitcast`, a reinterpret (briar-systems/mach#2373). The emitted IR is literally:

```
%4 = and i8 %p0: i8, 1: i8
%5 = bitcast i32 %4: i8        <- no conversion happens here
%8 = sub i32 0: i32, %5: i32
```

They are nonetheless correct, and I verified that by execution against a from-source compiler on both profiles with a genuinely dirty operand. **But the thing making them correct is the `& 1`**, which every backend emits at machine-register width with an immediate that clears the high bits:

```
x86_64    and edi, 1
aarch64   and w1, w0, w16
riscv64   and a1, a0, t0
```

By the time the bitcast runs there is nothing left to reinterpret.

**That is a property of the backend'"'"'s lowering, not of this source.** A narrow ALU op emitted at its declared width — a change mach#2357 explicitly considered and rejected on cost grounds, so it could plausibly land later — would leave the high bits alive, the bitcast would expose them, and *this line would be unchanged*. A reader of `crypto.ct` had no way to know any of that; the previous comment implied the cast was doing the work.

So: the four sites now say what protects them, and there is a test that **fails if it stops being true** — `ct: mask_* answer for the value under a dirty flag`. It hands the masks a flag whose high bits are stray (`mask_u8(1)`'"'"'s own output, which is `0 - one` and untruncated, so the byte `0xFF` arrives in a register holding `0xFFFFFFFF`) and asserts the masks and the `select_*` consumers.

**Mutation-checked**: dropping the `& 1` from `mask_u32` — i.e. simulating exactly the backend change being guarded — fails it.

Same shape as mach#2364'"'"'s bar: guard the invariant now, while the reason is understood, rather than rediscovering it when the pass changes.

## Verification

**680/680** with the released 4.2.2 compiler (679 before, +1 for the new guard). The ct module is 17 tests, green on both the released compiler and a from-source one at mach `38ddef46`.

With a from-source compiler at current mach `dev`, 677/679 — the two failures are `eq: heterogeneous fields` and `eq: signed zero compares equal, NaN never equal` in `src/derive.mach`. **Both reproduce on pristine `dev` with my change stashed out**, so they are not from this PR; they are `$each` field-wise compare, i.e. briar-systems/mach#2376, which is already owned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqq8dS4TDqoYPsx3JpVy4
