### PR TITLE
test(crypto): guard the backend property mask_* actually depends on

### DIFF
--- a/src/crypto/ct.mach
+++ b/src/crypto/ct.mach
@@ -62,6 +62,27 @@ pub fun mask_u8(c: ^u8) ^u8 {
 }
 
 # lift a secret 0/1 flag to an all-ones 16-bit mask
+#
+# WHAT MAKES THE WIDENING CAST SAFE HERE, stated once for the four `mask_*` that
+# widen (u16/u32/u64/usize), because it is not what it looks like.
+#
+# `(c & 1)::^uN` does NOT zero-extend. a secret-to-secret `::` currently lowers to
+# a width-changing `bitcast` — a reinterpret, not a conversion
+# (briar-systems/mach#2373) — so it cannot clean anything. the emitted IR is
+# literally `%5 = bitcast i32 %4: i8`.
+#
+# what protects these is the `& 1` immediately before it, which every backend
+# emits at machine-register width with an immediate that clears every high bit:
+# `and edi, 1` on x86_64, `and w1, w0, w16` on aarch64, `and a1, a0, t0` on
+# riscv64. by the time the bitcast runs there is nothing left to reinterpret, so
+# the mask is correct for any input — including one whose high bits are stray,
+# which a caller can easily hand over (a narrow `0 - x` is not truncated).
+#
+# that is a property of the BACKEND'S LOWERING, not of this source. a narrow ALU
+# op emitted at its declared width — a change #2357 considered and rejected on
+# cost — would leave the high bits alive and the bitcast would expose them, with
+# this line unchanged. `ct: mask_* answer for the value under a dirty flag` is the
+# guard for exactly that, so the day it changes this fails instead of going quiet.
 # ---
 # c:   secret flag, 0 or 1
 # ret: 0x0000 or 0xFFFF
@@ -72,6 +93,8 @@ pub fun mask_u16(c: ^u8) ^u16 {
 }
 
 # lift a secret 0/1 flag to an all-ones 32-bit mask
+#
+# the `& 1` is what makes the cast safe, not the cast — see `mask_u16`.
 # ---
 # c:   secret flag, 0 or 1
 # ret: 0x00000000 or 0xFFFFFFFF
@@ -82,6 +105,8 @@ pub fun mask_u32(c: ^u8) ^u32 {
 }
 
 # lift a secret 0/1 flag to an all-ones 64-bit mask
+#
+# the `& 1` is what makes the cast safe, not the cast — see `mask_u16`.
 # ---
 # c:   secret flag, 0 or 1
 # ret: 0 or 0xFFFFFFFFFFFFFFFF
@@ -92,6 +117,8 @@ pub fun mask_u64(c: ^u8) ^u64 {
 }
 
 # lift a secret 0/1 flag to an all-ones usize mask
+#
+# the `& 1` is what makes the cast safe, not the cast — see `mask_u16`.
 # ---
 # c:   secret flag, 0 or 1
 # ret: 0 or the all-ones usize
@@ -755,6 +782,33 @@ test "ct: zeroize of a zero-length span touches nothing" {
     zeroize(?buf[0], 0);
     if (buf[0]:^ != 0x11) { ret 1; }
     if (buf[1]:^ != 0x22) { ret 1; }
+    ret 0;
+}
+
+test "ct: mask_* answer for the value under a dirty flag" {
+    # GUARDS AN UNSTATED BACKEND PROPERTY. the widening in mask_u16/u32/u64/usize is
+    # a `bitcast`, not a zext (briar-systems/mach#2373), so it cleans nothing; what
+    # makes those four correct is that the preceding `& 1` is emitted at
+    # machine-register width and clears the high bits. nothing in this repo can
+    # state that, and nothing in the compiler promises it — a narrow ALU op emitted
+    # at its declared width would break it silently while this source stays the same.
+    #
+    # so: hand the masks a flag whose high bits ARE stray and check the answer.
+    # `mask_u8(1)` produces one by construction — it returns `0 - one`, and a narrow
+    # subtraction is not truncated, so the byte 0xFF arrives in a register holding
+    # 0xFFFFFFFF. if the high bits ever reach the subtract, the mask comes back
+    # 0x000000FF instead of all-ones and these fail.
+    val dirty: ^u8 = mask_u8(1);
+
+    if (mask_u8(dirty):^    != 0xFF) { ret 1; }
+    if (mask_u16(dirty):^   != 0xFFFF) { ret 1; }
+    if (mask_u32(dirty):^   != 0xFFFFFFFF) { ret 1; }
+    if (mask_u64(dirty):^   != 0xFFFFFFFFFFFFFFFF) { ret 1; }
+
+    # and the consumers, which is where a wrong mask would actually do damage
+    if (select_u16(dirty, 0xBEEF, 0xDEAD):^ != 0xBEEF) { ret 1; }
+    if (select_u32(dirty, 0xAAAAAAAA, 0x55555555):^ != 0xAAAAAAAA) { ret 1; }
+    if (select_u64(dirty, 0x0123456789ABCDEF, 0xFEDCBA9876543210):^ != 0x0123456789ABCDEF) { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Follow-up to #392 — **this commit raced #392's merge and was left behind**, same as happened on mach#2370/#2372. #392 landed the comment correction; this is the other half, which is the substantive one.

## The contingency

`mask_u16/u32/u64/usize` all do `val one: ^uN = (c & 1)::^uN;`. That cast **does not zero-extend** — a secret-to-secret `::` lowers to a width-changing `bitcast`, a reinterpret (briar-systems/mach#2373). The emitted IR is literally:

```
%4 = and i8 %p0: i8, 1: i8
%5 = bitcast i32 %4: i8        <- no conversion happens here
%8 = sub i32 0: i32, %5: i32
```

They are nonetheless correct — verified by execution against a from-source compiler, both profiles, repeated runs, with a genuinely dirty operand. **But what makes them correct is the `& 1`**, which every backend emits at machine-register width with an immediate that clears the high bits:

```
x86_64    and edi, 1
aarch64   and w1, w0, w16
riscv64   and a1, a0, t0
```

By the time the bitcast runs there is nothing left to reinterpret.

**That is a property of the backend's lowering, not of this source.** A narrow ALU op emitted at its declared width — a change mach#2357 explicitly considered and rejected on cost grounds, so it could plausibly land later — would leave the high bits alive, the bitcast would expose them, and *this line would be unchanged*. Someone reading `crypto.ct` had no way to know that; the previous comment implied the cast was doing the work.

## What this adds

**A test that fails the day it stops being true.** `ct: mask_* answer for the value under a dirty flag` hands the masks a flag whose high bits are stray — `mask_u8(1)`'s own output, which is `0 - one` and untruncated, so the byte `0xFF` arrives in a register holding `0xFFFFFFFF` — and asserts every widened mask plus the `select_*` consumers where a wrong mask would actually do damage.

**Mutation-checked**: dropping the `& 1` from `mask_u32`, i.e. simulating exactly the backend change being guarded, fails it.

**Plus the four cast sites documented** — stated once at `mask_u16` with a one-line pointer at the other three, rather than four near-identical paragraphs.

Same shape as mach#2364's bar: guard the invariant now, while the reason is understood, rather than rediscovering it when the pass changes.

## Verification

**680/680** with the released 4.2.2 compiler (679 before this branch, +1 for the new guard). Green on a from-source compiler at mach `38ddef46` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqq8dS4TDqoYPsx3JpVy4