### PR TITLE
fix(panic): terminate deliberately instead of dying by signal

### DIFF
--- a/src/system/panic.mach
+++ b/src/system/panic.mach
@@ -69,6 +69,71 @@ pub fun panic(msg: *u8) {
         }
     }
 
+    # TERMINATE DELIBERATELY (#2369). A trap instruction was the only terminator here,
+    # so a panic died by signal: `hlt` is PRIVILEGED, and executing it in user mode
+    # raises #GP, which the kernel delivers as SIGSEGV - exit 139, the exact status a
+    # wild pointer produces. A correctly detected invariant breach was indistinguishable
+    # from memory corruption at the shell, and the three architectures did not even agree
+    # (aarch64 and riscv64 trapped to SIGTRAP, 133).
+    #
+    # exit_group, not exit, so every thread of the process ends - a panic in a worker
+    # must not leave the rest running. PANIC_EXIT is 255, matching
+    # `std.system.os.abort()`; signal deaths are 128 + N with N <= 64, so it cannot be
+    # mistaken for one. The syscall is inlined rather than delegated to `std.system.os`
+    # because this module stays dependency-free so `result` and `option` can panic
+    # without an import cycle.
+    $if ($mach.build.os == $mach.os.linux) {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 231      # SYS_exit_group
+                mov edi, 255      # PANIC_EXIT
+                syscall
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x8, 94    # SYS_exit_group (linux aarch64)
+                mov x0, 255   # PANIC_EXIT
+                svc 0
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                li a7, 94     # SYS_exit_group (linux riscv64)
+                li a0, 255    # PANIC_EXIT
+                ecall
+            }
+        }
+        $or {
+            $error("std.system.panic: unsupported linux architecture");
+        }
+    }
+    $or ($mach.build.os == $mach.os.darwin) {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov eax, 0x2000001  # SYS_exit (darwin)
+                mov edi, 255        # PANIC_EXIT
+                syscall
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                mov x16, 1    # SYS_exit (darwin aarch64)
+                mov x0, 255   # PANIC_EXIT
+                svc 0x80
+            }
+        }
+        $or {
+            $error("std.system.panic: unsupported darwin architecture");
+        }
+    }
+
+    # exit_group never returns; trap only if it somehow does, matching
+    # `std.system.os.terminate`. This block is arch-gated with NO os gate, so on windows
+    # it is still the ONLY terminator - and the write above emitted darwin syscall
+    # numbers, so panicking there neither prints nor exits cleanly. Left as found rather
+    # than guessed at, because fixing the terminator alone would give a correct exit code
+    # for a message nobody saw: both halves have to move together (#397).
     $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 { hlt }
     }


### PR DESCRIPTION
Fixes the root cause behind briar-systems/mach#2369.

## Root cause

`panic` wrote its message and then ran a **trap instruction with no exit syscall at all**:

```mach
$if ($mach.build.arch == $mach.arch.x86_64) { asm x86_64 { hlt } }
$or ($mach.build.arch == $mach.arch.aarch64) { asm aarch64 { brk 0 } }
$or ($mach.build.arch == $mach.arch.riscv64) { asm riscv64 { ebreak } }
```

**`hlt` is privileged.** In user mode it raises #GP, which Linux delivers as **SIGSEGV** — so every deliberate panic exited **139**, the exact status a wild pointer produces. Confirmed under gdb:

```
Program received signal SIGSEGV, Segmentation fault.
=> 0x400070:	hlt
```

The three architectures did not even agree:

| ISA | terminator | signal | exit |
|---|---|---|---|
| x86_64 | `hlt` (privileged → #GP) | SIGSEGV | 139 |
| aarch64 | `brk 0` | SIGTRAP | 133 |
| riscv64 | `ebreak` | SIGTRAP | 133 |

**The abort path was not unsound** — no bad handle, no freed state, no dead frame. The message write completes; the fault came entirely from the choice of terminator. That distinction was the precondition for changing anything here: a corrupt panic path would have been the more serious defect, and swapping the exit code would have hidden it.

## The fix

`exit_group` (darwin: `exit`) with **`PANIC_EXIT = 255`**, matching `std.system.os.abort()` rather than inventing a constant. Signal deaths are 128 + N with N ≤ 64, so 255 cannot be mistaken for one. `exit_group` rather than `exit` so a panic in a worker thread ends the process instead of only that thread. The trap is kept *after* the syscall as an unreachable guard, exactly as `std.system.os.terminate` already does. The syscall is inlined rather than delegated to `std.system.os` because this module stays dependency-free so `result` and `option` can panic without an import cycle.

## Verified

| target | profile | exit | stderr |
|---|---|---|---|
| linux x86_64 | debug / release | **255** | `before` / `deliberate panic` |
| linux aarch64 | debug / release | **255** | `before` / `deliberate panic` |
| linux riscv64 | debug / release | **255** | `before` / `deliberate panic` |

Message still reaches the user, ordering preserved, no fault. **mach-std suite 611 / 0**; the mach compiler builds against this tree and self-tests **956 / 0**.

## Windows is deliberately NOT changed

Worth stating plainly because it is worse than the bug this PR fixes. The structure is `$if linux { ... } $or { ...darwin... }`, so **"not linux" is treated as "darwin"** and a Windows build compiles darwin syscall numbers into the panic path. From a real `--target windows` build:

```
mov    eax,0x2000004     ; darwin SYS_write
mov    edi,0x2
syscall
hlt
```

So on Windows a panic issues a meaningless syscall and then hits a privileged instruction — the message almost certainly never reaches the user at all. Fixing that means choosing a Windows termination ABI (`ExitProcess` needs a kernel32 import) for a module that is dependency-free by design. That is a decision, not a detail, so it is left untouched and called out rather than guessed at.