### PR TITLE
docs(crypto): the widening cast converts now — say so (after mach#2379)

### DIFF
--- a/src/crypto/ct.mach
+++ b/src/crypto/ct.mach
@@ -63,26 +63,26 @@ pub fun mask_u8(c: ^u8) ^u8 {
 
 # lift a secret 0/1 flag to an all-ones 16-bit mask
 #
-# WHAT MAKES THE WIDENING CAST SAFE HERE, stated once for the four `mask_*` that
-# widen (u16/u32/u64/usize), because it is not what it looks like.
+# THE WIDENING CAST AND THE `& 1` DO DIFFERENT JOBS, stated once for the four
+# `mask_*` that widen (u16/u32/u64/usize).
 #
-# `(c & 1)::^uN` does NOT zero-extend. a secret-to-secret `::` currently lowers to
-# a width-changing `bitcast` — a reinterpret, not a conversion
-# (briar-systems/mach#2373) — so it cannot clean anything. the emitted IR is
-# literally `%5 = bitcast i32 %4: i8`.
+# `::^uN` zero-extends: it takes the low 8 bits of the flag and nothing else, so a
+# caller's stray high bits cannot reach the subtraction. that is worth naming
+# because it was NOT true until briar-systems/mach#2373 — a secret-to-secret `::`
+# used to lower to a width-changing `bitcast`, a reinterpret that cleaned nothing,
+# and these four were correct only because the `& 1` happened to be emitted at
+# machine-register width. they are now correct because the cast converts.
 #
-# what protects these is the `& 1` immediately before it, which every backend
-# emits at machine-register width with an immediate that clears every high bit:
-# `and edi, 1` on x86_64, `and w1, w0, w16` on aarch64, `and a1, a0, t0` on
-# riscv64. by the time the bitcast runs there is nothing left to reinterpret, so
-# the mask is correct for any input — including one whose high bits are stray,
-# which a caller can easily hand over (a narrow `0 - x` is not truncated).
+# the `& 1` is the flag's normalization, not the cleanup: it reduces a flag outside
+# {0, 1} to its low bit, which is what lets `0 - one` be all-ones or all-zeros
+# rather than a partial blend. it is load-bearing for that reason alone, and
+# dropping it is caught by `ct: mask reads only the flag's low bit`.
 #
-# that is a property of the BACKEND'S LOWERING, not of this source. a narrow ALU
-# op emitted at its declared width — a change #2357 considered and rejected on
-# cost — would leave the high bits alive and the bitcast would expose them, with
-# this line unchanged. `ct: mask_* answer for the value under a dirty flag` is the
-# guard for exactly that, so the day it changes this fails instead of going quiet.
+# `ct: mask_* answer for the value under a dirty flag` pins the pair: the masks must
+# answer for the 8-bit VALUE of the flag whatever the register around it holds. a
+# caller can still hand over stray high bits — a narrow `0 - x` is not truncated,
+# #2357 canonicalized the shift consumers rather than the producers — so this stays
+# a live property to guard, not a historical one.
 # ---
 # c:   secret flag, 0 or 1
 # ret: 0x0000 or 0xFFFF
@@ -94,7 +94,7 @@ pub fun mask_u16(c: ^u8) ^u16 {
 
 # lift a secret 0/1 flag to an all-ones 32-bit mask
 #
-# the `& 1` is what makes the cast safe, not the cast — see `mask_u16`.
+# the cast zero-extends; the `& 1` normalizes the flag — see `mask_u16`.
 # ---
 # c:   secret flag, 0 or 1
 # ret: 0x00000000 or 0xFFFFFFFF
@@ -106,7 +106,7 @@ pub fun mask_u32(c: ^u8) ^u32 {
 
 # lift a secret 0/1 flag to an all-ones 64-bit mask
 #
-# the `& 1` is what makes the cast safe, not the cast — see `mask_u16`.
+# the cast zero-extends; the `& 1` normalizes the flag — see `mask_u16`.
 # ---
 # c:   secret flag, 0 or 1
 # ret: 0 or 0xFFFFFFFFFFFFFFFF
@@ -118,7 +118,7 @@ pub fun mask_u64(c: ^u8) ^u64 {
 
 # lift a secret 0/1 flag to an all-ones usize mask
 #
-# the `& 1` is what makes the cast safe, not the cast — see `mask_u16`.
+# the cast zero-extends; the `& 1` normalizes the flag — see `mask_u16`.
 # ---
 # c:   secret flag, 0 or 1
 # ret: 0 or the all-ones usize


### PR DESCRIPTION
**Draft deliberately: must merge after briar-systems/mach#2379**, and is wrong before it. Queued rather than promised, so it does not depend on anyone remembering.

## Why

#393 landed this, 40 minutes ago, and it was true when written:

> `(c & 1)::^uN` does **not** zero-extend … what protects these is the `& 1` … that is a property of the BACKEND'S LOWERING, not of this source.

mach#2379 makes a secret-to-secret `::` emit a real `zext`. Verified by building that branch:

```
before   %5 = bitcast i32 %4: i8
after    %5 = zext i32 %4: i8
```

So the sentence "the cast cleans nothing" becomes false, and the contingency the comment warns about — a narrow ALU op re-exposing high bits — stops existing, because `zext` takes the low 8 bits by definition regardless of how the AND was emitted.

**This is the same stale-comment shape as #392**, one step removed: a comment that was accurate, describing a compiler property that then changed underneath it. Left alone, the next reader would take a resolved hazard for a live one and reason from it.

## What it now says

The two operations do **different jobs**, and both are load-bearing:

- **the cast zero-extends** — stray high bits from a caller cannot reach the subtraction;
- **the `& 1` normalizes** — it reduces a flag outside `{0, 1}` to its low bit, which is what lets `0 - one` be all-ones or all-zeros rather than a partial blend.

Each has its own test, so neither is guarded by accident: dropping the `& 1` fails `ct: mask reads only the flag's low bit`, and the value/register distinction is pinned by `ct: mask_* answer for the value under a dirty flag`.

**That second guard stays live and stays falsifiable.** I checked rather than assuming — the mutation (drop the `& 1`) still fails it against a #2379 compiler. And its premise still holds: a caller can still hand over stray high bits, because #2357 canonicalized the shift *consumers*, not the producers, so a narrow `0 - x` is still untruncated. The comment now says that explicitly instead of implying the hazard was retired.

## Verification against mach#2379

Built the `fix/2373-secret-cast-classify` branch and ran against it:

- **`crypto.ct` is unchanged by the fix** — the no-change re-run I offered. My adversarial probe returns 12/12 correct on both profiles, identical to before, exactly as predicted for a `zext` of an already-clean 0/1.
- **mach-std 680/680** with that compiler.
- **The guard still discriminates** — dropping the `& 1` still fails it.
- **The signed half cannot reach mach-std at all**: zero `^i8`/`^i16`/`^i32`/`^i64`/`^isize` anywhere in `src/`, so the `shr_u`-for-`shr_s` and `cmp_lt_u`-for-`cmp_lt_s` miscompiles have no reachable call site here.

Comment-only. 680/680 on the released 4.2.2 compiler too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ntqq8dS4TDqoYPsx3JpVy4