### PR TITLE
release: mach-std 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-07-26
+
+Adds the `bmos` arm — support for [ReturnInfinity's BareMetal](https://github.com/ReturnInfinity/BareMetal) exokernel, whose compiler-side target shipped in mach 4.3.0.
+
+### Added
+- system: `std.system.bmos` — the BareMetal kernel API. BareMetal exposes no syscalls; its entire interface is a table of **fixed absolute addresses** called through indirectly (`b_output` at `0x100018`, and six siblings at an 8-byte stride). This module wraps all seven as named constants rather than raw bytes, which mach 4.3.0's `call [imm]` form (mach#2398) made expressible, plus the `b_system` sub-functions: `output`, `input`, `system`, `timecounter`, `shutdown`, `nvs_read`, `nvs_write`, `net_tx`, `net_rx`. The register moves follow `libBareMetal.c`; the convention is **not** SysV (PR #400, mach#2396).
+- runtime: `std.runtime.bmos` — the `x86_64` entry point. BareMetal enters a program at the **first byte of a flat image** and expects it to `ret`, and it does two things a hosted loader would do that this kernel does not: it neither guarantees a 16-byte-aligned `RSP` nor zeroes `.bss`. `_start` is `#[naked]` (a compiler frame would sit between the alignment and the callee), parks the entry `RSP`, aligns it, calls `main(0, nil)`, restores and returns. The `.bss` half is handled in the compiler instead, by storing the flat image's zero-fill (mach#2402) (PR #400).
+- panic: a `bmos` arm — writes the message through `b_output`, then enters a **halt loop**. Deliberately neither of the obvious alternatives: a plain `ret` would make this the only panic arm on any platform that *does not terminate*, returning into the failed program and looking to an operator exactly like a clean exit; `b_system`'s `SHUTDOWN` terminates but powers the machine off, taking the message with it. The loop rather than a bare `hlt` is required because interrupts are enabled and `hlt` resumes on the next timer tick (PR #400).
+
+### Changed
+- Both new modules gate their **declarations**, not merely their imports. `mach test` compiles every module on a linux build even where nothing imports them, so an ungated `_start` is a second definition of linux's — `multiple definition of '_start'`. darwin and windows avoid this only by spelling their entry `start` / `mainCRTStartup`; `bmos` shares linux's spelling (PR #400).
+
 ## [0.19.0] - 2026-07-25
 
 Adds the constant-time crypto substrate, SHA-3, derive helpers, terminal/line input and the SIMD/float math follow-ups, and overhauls the string, io, filesystem, path and process surfaces. Panics now terminate deliberately on every supported OS instead of dying by trap.

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.19.0"
+version = "0.20.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/runtime.mach
+++ b/src/runtime.mach
@@ -25,6 +25,9 @@ $or ($mach.build.os == $mach.os.darwin) {
 $or ($mach.build.os == $mach.os.windows) {
     use std.runtime.windows;
 }
+$or ($mach.build.os == $mach.os.bmos) {
+    use std.runtime.bmos;
+}
 $or {
     $error("std.runtime: unsupported target");
 }

--- a/src/runtime/bmos.mach
+++ b/src/runtime/bmos.mach
@@ -1,0 +1,12 @@
+# bmos program entrypoint, dispatched by architecture
+#
+# BareMetal is an x86-64 kernel and has been ported to no other architecture, so
+# the dispatch has one arm; it is written as a dispatch anyway so a second one
+# would slot in beside it rather than replacing a bare import.
+
+$if ($mach.build.arch == $mach.arch.x86_64) {
+    use std.runtime.bmos.x86_64;
+}
+$or {
+    $error("std.runtime.bmos: bmos runs on x86-64 only");
+}

--- a/src/runtime/bmos/x86_64.mach
+++ b/src/runtime/bmos/x86_64.mach
@@ -1,0 +1,77 @@
+# x86-64 BareMetal (bmos) entrypoint
+# ---
+# provides `_start`, the first byte of a bmos flat image.
+#
+# BareMetal does not exec a program, it CALLS one: the monitor copies the image
+# verbatim to 0xFFFF800000000000 and does `call [ProgramLocation]`. So the entry
+# contract is a function call, not a process start, and it differs from the hosted
+# runtimes on every point:
+#
+#   - there is no initial stack layout to decode. no argc, no argv, no envp. the
+#     program is handed nothing, so `main` receives 0 and nil.
+#   - the program LEAVES BY RETURNING, back into the monitor's command loop. there
+#     is no exit syscall, and nothing reads `main`'s return value.
+#   - `_start` MUST BE THE FIRST FUNCTION EMITTED. a flat image carries no entry
+#     record, so execution begins at its base; the linker rejects an entry
+#     elsewhere ("raw: flat image must enter at its base address") rather than
+#     silently entering the wrong code. this module is the entry module, and
+#     `_start` is its first function, which is what puts it at offset 0.
+#
+# WHAT THE KERNEL DOES NOT DO, and this startup must:
+#
+#   - THE STACK IS NOT 16-BYTE ALIGNED AT ENTRY. BareMetal's own `crt0.c` aligns
+#     RSP before calling into C, with a comment naming the reason: an SSE
+#     instruction such as MOVAPS raises #GP on a misaligned stack. mach emits SSE
+#     for float and vector work, so without this a bmos program faults on its first
+#     aligned spill. `_start` therefore parks the entry RSP in RBP, aligns, and
+#     restores it before returning - the same shape crt0.c uses.
+#
+#   - `.bss` IS NOT ZEROED, AND THIS STARTUP CANNOT ZERO IT EITHER. see the note
+#     below; it is a compiler-side gap, not an omission here.
+
+# THE `.bss` GAP (unresolved, tracked in the PR that adds this module)
+#
+# A zero-initialized global lands in a byteless BSS section: the raw writer stores
+# only `filesz`, so those bytes are not in the image, and the BareMetal loader
+# copies only what the file holds. Whatever sat at that address before is what the
+# program reads. `raw.mach`'s own header says "a trailing zero-fill (memsz >
+# filesz, bss) is not written, since bare-metal startup zeroes bss itself" - but
+# the linker exports no `__bss_start` / `__bss_end`, so no startup written in Mach
+# can find the region. Referencing either is an "undefined symbol" error today.
+#
+# Until that is closed compiler-side, a bmos program must not rely on a
+# zero-initialized global. An explicitly initialized one is fine: it carries file
+# bytes and is inside the image.
+
+# THE DEFINITION IS OS-GATED, NOT JUST THE IMPORT. `_start` is the entry symbol on
+# linux as well as bmos, and this module is compiled on a linux build even though
+# nothing there imports it - so an ungated definition here is a second `_start` and
+# the link fails with "multiple definition of '_start'". The hosted runtimes do not
+# collide with each other only because darwin spells its entry `start` and windows
+# `mainCRTStartup`; bmos shares linux's spelling, so it must gate the DECLARATION.
+# Same discipline as `std.system.panic`, and for the same reason: what is gated is
+# what exists, not merely what is reached.
+$if ($mach.build.os == $mach.os.bmos) {
+    # `#[naked]` because the body IS the contract. A compiler-emitted prologue would
+    # run before the alignment below and an epilogue after the restore, so the frame
+    # this function hands `main` would not be the one it aligned - and unlike the
+    # hosted runtimes, whose `_start` ends in an exit syscall and never reaches its
+    # epilogue, this one returns. The `ret` is therefore ours to write.
+    #[naked]
+    #[symbol("_start")]
+    pub fun _start() {
+        asm x86_64 {
+            push rbp      # the monitor's frame pointer, restored before we return
+            mov rbp, rsp  # remember the entry stack pointer
+            and rsp, -16  # 16-align: BareMetal does not, and SSE faults without it
+
+            mov rdi, 0    # argc: a bmos program is handed no arguments
+            mov rsi, 0    # argv
+            call main
+
+            mov rsp, rbp  # undo the alignment adjustment
+            pop rbp
+            ret           # back into the monitor's command loop
+        }
+    }
+}

--- a/src/system/bmos.mach
+++ b/src/system/bmos.mach
@@ -1,0 +1,209 @@
+# the BareMetal kernel API
+#
+# BareMetal exposes its kernel through a table of SEVEN ABSOLUTE FUNCTION
+# POINTERS at 0x100010..0x100040, called indirectly (`call [0x100018]`), under a
+# register convention of its own. It is not a syscall interface and it is not
+# SysV, so every entry here is an inline-asm shim that moves arguments from the
+# Mach calling convention into BareMetal's and calls through the slot.
+#
+# WHY THIS IS NOT `std.system.os.bmos`. `std.system.os` forwards 125 names - files,
+# directories, processes, threads, sockets, DNS - and an implementation is expected
+# to supply all of them. BareMetal has none of that: it has block-level storage,
+# raw packet send/receive, console output, and a handful of `b_system`
+# sub-functions. Putting this module under `os/` would claim it satisfies an
+# interface it cannot, so it sits beside `std.system.os` as what it is: the
+# platform's own API. `std.print` and `std.filesystem` therefore do not work on
+# bmos yet; output goes through `output` below.
+#
+# The addresses are the kernel's, from `api/libBareMetal.asm`, and are fixed: the
+# call table is part of the ABI, not a symbol the linker resolves. Each shim's
+# register moves follow `api/libBareMetal.c`, the maintained C binding.
+
+use std.types.size.usize;
+
+# THE WHOLE SURFACE IS OS-GATED. This module is compiled on builds that do not
+# target bmos - a `mach test` on linux compiles it - and every entry below is an
+# `asm x86_64` block, which an aarch64 or riscv64 build cannot encode. Gating the
+# DECLARATIONS rather than each body keeps the rule in one place and says the true
+# thing: the BareMetal call table exists only when the target is BareMetal.
+$if ($mach.build.os == $mach.os.bmos) {
+
+    # the kernel's call table. these are the ADDRESSES OF SLOTS holding function
+    # pointers, not the functions - hence the indirection through memory at each call
+    pub val B_INPUT:     u64 = 0x100010;  # scan for console input
+    pub val B_OUTPUT:    u64 = 0x100018;  # write characters to standard output
+    pub val B_NET_TX:    u64 = 0x100020;  # transmit a packet
+    pub val B_NET_RX:    u64 = 0x100028;  # poll for a received packet
+    pub val B_NVS_READ:  u64 = 0x100030;  # read sectors from non-volatile storage
+    pub val B_NVS_WRITE: u64 = 0x100038;  # write sectors to non-volatile storage
+    pub val B_SYSTEM:    u64 = 0x100040;  # configure/query the system
+
+    # `b_system` sub-function indices, passed in its function argument
+    pub val SYS_TIMECOUNTER:  u64 = 0x00;  # nanoseconds since startup
+    pub val SYS_FREE_MEMORY:  u64 = 0x01;  # free memory
+    pub val SYS_SMP_ID:       u64 = 0x10;  # this core's id
+    pub val SYS_SMP_NUMCORES: u64 = 0x11;  # core count
+    pub val SYS_TSC:          u64 = 0x1F;  # timestamp counter
+    pub val SYS_SCREEN_X:     u64 = 0x21;  # screen width
+    pub val SYS_SCREEN_Y:     u64 = 0x22;  # screen height
+    pub val SYS_DELAY:        u64 = 0x72;  # delay by microseconds
+    pub val SYS_RESET:        u64 = 0x7D;  # reset
+    pub val SYS_REBOOT:       u64 = 0x7E;  # reboot
+    pub val SYS_SHUTDOWN:     u64 = 0x7F;  # power off
+
+    # write `len` characters from `msg` to standard output
+    #
+    # `b_output` takes RSI = message address, RCX = character count, and preserves
+    # every register. It writes exactly `len` bytes and does not stop at a NUL, so a
+    # caller passing a Mach `str` must pass its length rather than relying on
+    # termination.
+    # ---
+    # msg: the bytes to write
+    # len: how many bytes to write
+    pub fun output(msg: *u8, len: usize) {
+        asm x86_64 {
+            mov rsi, {msg}
+            mov rcx, {len}
+            call [0x100018]
+        }
+    }
+
+    # scan for a console keypress, without blocking
+    #
+    # `b_input` returns the ASCII code in AL, or 0 when no key is waiting, and
+    # preserves every other register. The high bytes of RAX are not part of the
+    # result, so the shim zero-extends AL rather than returning RAX.
+    # ---
+    # ret: the ASCII code, or 0 when no key is pending
+    pub fun input() u8 {
+        var c: u64 = 0;
+        asm x86_64 {
+            call [0x100010]
+            movzx rax, al
+            mov {c}, rax
+        }
+        ret c::u8;
+    }
+
+    # call a `b_system` sub-function
+    #
+    # `b_system` takes RCX = sub-function index, RAX = first variable, RDX = second,
+    # and returns its result in RAX. It is the kernel's catch-all: timers, core
+    # counts, screen geometry, and the reset / reboot / shutdown terminators all ride
+    # it.
+    # ---
+    # fn:   the sub-function index (one of SYS_*)
+    # var1: first argument, meaning depends on `fn`
+    # var2: second argument, meaning depends on `fn`
+    # ret:  the sub-function's result
+    pub fun system(fn: u64, var1: u64, var2: u64) u64 {
+        var out: u64 = 0;
+        asm x86_64 {
+            mov rcx, {fn}
+            mov rax, {var1}
+            mov rdx, {var2}
+            call [0x100040]
+            mov {out}, rax
+        }
+        ret out;
+    }
+
+    # nanoseconds elapsed since the machine started
+    # ---
+    # ret: the kernel's nanosecond counter
+    pub fun timecounter() u64 {
+        ret system(SYS_TIMECOUNTER, 0, 0);
+    }
+
+    # power the machine off
+    #
+    # Does not return. This is the machine's terminator, not a program's: a program
+    # that merely wants to finish returns from `main`, which hands control back to the
+    # monitor's command loop.
+    pub fun shutdown() {
+        system(SYS_SHUTDOWN, 0, 0);
+    }
+
+    # read `count` sectors from non-volatile storage into `buf`
+    #
+    # `b_nvs_read` takes RAX = starting sector, RCX = sector count, RDX = device, RDI
+    # = destination, and returns the number of sectors transferred in RCX. Sectors are
+    # 4096 bytes: `buf` must have room for `count * 4096`.
+    # ---
+    # buf:    destination, at least `count * 4096` bytes
+    # start:  first sector to read
+    # count:  how many sectors to read
+    # device: storage device index
+    # ret:    sectors actually read
+    pub fun nvs_read(buf: *u8, start: u64, count: u64, device: u64) u64 {
+        var got: u64 = 0;
+        asm x86_64 {
+            mov rax, {start}
+            mov rcx, {count}
+            mov rdx, {device}
+            mov rdi, {buf}
+            call [0x100030]
+            mov {got}, rcx
+        }
+        ret got;
+    }
+
+    # write `count` sectors from `buf` to non-volatile storage
+    #
+    # `b_nvs_write` takes RAX = starting sector, RCX = sector count, RDX = device, RSI
+    # = source, and returns the number of sectors transferred in RCX.
+    # ---
+    # buf:    source, at least `count * 4096` bytes
+    # start:  first sector to write
+    # count:  how many sectors to write
+    # device: storage device index
+    # ret:    sectors actually written
+    pub fun nvs_write(buf: *u8, start: u64, count: u64, device: u64) u64 {
+        var put: u64 = 0;
+        asm x86_64 {
+            mov rax, {start}
+            mov rcx, {count}
+            mov rdx, {device}
+            mov rsi, {buf}
+            call [0x100038]
+            mov {put}, rcx
+        }
+        ret put;
+    }
+
+    # transmit a packet on a network interface
+    #
+    # `b_net_tx` takes RSI = packet address, RCX = length, RDX = interface. The packet
+    # must carry its own 14-byte ethernet header; the kernel adds nothing.
+    # ---
+    # pkt:    the packet bytes, header included
+    # len:    packet length
+    # device: interface index
+    pub fun net_tx(pkt: *u8, len: usize, device: u64) {
+        asm x86_64 {
+            mov rsi, {pkt}
+            mov rcx, {len}
+            mov rdx, {device}
+            call [0x100020]
+        }
+    }
+
+    # poll a network interface for a received packet
+    #
+    # `b_net_rx` takes RDI = destination, RDX = interface, and returns the packet
+    # length in RCX - zero when nothing was waiting. It does not block.
+    # ---
+    # buf:    destination for the packet
+    # device: interface index
+    # ret:    packet length, or 0 when nothing was received
+    pub fun net_rx(buf: *u8, device: u64) usize {
+        var n: u64 = 0;
+        asm x86_64 {
+            mov rdi, {buf}
+            mov rdx, {device}
+            call [0x100028]
+            mov {n}, rcx
+        }
+        ret n::usize;
+    }
+}

--- a/src/system/panic.mach
+++ b/src/system/panic.mach
@@ -169,6 +169,54 @@ $or ($mach.build.os == $mach.os.windows) {
         ExitProcess(PANIC_EXIT);
     }
 }
+$or ($mach.build.os == $mach.os.bmos) {
+    # b_output(msg, len) then return to the monitor
+    #
+    # BareMetal is not a syscall interface: its API is a table of absolute function
+    # pointers at 0x100010..0x100040, called indirectly, under a convention of its
+    # own. `b_output` sits at 0x100018 and takes RSI = message address, RCX =
+    # character count, preserving every register. x86-64 only, because the kernel is.
+    #
+    # THE TERMINATOR IS A HALT LOOP, and the choice is not obvious - all three
+    # candidates were weighed against what the kernel actually does.
+    #
+    # A bmos program is `call`ed by the monitor (`call [ProgramLocation]`) and
+    # normally leaves by RETURNING to its command loop. So a `ret` here would be the
+    # one panic arm on any platform that DOES NOT TERMINATE: it returns to `panic`,
+    # which returns to its caller, and the failed program keeps running. Worse, to an
+    # operator it is indistinguishable from a clean exit.
+    #
+    # `b_system`'s SHUTDOWN (0x7F) does terminate, but it powers the machine off -
+    # taking the message off the screen with it and ending the session rather than
+    # reporting it. A panic exists to be read.
+    #
+    # `hlt` in a loop stops the program with the message on screen. The loop is
+    # required, not decorative: BareMetal runs with interrupts enabled, so a bare
+    # `hlt` resumes on the next timer tick and falls through into whatever follows.
+    # The cost is that the machine is wedged until reset - which is the honest state
+    # for an unrecoverable fault on a system with no memory protection.
+    #
+    # There is no exit status: nothing in BareMetal reads a program's return value,
+    # so `PANIC_EXIT` has no carrier here.
+    # ---
+    # msg: message bytes
+    # len: message length
+    fun panic_os(msg: *u8, len: usize) {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov rsi, {msg}
+                mov rcx, {len}
+                call [0x100018]   # b_output(RSI = message, RCX = count)
+            1:
+                hlt
+                jmp 1b
+            }
+        }
+        $or {
+            $error("std.system.panic: bmos runs on x86-64 only");
+        }
+    }
+}
 $or {
     $error("std.system.panic: unsupported operating system");
 }


### PR DESCRIPTION
Release merge for **mach-std 0.20.0** — `dev` → `main`.

**Do not squash.** Merge commit, then tag `v0.20.0` on `main`.

## What's in it

The **BareMetal arm** (PR #400, mach#2396). `bmos` became a mach target in 4.3.0; this is the standard library reaching it.

- **`std.system.bmos`** — the kernel's seven-slot call table at `0x100010..0x100040`, called indirectly rather than through syscalls, under a register convention that is not SysV. Deliberately **not** `std.system.os.bmos`: that interface forwards 125 names — files, processes, threads, sockets, DNS — and BareMetal has none of them, so a module under `os/` would claim an interface it cannot satisfy. `std.print` and `std.filesystem` consequently do not work on bmos yet.
- **`std.runtime.bmos`** — `_start`, `#[naked]`. BareMetal *calls* a program rather than exec'ing it, hands it nothing, takes it back by **return**, and does not 16-align the stack (which SSE requires, and which BareMetal's own `crt0.c` fixes for the same reason).
- **The `std.system.panic` bmos arm** — terminator is a **halt loop**, and the reasoning is the useful part: a `ret` would make this the one panic arm that *doesn't terminate* (it returns into the failed program, and looks to an operator exactly like a clean exit); SHUTDOWN terminates but powers off, taking the message with it. The loop is required rather than decorative — interrupts are enabled, so a bare `hlt` resumes on the next timer tick.

Both new modules gate their **declarations**, not just their imports, because `mach test` compiles them on a linux build where nothing imports them — an ungated `_start` is a second definition of linux's.

## Verification

- **Suites: 680 passed, 0 failed** — identical to `dev` before the bmos arm.
- **linux-arm64 cross-build** clean.
- On PR #400: **195/195 byte-identical** across all six hosted targets against pristine `dev`, and an 807-byte bmos image that prints through `b_output` and returns cleanly.

## Known gap, unchanged by this release

`std.print` on bmos needs the 125-name `std.system.os` surface. Three options were laid out on #400; the tiering question (a core every OS must provide plus optional capability modules) is with the owner. This release ships the smallest honest increment rather than ~120 stubs a proper tiering would delete.