### PR TITLE
fix(darwin): return path length on success in getcwd (#2327)

### DIFF
--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -966,7 +966,9 @@ pub fun cpu_count() i64 {
 # size: buffer capacity in bytes
 # ret:  length of path on success, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
-    ret syscall2(SYS___GETCWD, buf::usize, size);
+    val res: i64 = syscall2(SYS___GETCWD, buf::usize, size);
+    if (res < 0) { ret res; }
+    ret str_len(buf)::i64;
 }
 
 # look up an environment variable by name


### PR DESCRIPTION
Fixes getcwd on Darwin to return path length on success to match the cross-platform os.getcwd contract.