### PR TITLE
fix(runtime): select the darwin x86_64 entry contract from $mach.build.pie

### DIFF
--- a/src/runtime/darwin/x86_64.mach
+++ b/src/runtime/darwin/x86_64.mach
@@ -2,17 +2,31 @@
 #
 # provides `_start` (via `start`), the Mach-O entry point for x86_64 darwin executables.
 #
-# on entry, the kernel places the following on the stack:
-#   [rsp]     = argc
-#   [rsp+8]   = argv[0]
-#   [rsp+16]  = argv[1]
-#   ...
+# darwin has two entry contracts and the image's load command selects which one the
+# kernel/dyld uses, so this module carries both and picks at compile time:
+#
+#   LC_UNIXTHREAD (a non-PIE image): the kernel enters at the thread state's pc with
+#   the argument block on the stack -
+#     [rsp]    = argc
+#     [rsp+8]  = argv[0]
+#     ...
+#     argv + (argc+1)*8 = envp[0]
+#
+#   LC_MAIN (a `--pie` image): dyld CALLS the entry like a C `main`, so the arguments
+#   are in registers and `[rsp]` is dyld's return address -
+#     rdi = argc, rsi = argv, rdx = envp, rcx = apple
+#
+# the selector is `$mach.build.pie`, the same request bit the Mach-O writer gates the
+# LC_MAIN command on (`mach/src/lang/target/of/macho.mach` writes LC_MAIN when `pie`,
+# LC_UNIXTHREAD otherwise), so the two can never disagree.
 #
 # this entrypoint:
-#   1. extracts argc and argv from the initial stack
-#   2. aligns the stack to 16 bytes (required by SysV ABI before CALL)
-#   3. calls user-supplied `main(argc, argv)`
-#   4. exits via sys_exit with the return code from main
+#   1. captures argc/argv/envp for the runtime, per the selected contract
+#   2. aligns the stack to 16 bytes (the SysV call-boundary invariant: RSP is
+#      16-aligned at the CALL site, so the callee is entered with RSP%16==8)
+#   3. calls _rt_init to store envp into the OS layer
+#   4. calls user-supplied `main(argc, argv)`
+#   5. exits via sys_exit with the return code from main
 #
 # user code must define:
 #   #[symbol("main")]
@@ -40,31 +54,60 @@ fun _rt_init() {
     os._envp = _rt_envp;
 }
 
-#[symbol("start")]
-pub fun _start() {
-    asm x86_64 {
-        mov rax, rsp      # rax = initial stack pointer
-        mov rdi, [rax]    # argc -> rdi (1st argument)
-        lea rsi, [rax+8]  # argv -> rsi (2nd argument)
+$if ($mach.build.pie == 1) {
+    # LC_MAIN: dyld calls the entry with main's arguments in registers. `[rsp]` holds
+    # dyld's return address, and rsp is the post-CALL RSP%16==8, so the `and rsp, -16`
+    # below both discards that frame (this entry never returns) and restores the
+    # 16-alignment the next CALL boundary needs.
+    #[symbol("start")]
+    pub fun _start() {
+        asm x86_64 {
+            mov [_rt_argc], rdi    # argc
+            mov [_rt_argv], rsi    # argv
+            mov [_rt_envp], rdx    # envp
 
-        # envp = argv + (argc + 1) * 8
-        mov rcx, rdi
-        inc rcx
-        lea rcx, [rsi + rcx*8]
+            and rsp, -16      # 16-align rsp for the SysV call boundary
+            call _rt_init
 
-        mov [_rt_argc], rdi
-        mov [_rt_argv], rsi
-        mov [_rt_envp], rcx
+            mov rdi, [_rt_argc]
+            mov rsi, [_rt_argv]
+            call main
 
-        and rsp, -16      # 16-align rsp for the SysV call boundary
-        call _rt_init
+            mov rdi, rax      # exit code from main -> rdi (1st syscall arg)
+            mov rax, 0x2000001 # SYS_exit (BSD syscall class 2 + exit=1)
+            syscall
+        }
+    }
+}
+$or {
+    # LC_UNIXTHREAD: the kernel enters at the thread state's pc with rsp pointing at
+    # the argument block, so argc/argv are read off the stack and envp is derived.
+    #[symbol("start")]
+    pub fun _start() {
+        asm x86_64 {
+            mov rax, rsp      # rax = initial stack pointer
+            mov rdi, [rax]    # argc -> rdi (1st argument)
+            lea rsi, [rax+8]  # argv -> rsi (2nd argument)
 
-        mov rdi, [_rt_argc]
-        mov rsi, [_rt_argv]
-        call main
+            # envp = argv + (argc + 1) * 8
+            mov rcx, rdi
+            inc rcx
+            lea rcx, [rsi + rcx*8]
 
-        mov rdi, rax      # exit code from main -> rdi (1st syscall arg)
-        mov rax, 0x2000001 # SYS_exit (BSD syscall class 2 + exit=1)
-        syscall
+            mov [_rt_argc], rdi
+            mov [_rt_argv], rsi
+            mov [_rt_envp], rcx
+
+            and rsp, -16      # 16-align rsp for the SysV call boundary
+            call _rt_init
+
+            mov rdi, [_rt_argc]
+            mov rsi, [_rt_argv]
+            call main
+
+            mov rdi, rax      # exit code from main -> rdi (1st syscall arg)
+            mov rax, 0x2000001 # SYS_exit (BSD syscall class 2 + exit=1)
+            syscall
+        }
     }
 }


### PR DESCRIPTION
Fixes briar-systems/mach#2576 (cross-repo; GitHub will not auto-close it, so close on merge).

Fixture PR: briar-systems/mach#2581

## Problem

A `--pie` darwin x86_64 executable is emitted MH_PIE with an **LC_MAIN** entry (`mach/src/lang/target/of/macho.mach` writes LC_MAIN whenever the link request's `pie` bit is set). dyld CALLs an LC_MAIN entry like a C `main`: argc/argv/envp arrive in `rdi`/`rsi`/`rdx`, and `[rsp]` is dyld's return address.

`src/runtime/darwin/x86_64.mach` read the argument block off the stack — the **LC_UNIXTHREAD** convention — so under `--pie` it captured dyld's return address as `argc`, pointed `argv` one slot past it, and derived `_rt_envp` from both, corrupting every `std.process.env` read.

## Fix

Both contracts are real: a non-PIE darwin x86_64 image is still entered by the kernel with the block on the stack. So the entry carries both prologues and selects at **compile time** on `$mach.build.pie`.

That is not a heuristic: `$mach.build.pie` is the *same request bit* the Mach-O writer gates the LC_MAIN load command on, threaded to comptime by `mach/src/lang/driver/load.mach`. The entry command in the image and the code at the entry are therefore driven by one input and cannot disagree. It is also the established idiom in this repo — `src/runtime/linux/{x86_64,aarch64,riscv64}.mach` already gate their static-PIE self-relocation on the same fact.

`aarch64.mach` is untouched: arm64 darwin is always PIE/LC_MAIN and was already on the register convention (#324).

## Verification

Cross-built both layouts from linux against this branch and disassembled the emitted entry.

`--pie` → `MH_MAGIC_64 ... DYLDLINK TWOLEVEL PIE`, `cmd LC_MAIN`, `entryoff 33359`:

```
10000824f: movq %rdi, 0x14dca(%rip)     # argc
100008256: movq %rsi, 0x14dcb(%rip)     # argv
10000825d: movq %rdx, 0x14dcc(%rip)     # envp
100008264: andq $-0x10, %rsp
100008268: callq _rt_init
10000826d: movq 0x14dac(%rip), %rdi
100008274: movq 0x14dad(%rip), %rsi
10000827b: callq main
100008280: movq %rax, %rdi
100008283: movq $0x2000001, %rax
10000828a: syscall
```

The stores are RIP-relative, so they need no rebase under dyld's load bias.

no flags → `cmd LC_UNIXTHREAD`, `rip 0x10000724f`, prologue byte-identical to before:

```
mov  %rsp,%rax
mov  (%rax),%rdi
lea  0x8(%rax),%rsi
mov  %rdi,%rcx
inc  %rcx
lea  (%rsi,%rcx,8),%rcx
mov  %rdi,0x14db6(%rip)
...
```

### Stack alignment

Re-checked rather than carried over. At an LC_MAIN entry `rsp % 16 == 8` (post-CALL), so `and rsp, -16` restores the 16-alignment the next CALL boundary needs and discards dyld's frame — correct, and this entry never returns. Under LC_UNIXTHREAD the kernel's rsp is already 16-aligned and the mask is a no-op. One instruction is right for both.

### Native execution

The behavioural proof is the fixture pair in briar-systems/mach — they execute on the `macos-15-intel` leg. Cannot be run from a linux host.
