### PR TITLE
ci: cross-compile windows and darwin backends

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,25 @@ jobs:
 
       - name: RELRO re-protection contract (aarch64)
         run: bash test/relro/verify.sh mach linux-arm64 qemu-aarch64
+
+  cross-backends:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Install mach
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          mkdir -p /tmp/machdl
+          gh release download --repo briar-systems/mach \
+            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
+          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
+          cp /tmp/machdl/mach /usr/local/bin/mach
+          chmod +x /usr/local/bin/mach
+          mach info
+
+      - name: Cross-compile the windows and darwin backends
+        run: bash test/backends/verify.sh

--- a/test/backends/mach.toml
+++ b/test/backends/mach.toml
@@ -1,0 +1,36 @@
+[project]
+id = "backends"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.windows-x86_64]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = true
+simd = "scalarize"
+
+[artifact.backends]
+kind = "bin"
+entry = "main.mach"
+out = "bin/backends"
+targets = ["*"]
+link = []
+need = []
+
+[dep.std]
+path = "dep/std"

--- a/test/backends/src/main.mach
+++ b/test/backends/src/main.mach
@@ -1,0 +1,13 @@
+# cross-compile smoke test for the non-linux backends: imports the
+# top-level OS surface so the target-gated windows / darwin modules are
+# actually instantiated instead of skipped as dead $if branches. this
+# only needs to compile, not run.
+use std.runtime;
+use std.system.os;
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    var c: u8 = 'k'::u8;
+    os.write(1, ?c, 1);
+    ret 0;
+}

--- a/test/backends/verify.sh
+++ b/test/backends/verify.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# cross-compile a program that references std.system.os (and, through it,
+# std.runtime) for the windows and darwin targets, against this checkout's
+# std. proves the target-gated backend modules actually compile instead of
+# being skipped as dead $if branches -- see #426. compile only; nothing here
+# is run.
+#
+# usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -euo pipefail
+
+mach="${1:-mach}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# vendor this checkout's std as the path dependency (dep/std -> repo root).
+mkdir -p dep
+ln -sfn "$(cd ../.. && pwd)" dep/std
+
+targets=(windows-x86_64 darwin-x86_64 darwin-aarch64)
+
+for target in "${targets[@]}"; do
+    echo "cross-compiling the backend smoke test for $target with $mach"
+    rm -rf "out/$target"
+    log="$("$mach" build . --target "$target" --profile debug -vv 2>&1)" \
+        || { echo "$log" >&2; fail "$target failed to compile"; }
+
+    exe="$(find "out/$target" -name backends -type f -print -quit)"
+    [ -n "$exe" ] || fail "$target: no backends binary produced"
+
+    # confirm the backend's shared module was actually compiled, not skipped
+    # as a target-gated dead branch.
+    echo "$log" | grep -q "skipped .* target-gated modules" \
+        && fail "$target: target-gated modules were skipped"
+    echo "$log" | grep -q "std.system.os.${target%%-*}.shared" \
+        || fail "$target: std.system.os.${target%%-*}.shared was never compiled"
+
+    echo "OK: $target backend compiles ($exe)"
+done


### PR DESCRIPTION
## Summary
- CI only ever compiled the linux backend (`build`, `cross-arm64`, `cross-riscv64` are all linux), so a break in `src/system/os/windows/**` or `src/system/os/darwin/**` could go undetected — demonstrated concretely by PR #423.
- Add a `cross-backends` job that cross-compiles `test/backends/` (a small program importing `std.system.os`, which pulls in the target-gated backend) for `windows-x86_64`, `darwin-x86_64`, and `darwin-aarch64`.
- `test/backends/verify.sh` asserts the backend's `shared` module was actually compiled (not skipped as a dead `$if` branch) by grepping `mach build -vv` output, matching the failure mode called out in the issue.
- No new runner OS — cross-compile only, on `ubuntu-latest`, consistent with the existing `cross-arm64` / `cross-riscv64` jobs.

## Verification
Locally, against this branch:
- `mach build . --target windows-x86_64/darwin-x86_64/darwin-aarch64` all succeed and `-vv` output shows `std.system.os.<os>.shared` compiled (no "skipped ... target-gated modules" note).
- Deliberately broke `src/system/os/windows/shared.mach` (bad token) → `test/backends/verify.sh` failed as expected; restored → green.
- Deliberately broke `src/system/os/darwin/shared.mach` → both `darwin-x86_64` and `darwin-aarch64` failed as expected; restored → green.
- No backend was found to be currently broken.

Closes #426

## Test plan
- [x] `test/backends/verify.sh` cross-compiles all three targets locally
- [x] confirmed the job fails when `windows/shared.mach` is broken
- [x] confirmed the job fails when `darwin/shared.mach` is broken
- [ ] CI green on this PR