### PR TITLE
fix(os): windows rename replaces an existing destination

### DIFF
--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -403,6 +403,11 @@ pub fun remove_dir(p: Path) O.Option[str] {
 }
 
 # rename or move a file or directory
+#
+# An existing destination file is replaced, as POSIX rename does. Replacing an
+# existing *directory* is not portable: POSIX allows it when the destination is
+# an empty directory and windows refuses it outright, so callers should not rely
+# on it.
 # ---
 # from: source path
 # to:   destination path
@@ -807,6 +812,40 @@ test "std.filesystem.rename:moves_entry" {
     if (O.is_some[str](rename(from, to))) { bad = 1; }
     if (exists(from))                     { bad = 1; }
     if (!is_file(to))                     { bad = 1; }
+
+    remove_file(to);
+    remove_file(from);
+    ret bad;
+}
+
+# rename replaces an existing destination file rather than refusing
+#
+# the POSIX parity the docstring promises. windows needed MoveFileEx with
+# REPLACE_EXISTING for this: bare MoveFile fails whenever the destination
+# exists, which is the common case for write-a-temp-then-rename (#414)
+test "std.filesystem.rename:replaces_existing_destination" {
+    val from: Path = "/tmp/mach_std_fs_ren_r_a";
+    val to:   Path = "/tmp/mach_std_fs_ren_r_b";
+    if (O.is_some[str](write_bytes(from, "new", 3, 0o644))) { ret 1; }
+    if (O.is_some[str](write_bytes(to,   "old", 3, 0o644))) { remove_file(from); ret 1; }
+
+    var bad: i32 = 0;
+    if (O.is_some[str](rename(from, to))) { bad = 1; }
+    if (exists(from))                     { bad = 1; }
+    if (!is_file(to))                     { bad = 1; }
+
+    # the destination carries the source's bytes, not the ones it had
+    var scratch: [3]u8;
+    val ro: R.Result[File, str] = open(to);
+    if (R.is_err[File, str](ro)) { bad = 1; }
+    or {
+        val f: File = R.unwrap_ok[File, str](ro);
+        val rr: R.Result[usize, str] = read(f, ?scratch[0], 3);
+        if (R.is_err[usize, str](rr))         { bad = 1; }
+        or (R.unwrap_ok[usize, str](rr) != 3) { bad = 1; }
+        or (scratch[0] != 'n' || scratch[1] != 'e' || scratch[2] != 'w') { bad = 1; }
+        close(f);
+    }
 
     remove_file(to);
     remove_file(from);

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -49,6 +49,10 @@ val FILE_ATTRIBUTE_HIDDEN:    u32 = 0x02;
 val FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
 val FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x02000000;
 
+# MoveFileEx flags
+val MOVEFILE_REPLACE_EXISTING: u32 = 0x01;
+val MOVEFILE_WRITE_THROUGH:    u32 = 0x08;
+
 # invalid handle
 val INVALID_HANDLE_VALUE: isize = -1;
 
@@ -233,7 +237,7 @@ ext fun FlushViewOfFile(p0: ptr, p1: usize) i32;
 #[library("kernel32.dll")]
 ext fun DeleteFileA(p0: *u8) i32;
 #[library("kernel32.dll")]
-ext fun MoveFileA(p0: *u8, p1: *u8) i32;
+ext fun MoveFileExA(p0: *u8, p1: *u8, p2: u32) i32;
 #[library("kernel32.dll")]
 ext fun CreateDirectoryA(p0: *u8, p1: ptr) i32;
 #[library("kernel32.dll")]
@@ -1226,8 +1230,19 @@ pub fun unlink(dirfd: i32, path: *u8, flags: i32) i64 {
 }
 
 # stub: olddir/newdir are ignored, paths must be absolute or relative to cwd
+#
+# MoveFileEx, not MoveFile: the bare form refuses an existing destination, which
+# breaks the write-a-temp-then-rename-into-place pattern this call exists to
+# serve and contradicts fs.rename's POSIX-parity contract. REPLACE_EXISTING
+# restores that, and WRITE_THROUGH matches the durability a caller renaming for
+# atomicity expects. COPY_ALLOWED is deliberately NOT set: POSIX rename fails
+# across devices rather than silently copying, and so does this.
+#
+# one divergence remains and cannot be closed here: REPLACE_EXISTING does not
+# apply to a directory destination, so renaming a directory onto an existing
+# empty directory still fails where POSIX succeeds.
 pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
-    if (MoveFileA(oldpath, newpath) == 0) {
+    if (MoveFileExA(oldpath, newpath, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0) {
         ret last_error();
     }
     ret 0;


### PR DESCRIPTION
`std.system.os.rename` on windows wrapped `MoveFileA`, which does not replace an existing destination. It fails with `ERROR_ALREADY_EXISTS` whenever `newpath` exists, contradicting `fs.rename`'s own docstring and diverging from linux and darwin, which both call POSIX `rename(2)`.

That breaks the write-a-temp-then-rename-into-place pattern for exactly the case it is used in: the destination already existing. mach#2475 hit this across every writer that rebuilds an existing output, and mach currently carries a remove-then-retry fallback to work around it.

## Change

`MoveFileExA` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH`.

- `REPLACE_EXISTING` restores the documented POSIX-parity semantics.
- `WRITE_THROUGH` matches the durability a caller renaming for atomicity expects, which is the whole reason to reach for rename rather than copy.
- `COPY_ALLOWED` is deliberately **not** set. POSIX rename fails across devices rather than silently copying, and so should this. Setting it would trade a loud `EXDEV` for a silent non-atomic copy, which is the opposite of what a caller renaming for atomicity wants.

## One divergence remains, and it is now documented rather than implied

`MOVEFILE_REPLACE_EXISTING` does not apply to a directory destination, so renaming a directory onto an existing empty directory still fails on windows where POSIX succeeds. There is no MoveFileEx flag for it. `fs.rename`'s docstring now says so, instead of promising parity it cannot deliver.

## Test

`std.filesystem.rename:replaces_existing_destination` writes both paths, renames, and asserts the source is gone, the destination exists, and the destination carries the **source's** bytes rather than the ones it had. That last assertion is the one that matters: without it a test could pass against a rename that quietly did nothing.

The fix itself is windows-only, so on linux the new test passes before and after. To show it is not vacuous, `fs.rename` was temporarily given `MoveFileA`'s semantics on this host (refuse when the destination exists) and the test fails as it should:

```
  FAIL  std.filesystem.rename:replaces_existing_destination  ./src/filesystem.mach:827  (exit 1)
1 passed, 1 failed, 2 total
```

Restored afterwards. The real windows behaviour is settled by the windows CI leg, not by this machine, and I have said so rather than claiming coverage I did not get.

`mach test .` green (762/762) on linux.

Closes #414
