### PR TITLE
fix(os): darwin getcwd honors the caller's buffer capacity

### DIFF
--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -74,6 +74,9 @@ val SIGABRT: i32 = 6;
 
 # fcntl flags
 val F_GETPATH:  usize = 50;
+# XNU writes a F_GETPATH result of up to this many bytes whatever the caller
+# sized its destination, so a F_GETPATH destination is never smaller
+val MAXPATHLEN: usize = 1024;
 
 # mmap protection
 val PROT_NONE:  i32 = 0;
@@ -219,6 +222,7 @@ pub val EROFS:     i64 = -30;
 pub val EPIPE:     i64 = -32;
 pub val ENOTEMPTY: i64 = -66;
 pub val ENOTSUP:   i64 = -45;
+pub val ERANGE:    i64 = -34;
 
 pub val EINTR_MAX_RETRIES: usize = 8;
 
@@ -1022,17 +1026,70 @@ pub fun cpu_count() i64 {
 }
 
 # get the current working directory
+#
+# F_GETPATH carries no capacity and XNU writes up to MAXPATHLEN bytes into the
+# destination whatever the caller sized it, so it must never be handed a buffer
+# that could be smaller. the path is read into a MAXPATHLEN scratch and copied
+# out only when it fits, which is what makes `size` mean what the signature says
+# it means. a path too long for the caller is ERANGE, as it is on linux (#409).
 # ---
 # buf:  destination buffer
-# size: buffer capacity in bytes
+# size: buffer capacity in bytes, including room for the terminator
 # ret:  length of path on success, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
+    var scratch: [MAXPATHLEN]u8;
     val fd: i64 = syscall2(SYS_OPEN, "."::usize, O_RDONLY::u32::usize);
     if (fd < 0) { ret fd; }
-    val res: i64 = syscall3(SYS_FCNTL, fd::usize, F_GETPATH, buf::usize);
+    val res: i64 = syscall3(SYS_FCNTL, fd::usize, F_GETPATH, (?scratch[0])::usize);
     syscall1(SYS_CLOSE, fd::usize);
     if (res < 0) { ret res; }
-    ret str_len(buf)::i64;
+
+    val n: usize = str_len(?scratch[0]);
+    if (n + 1 > size) { ret ERANGE; }
+    var i: usize = 0;
+    for (i < n) {
+        buf[i] = scratch[i];
+        i = i + 1;
+    }
+    buf[n] = 0;
+    ret n::i64;
+}
+
+# a destination too small for the path is refused rather than overrun
+#
+# the regression for #409: F_GETPATH used to be pointed straight at the caller's
+# buffer, and it takes no capacity, so XNU wrote up to MAXPATHLEN bytes into a
+# buffer the caller had declared much smaller
+test "std.system.os.getcwd:small_buffer_is_refused_not_overrun" {
+    val cap:  usize = 8;
+    var slab: [64]u8;
+    var i: usize = 0;
+    for (i < 64) {
+        slab[i] = 0xAB;
+        i = i + 1;
+    }
+
+    # shorter than any real absolute cwd, so this always takes the refusal path
+    if (getcwd(?slab[0], cap) != ERANGE) { ret 1; }
+
+    # nothing past the capacity the caller declared was touched
+    i = cap;
+    for (i < 64) {
+        if (slab[i] != 0xAB) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a buffer with room reports the path length and null-terminates at it
+test "std.system.os.getcwd:sufficient_buffer_reports_length" {
+    var buf: [1024]u8;
+    val n: i64 = getcwd(?buf[0], 1024);
+    if (n < 1)            { ret 1; }
+    if (buf[0] != '/')    { ret 1; }
+    if (buf[n::usize] != 0) { ret 1; }
+    if (str_len(?buf[0]) != n::usize) { ret 1; }
+    ret 0;
 }
 
 # look up an environment variable by name

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -411,6 +411,7 @@ pub val EROFS:     i64 = -30;
 pub val EPIPE:     i64 = -32;
 pub val ENOTEMPTY: i64 = -39;
 pub val ENOTSUP:   i64 = -95;
+pub val ERANGE:    i64 = -34;
 
 pub val EINTR_MAX_RETRIES: usize = 8;
 
@@ -1711,6 +1712,50 @@ pub fun cpu_count() i64 {
 # ret:  length of path on success, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
     ret syscall2(SYS_GETCWD, buf::usize, size);
+}
+
+# the getcwd capacity contract, pinned on a per-PR runner
+#
+# darwin had to reimplement this by hand because F_GETPATH carries no capacity
+# (#409), so the contract it has to match is asserted here too rather than only
+# on the darwin leg: `size` is the destination's capacity including the
+# terminator, a path that does not fit is ERANGE, and nothing past the declared
+# capacity is written.
+test "std.system.os.getcwd:small_buffer_is_refused_not_overrun" {
+    val cap:  usize = 8;
+    var slab: [64]u8;
+    var i: usize = 0;
+    for (i < 64) {
+        slab[i] = 0xAB;
+        i = i + 1;
+    }
+
+    # shorter than any real absolute cwd, so this always takes the refusal path
+    if (getcwd(?slab[0], cap) != ERANGE) { ret 1; }
+
+    # nothing past the capacity the caller declared was touched
+    i = cap;
+    for (i < 64) {
+        if (slab[i] != 0xAB) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a buffer with room writes an absolute, null-terminated path
+#
+# the RETURN value is deliberately not asserted here: linux returns the length
+# including the terminator (the raw syscall's contract) while darwin and windows
+# return it excluding one, so "length of path" means two different things across
+# this layer. that divergence is its own defect and is not settled by this test.
+test "std.system.os.getcwd:sufficient_buffer_writes_absolute_path" {
+    var buf: [1024]u8;
+    val n: i64 = getcwd(?buf[0], 1024);
+    if (n < 1)                       { ret 1; }
+    if (buf[0] != '/')               { ret 1; }
+    if (str_len(?buf[0]) < 1)        { ret 1; }
+    if (buf[str_len(?buf[0])] != 0)  { ret 1; }
+    ret 0;
 }
 
 # look up an environment variable by name


### PR DESCRIPTION
`getcwd(buf, size)` on darwin called `fcntl(F_GETPATH, buf)` and never looked at `size`. XNU receives no capacity for `F_GETPATH` and writes up to `MAXPATHLEN` bytes into the destination regardless, so any caller supplying a smaller buffer could be overrun, even though the public signature documents `size` as the capacity.

`std.process.env.current_dir` supplies 4096 bytes, so nothing in tree was hitting it. A direct caller could.

## Change

Read `F_GETPATH` into a `MAXPATHLEN` scratch, measure the result, and copy out only when it fits. A path too long for the destination is `ERANGE`, which is what linux's `getcwd(2)` already returns for the same condition, so the two agree on the refusal.

`ERANGE` was not previously defined in the darwin errno block; it is now, alongside the rest.

## Tests

Two on darwin, in `src/system/os/darwin/shared.mach`:

- `getcwd:small_buffer_is_refused_not_overrun` fills a 64-byte slab with a sentinel, declares only 8 bytes of it, and asserts the call returns `ERANGE` and that **no byte past the declared capacity was touched**. That last assertion is the actual safety property, and it is the one the old code violated.
- `getcwd:sufficient_buffer_reports_length` asserts an absolute, null-terminated path whose reported length matches its `str_len`.

The os layer is target-gated, so those only run on a darwin leg. To get the contract onto a per-PR runner as well, the same capacity assertion is added to `src/system/os/linux/shared.mach`, where it already passes. That gives darwin a spec to match rather than leaving the rule asserted only where it is hardest to run.

`test/backends/verify.sh` cross-compiles the darwin x86_64 and aarch64 backends clean, which is what proves the changed module actually builds from this host. It compiles rather than runs, so the darwin test bodies themselves are settled by the darwin leg, not by this machine.

`mach test .` green (763/763) on linux.

## Two divergences found while doing this, not fixed here

Both are in this same layer and neither is #409, so they are being filed separately rather than smuggled in:

1. **`getcwd`'s return value means different things per platform.** Linux returns the length *including* the terminator (the raw syscall's contract), while darwin and windows return it *excluding* one. The docstring says "length of path on success" on all three. `current_dir` only tests `n <= 0 || n >= cap` so it never noticed. The linux length test here deliberately asserts only the uncontested part (absolute, null-terminated) and says so in a comment, rather than enshrining one side of the divergence.

2. **Windows has the same class of bug as this issue, with a different shape.** `GetCurrentDirectoryA` returns the *required* size when the buffer is too small and writes nothing, so windows reports a positive value larger than `size` where linux and darwin both report `ERANGE`. Not an overrun, but a third contract for the same call.

Closes #409
