### PR TITLE
fix(os): one getcwd contract across the three backends

### DIFF
--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -1706,12 +1706,18 @@ pub fun cpu_count() i64 {
 }
 
 # get the current working directory
+#
+# the raw syscall returns the length INCLUDING the terminator; this layer
+# reports the path length the way darwin and windows do, so "length of path"
+# means one thing across the three backends (#432).
 # ---
 # buf:  destination buffer
-# size: buffer capacity in bytes
-# ret:  length of path on success, or negative errno
+# size: buffer capacity in bytes, including room for the terminator
+# ret:  length of the path, excluding the terminator, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
-    ret syscall2(SYS_GETCWD, buf::usize, size);
+    val n: i64 = syscall2(SYS_GETCWD, buf::usize, size);
+    if (n < 1) { ret n; }
+    ret n - 1;
 }
 
 # the getcwd capacity contract, pinned on a per-PR runner
@@ -1742,19 +1748,14 @@ test "std.system.os.getcwd:small_buffer_is_refused_not_overrun" {
     ret 0;
 }
 
-# a buffer with room writes an absolute, null-terminated path
-#
-# the RETURN value is deliberately not asserted here: linux returns the length
-# including the terminator (the raw syscall's contract) while darwin and windows
-# return it excluding one, so "length of path" means two different things across
-# this layer. that divergence is its own defect and is not settled by this test.
-test "std.system.os.getcwd:sufficient_buffer_writes_absolute_path" {
+# a buffer with room reports the path length and null-terminates at it
+test "std.system.os.getcwd:sufficient_buffer_reports_length" {
     var buf: [1024]u8;
     val n: i64 = getcwd(?buf[0], 1024);
-    if (n < 1)                       { ret 1; }
-    if (buf[0] != '/')               { ret 1; }
-    if (str_len(?buf[0]) < 1)        { ret 1; }
-    if (buf[str_len(?buf[0])] != 0)  { ret 1; }
+    if (n < 1)                        { ret 1; }
+    if (buf[0] != '/')                { ret 1; }
+    if (buf[n::usize] != 0)           { ret 1; }
+    if (str_len(?buf[0]) != n::usize) { ret 1; }
     ret 0;
 }
 

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -517,6 +517,7 @@ pub val EROFS:     i64 = -30;
 pub val EPIPE:     i64 = -32;
 pub val ENOTEMPTY: i64 = -39;
 pub val ENOTSUP:   i64 = -95;
+pub val ERANGE:    i64 = -34;
 
 pub val EINTR_MAX_RETRIES: usize = 8;
 
@@ -1953,16 +1954,59 @@ pub fun cpu_count() i64 {
 }
 
 # get the current working directory
+#
+# GetCurrentDirectoryA overloads its return: on success it is the length
+# written, and when the destination is too small it is the size required
+# INCLUDING the terminator, with nothing written. Passing both through as a
+# success let a caller read an untouched buffer and believe it held a path, so
+# the too-small case is reported as ERANGE the way linux and darwin report it.
 # ---
 # buf:  destination buffer
-# size: buffer capacity in bytes
-# ret:  length of path on success, or negative errno
+# size: buffer capacity in bytes, including room for the terminator
+# ret:  length of the path, excluding the terminator, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
     val len: u32 = GetCurrentDirectoryA(size::u32, buf);
-    if (len == 0) {
-        ret last_error();
-    }
+    if (len == 0)           { ret last_error(); }
+    if (len::usize >= size) { ret ERANGE; }
     ret len::i64;
+}
+
+# the getcwd capacity contract, pinned on every backend
+#
+# GetCurrentDirectoryA reports the required size rather than failing when the
+# destination is too small, so windows used to return a positive value for a
+# call that wrote no path (#433). the rule all three backends now hold: size is
+# the capacity including the terminator, a path that does not fit is ERANGE,
+# and nothing past the declared capacity is written.
+test "std.system.os.getcwd:small_buffer_is_refused_not_overrun" {
+    val cap:  usize = 4;
+    var slab: [64]u8;
+    var i: usize = 0;
+    for (i < 64) {
+        slab[i] = 0xAB;
+        i = i + 1;
+    }
+
+    # shorter than any real absolute path, so this always takes the refusal path
+    if (getcwd(?slab[0], cap) != ERANGE) { ret 1; }
+
+    # nothing past the capacity the caller declared was touched
+    i = cap;
+    for (i < 64) {
+        if (slab[i] != 0xAB) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a buffer with room reports the path length and null-terminates at it
+test "std.system.os.getcwd:sufficient_buffer_reports_length" {
+    var buf: [1024]u8;
+    val n: i64 = getcwd(?buf[0], 1024);
+    if (n < 1)                        { ret 1; }
+    if (buf[n::usize] != 0)           { ret 1; }
+    if (str_len(?buf[0]) != n::usize) { ret 1; }
+    ret 0;
 }
 
 # look up an environment variable by name


### PR DESCRIPTION
Both issues are the same call disagreeing with itself across backends, and fixing either one alone leaves `getcwd`'s docstring false, so they land together.

## #432 — the return value counted different things

| backend | was | now |
|---|---|---|
| linux | `str_len(path) + 1`, the raw syscall's contract | `str_len(path)` |
| darwin | `str_len(path)` | unchanged |
| windows | `str_len(path)` | unchanged |

The docstring said "length of path on success" everywhere. Linux was the outlier because its wrapper was a bare `syscall2(SYS_GETCWD, ...)` passing the kernel's include-the-NUL count straight through. Two of three backends already did the documented thing, so linux moves.

## #433 — windows reported success for a call that wrote nothing

`GetCurrentDirectoryA` overloads its return: the length written on success, or the size *required* when the buffer is too small, with nothing written. The wrapper passed both through as non-negative, so a caller that did not separately compare the result against its own capacity would read an untouched buffer and believe it held a path. It is now `ERANGE`, matching linux and darwin. `ERANGE` was not defined in the windows errno block and is now.

`std.process.env.current_dir` was safe by accident here, because it tests `n::usize >= 4096` against its own buffer size. That is the caller defending itself against the API rather than the API being honest, and it only worked because that one caller knew to.

## No caller changes

Three call sites read `os.getcwd`: `env.cwd_raw`, and two in `exec.mach` that only test `< 0`. `current_dir` tolerates either convention. Nothing needed adjusting, which is also why this drifted unnoticed for so long.

## Tests

Both assertions now live on **all three** backends rather than only the one they were written against, which is the acceptance criterion for #433 and what stops this diverging again:

- `getcwd:small_buffer_is_refused_not_overrun` — sentinel-filled slab, small declared capacity, asserts `ERANGE` and that no byte past the declared capacity was touched.
- `getcwd:sufficient_buffer_reports_length` — asserts `str_len(buf) == ret` and that the buffer is terminated at `ret`.

The linux length test was added in #409's PR in a deliberately weakened form, with a comment saying the return value was not asserted because the backends disagreed. That weakening and its comment come out here, which is what the issue asked for.

Mutation check on the linux change, with the assertion in place:

```
--- with the linux fix reverted:
  std.system.os.getcwd:sufficient_buffer_reports_length  ./src/system/os/linux/shared.mach:1751  (exit 1)
1 passed, 1 failed
--- restored:
2 passed, 0 failed
```

## What is settled where

`mach test .` green (764/764) on linux, and `test/backends/verify.sh` cross-compiles the windows, darwin x86_64 and darwin aarch64 backends clean. The os layer is target-gated, so the windows and darwin **test bodies** run on their own CI legs, not on this host. Their assertions are stated here; the legs settle them.

Closes #432
Closes #433
