### PR TITLE
chore(release): 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-08-07
+
+Settles the OS-layer filesystem contracts that differed silently between backends. Every fix here is a case where the public docstring described one behaviour and at least one backend did another, and no caller in tree happened to notice.
+
+### Fixed
+- system: **`os.rename` on windows now replaces an existing destination.** It wrapped `MoveFileA`, which fails with `ERROR_ALREADY_EXISTS` whenever the destination exists, contradicting `fs.rename`'s own docstring and diverging from linux and darwin, which both call POSIX `rename(2)`. That broke the write-a-temp-then-rename-into-place pattern in exactly the case it is used in, and mach#2475 hit it across every writer that rebuilds an existing output. Now `MoveFileExA` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH`. `MOVEFILE_COPY_ALLOWED` is deliberately not set, because POSIX `rename` fails across devices rather than silently copying and so should this. One divergence remains and is now documented rather than implied: `REPLACE_EXISTING` does not apply to a directory destination, so renaming a directory onto an existing empty directory still fails on windows where POSIX succeeds (#414).
+- system: **`os.getcwd` on darwin no longer overruns a caller buffer.** It called `fcntl(F_GETPATH, buf)` and never looked at `size`. XNU receives no capacity for `F_GETPATH` and writes up to `MAXPATHLEN` bytes into the destination regardless, so any caller supplying a smaller buffer could be overrun even though the signature documents `size` as the capacity. The path is now read into a `MAXPATHLEN` scratch and copied out only when it fits, with a path too long for the destination reported as `ERANGE` the way linux reports it. `std.process.env.current_dir` supplies 4096 bytes, so nothing in tree was reaching it (#409).
+- system: **`os.getcwd`'s return value meant two different things.** Linux passed the raw syscall's length through, which includes the terminator, while darwin and windows reported the string length. The docstring said "length of path" on all three. Linux now reports the path length, matching the other two and the wording. `current_dir` only tested `n <= 0 || n >= cap`, which is why an off-by-one in a documented length went unnoticed (#432).
+- system: **`os.getcwd` on windows reported success for a call that wrote nothing.** `GetCurrentDirectoryA` overloads its return with the size *required* when the destination is too small, writing nothing, and the wrapper passed that through as a non-negative result. A caller that did not separately compare the result against its own capacity would read an untouched buffer and believe it held a path. It is now `ERANGE`, matching linux and darwin (#433).
+
+### Changed
+- `ERANGE` is now defined in the darwin and windows errno blocks, alongside linux's.
+- `fs.rename`'s docstring states that an existing destination file is replaced, and that replacing an existing *directory* is not portable.
+
+### Tests
+- The `getcwd` capacity and length assertions are carried by **all three backends** rather than only the one they were written against. The os layer is target-gated, so each backend's tests run on its own CI leg; stating the same rule three times is what stops the three implementations diverging again, which is how every defect in this release arose.
+- `fs.rename:replaces_existing_destination` asserts the destination carries the **source's** bytes rather than merely existing, so it cannot pass against a rename that quietly did nothing.
+
 ## [0.23.0] - 2026-08-07
 
 Adds the shell-execution and working-directory half of the process surface, so a consumer never hand-assembles a shell invocation again, and fixes the darwin x86_64 entry under `--pie`.

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.23.0"
+version = "0.24.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -403,6 +403,11 @@ pub fun remove_dir(p: Path) O.Option[str] {
 }
 
 # rename or move a file or directory
+#
+# An existing destination file is replaced, as POSIX rename does. Replacing an
+# existing *directory* is not portable: POSIX allows it when the destination is
+# an empty directory and windows refuses it outright, so callers should not rely
+# on it.
 # ---
 # from: source path
 # to:   destination path
@@ -807,6 +812,40 @@ test "std.filesystem.rename:moves_entry" {
     if (O.is_some[str](rename(from, to))) { bad = 1; }
     if (exists(from))                     { bad = 1; }
     if (!is_file(to))                     { bad = 1; }
+
+    remove_file(to);
+    remove_file(from);
+    ret bad;
+}
+
+# rename replaces an existing destination file rather than refusing
+#
+# the POSIX parity the docstring promises. windows needed MoveFileEx with
+# REPLACE_EXISTING for this: bare MoveFile fails whenever the destination
+# exists, which is the common case for write-a-temp-then-rename (#414)
+test "std.filesystem.rename:replaces_existing_destination" {
+    val from: Path = "/tmp/mach_std_fs_ren_r_a";
+    val to:   Path = "/tmp/mach_std_fs_ren_r_b";
+    if (O.is_some[str](write_bytes(from, "new", 3, 0o644))) { ret 1; }
+    if (O.is_some[str](write_bytes(to,   "old", 3, 0o644))) { remove_file(from); ret 1; }
+
+    var bad: i32 = 0;
+    if (O.is_some[str](rename(from, to))) { bad = 1; }
+    if (exists(from))                     { bad = 1; }
+    if (!is_file(to))                     { bad = 1; }
+
+    # the destination carries the source's bytes, not the ones it had
+    var scratch: [3]u8;
+    val ro: R.Result[File, str] = open(to);
+    if (R.is_err[File, str](ro)) { bad = 1; }
+    or {
+        val f: File = R.unwrap_ok[File, str](ro);
+        val rr: R.Result[usize, str] = read(f, ?scratch[0], 3);
+        if (R.is_err[usize, str](rr))         { bad = 1; }
+        or (R.unwrap_ok[usize, str](rr) != 3) { bad = 1; }
+        or (scratch[0] != 'n' || scratch[1] != 'e' || scratch[2] != 'w') { bad = 1; }
+        close(f);
+    }
 
     remove_file(to);
     remove_file(from);

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -74,6 +74,9 @@ val SIGABRT: i32 = 6;
 
 # fcntl flags
 val F_GETPATH:  usize = 50;
+# XNU writes a F_GETPATH result of up to this many bytes whatever the caller
+# sized its destination, so a F_GETPATH destination is never smaller
+val MAXPATHLEN: usize = 1024;
 
 # mmap protection
 val PROT_NONE:  i32 = 0;
@@ -219,6 +222,7 @@ pub val EROFS:     i64 = -30;
 pub val EPIPE:     i64 = -32;
 pub val ENOTEMPTY: i64 = -66;
 pub val ENOTSUP:   i64 = -45;
+pub val ERANGE:    i64 = -34;
 
 pub val EINTR_MAX_RETRIES: usize = 8;
 
@@ -1022,17 +1026,70 @@ pub fun cpu_count() i64 {
 }
 
 # get the current working directory
+#
+# F_GETPATH carries no capacity and XNU writes up to MAXPATHLEN bytes into the
+# destination whatever the caller sized it, so it must never be handed a buffer
+# that could be smaller. the path is read into a MAXPATHLEN scratch and copied
+# out only when it fits, which is what makes `size` mean what the signature says
+# it means. a path too long for the caller is ERANGE, as it is on linux (#409).
 # ---
 # buf:  destination buffer
-# size: buffer capacity in bytes
+# size: buffer capacity in bytes, including room for the terminator
 # ret:  length of path on success, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
+    var scratch: [MAXPATHLEN]u8;
     val fd: i64 = syscall2(SYS_OPEN, "."::usize, O_RDONLY::u32::usize);
     if (fd < 0) { ret fd; }
-    val res: i64 = syscall3(SYS_FCNTL, fd::usize, F_GETPATH, buf::usize);
+    val res: i64 = syscall3(SYS_FCNTL, fd::usize, F_GETPATH, (?scratch[0])::usize);
     syscall1(SYS_CLOSE, fd::usize);
     if (res < 0) { ret res; }
-    ret str_len(buf)::i64;
+
+    val n: usize = str_len(?scratch[0]);
+    if (n + 1 > size) { ret ERANGE; }
+    var i: usize = 0;
+    for (i < n) {
+        buf[i] = scratch[i];
+        i = i + 1;
+    }
+    buf[n] = 0;
+    ret n::i64;
+}
+
+# a destination too small for the path is refused rather than overrun
+#
+# the regression for #409: F_GETPATH used to be pointed straight at the caller's
+# buffer, and it takes no capacity, so XNU wrote up to MAXPATHLEN bytes into a
+# buffer the caller had declared much smaller
+test "std.system.os.getcwd:small_buffer_is_refused_not_overrun" {
+    val cap:  usize = 8;
+    var slab: [64]u8;
+    var i: usize = 0;
+    for (i < 64) {
+        slab[i] = 0xAB;
+        i = i + 1;
+    }
+
+    # shorter than any real absolute cwd, so this always takes the refusal path
+    if (getcwd(?slab[0], cap) != ERANGE) { ret 1; }
+
+    # nothing past the capacity the caller declared was touched
+    i = cap;
+    for (i < 64) {
+        if (slab[i] != 0xAB) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a buffer with room reports the path length and null-terminates at it
+test "std.system.os.getcwd:sufficient_buffer_reports_length" {
+    var buf: [1024]u8;
+    val n: i64 = getcwd(?buf[0], 1024);
+    if (n < 1)            { ret 1; }
+    if (buf[0] != '/')    { ret 1; }
+    if (buf[n::usize] != 0) { ret 1; }
+    if (str_len(?buf[0]) != n::usize) { ret 1; }
+    ret 0;
 }
 
 # look up an environment variable by name

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -1706,12 +1706,18 @@ pub fun cpu_count() i64 {
 }
 
 # get the current working directory
+#
+# the raw syscall returns the length INCLUDING the terminator; this layer
+# reports the path length the way darwin and windows do, so "length of path"
+# means one thing across the three backends (#432).
 # ---
 # buf:  destination buffer
-# size: buffer capacity in bytes
-# ret:  length of path on success, or negative errno
+# size: buffer capacity in bytes, including room for the terminator
+# ret:  length of the path, excluding the terminator, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
-    ret syscall2(SYS_GETCWD, buf::usize, size);
+    val n: i64 = syscall2(SYS_GETCWD, buf::usize, size);
+    if (n < 1) { ret n; }
+    ret n - 1;
 }
 
 # the getcwd capacity contract, pinned on a per-PR runner
@@ -1742,19 +1748,14 @@ test "std.system.os.getcwd:small_buffer_is_refused_not_overrun" {
     ret 0;
 }
 
-# a buffer with room writes an absolute, null-terminated path
-#
-# the RETURN value is deliberately not asserted here: linux returns the length
-# including the terminator (the raw syscall's contract) while darwin and windows
-# return it excluding one, so "length of path" means two different things across
-# this layer. that divergence is its own defect and is not settled by this test.
-test "std.system.os.getcwd:sufficient_buffer_writes_absolute_path" {
+# a buffer with room reports the path length and null-terminates at it
+test "std.system.os.getcwd:sufficient_buffer_reports_length" {
     var buf: [1024]u8;
     val n: i64 = getcwd(?buf[0], 1024);
-    if (n < 1)                       { ret 1; }
-    if (buf[0] != '/')               { ret 1; }
-    if (str_len(?buf[0]) < 1)        { ret 1; }
-    if (buf[str_len(?buf[0])] != 0)  { ret 1; }
+    if (n < 1)                        { ret 1; }
+    if (buf[0] != '/')                { ret 1; }
+    if (buf[n::usize] != 0)           { ret 1; }
+    if (str_len(?buf[0]) != n::usize) { ret 1; }
     ret 0;
 }
 

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -411,6 +411,7 @@ pub val EROFS:     i64 = -30;
 pub val EPIPE:     i64 = -32;
 pub val ENOTEMPTY: i64 = -39;
 pub val ENOTSUP:   i64 = -95;
+pub val ERANGE:    i64 = -34;
 
 pub val EINTR_MAX_RETRIES: usize = 8;
 
@@ -1711,6 +1712,50 @@ pub fun cpu_count() i64 {
 # ret:  length of path on success, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
     ret syscall2(SYS_GETCWD, buf::usize, size);
+}
+
+# the getcwd capacity contract, pinned on a per-PR runner
+#
+# darwin had to reimplement this by hand because F_GETPATH carries no capacity
+# (#409), so the contract it has to match is asserted here too rather than only
+# on the darwin leg: `size` is the destination's capacity including the
+# terminator, a path that does not fit is ERANGE, and nothing past the declared
+# capacity is written.
+test "std.system.os.getcwd:small_buffer_is_refused_not_overrun" {
+    val cap:  usize = 8;
+    var slab: [64]u8;
+    var i: usize = 0;
+    for (i < 64) {
+        slab[i] = 0xAB;
+        i = i + 1;
+    }
+
+    # shorter than any real absolute cwd, so this always takes the refusal path
+    if (getcwd(?slab[0], cap) != ERANGE) { ret 1; }
+
+    # nothing past the capacity the caller declared was touched
+    i = cap;
+    for (i < 64) {
+        if (slab[i] != 0xAB) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a buffer with room writes an absolute, null-terminated path
+#
+# the RETURN value is deliberately not asserted here: linux returns the length
+# including the terminator (the raw syscall's contract) while darwin and windows
+# return it excluding one, so "length of path" means two different things across
+# this layer. that divergence is its own defect and is not settled by this test.
+test "std.system.os.getcwd:sufficient_buffer_writes_absolute_path" {
+    var buf: [1024]u8;
+    val n: i64 = getcwd(?buf[0], 1024);
+    if (n < 1)                       { ret 1; }
+    if (buf[0] != '/')               { ret 1; }
+    if (str_len(?buf[0]) < 1)        { ret 1; }
+    if (buf[str_len(?buf[0])] != 0)  { ret 1; }
+    ret 0;
 }
 
 # look up an environment variable by name

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -49,6 +49,10 @@ val FILE_ATTRIBUTE_HIDDEN:    u32 = 0x02;
 val FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x400;
 val FILE_FLAG_BACKUP_SEMANTICS: u32 = 0x02000000;
 
+# MoveFileEx flags
+val MOVEFILE_REPLACE_EXISTING: u32 = 0x01;
+val MOVEFILE_WRITE_THROUGH:    u32 = 0x08;
+
 # invalid handle
 val INVALID_HANDLE_VALUE: isize = -1;
 
@@ -233,7 +237,7 @@ ext fun FlushViewOfFile(p0: ptr, p1: usize) i32;
 #[library("kernel32.dll")]
 ext fun DeleteFileA(p0: *u8) i32;
 #[library("kernel32.dll")]
-ext fun MoveFileA(p0: *u8, p1: *u8) i32;
+ext fun MoveFileExA(p0: *u8, p1: *u8, p2: u32) i32;
 #[library("kernel32.dll")]
 ext fun CreateDirectoryA(p0: *u8, p1: ptr) i32;
 #[library("kernel32.dll")]
@@ -1226,8 +1230,19 @@ pub fun unlink(dirfd: i32, path: *u8, flags: i32) i64 {
 }
 
 # stub: olddir/newdir are ignored, paths must be absolute or relative to cwd
+#
+# MoveFileEx, not MoveFile: the bare form refuses an existing destination, which
+# breaks the write-a-temp-then-rename-into-place pattern this call exists to
+# serve and contradicts fs.rename's POSIX-parity contract. REPLACE_EXISTING
+# restores that, and WRITE_THROUGH matches the durability a caller renaming for
+# atomicity expects. COPY_ALLOWED is deliberately NOT set: POSIX rename fails
+# across devices rather than silently copying, and so does this.
+#
+# one divergence remains and cannot be closed here: REPLACE_EXISTING does not
+# apply to a directory destination, so renaming a directory onto an existing
+# empty directory still fails where POSIX succeeds.
 pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
-    if (MoveFileA(oldpath, newpath) == 0) {
+    if (MoveFileExA(oldpath, newpath, MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH) == 0) {
         ret last_error();
     }
     ret 0;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -517,6 +517,7 @@ pub val EROFS:     i64 = -30;
 pub val EPIPE:     i64 = -32;
 pub val ENOTEMPTY: i64 = -39;
 pub val ENOTSUP:   i64 = -95;
+pub val ERANGE:    i64 = -34;
 
 pub val EINTR_MAX_RETRIES: usize = 8;
 
@@ -1953,16 +1954,59 @@ pub fun cpu_count() i64 {
 }
 
 # get the current working directory
+#
+# GetCurrentDirectoryA overloads its return: on success it is the length
+# written, and when the destination is too small it is the size required
+# INCLUDING the terminator, with nothing written. Passing both through as a
+# success let a caller read an untouched buffer and believe it held a path, so
+# the too-small case is reported as ERANGE the way linux and darwin report it.
 # ---
 # buf:  destination buffer
-# size: buffer capacity in bytes
-# ret:  length of path on success, or negative errno
+# size: buffer capacity in bytes, including room for the terminator
+# ret:  length of the path, excluding the terminator, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
     val len: u32 = GetCurrentDirectoryA(size::u32, buf);
-    if (len == 0) {
-        ret last_error();
-    }
+    if (len == 0)           { ret last_error(); }
+    if (len::usize >= size) { ret ERANGE; }
     ret len::i64;
+}
+
+# the getcwd capacity contract, pinned on every backend
+#
+# GetCurrentDirectoryA reports the required size rather than failing when the
+# destination is too small, so windows used to return a positive value for a
+# call that wrote no path (#433). the rule all three backends now hold: size is
+# the capacity including the terminator, a path that does not fit is ERANGE,
+# and nothing past the declared capacity is written.
+test "std.system.os.getcwd:small_buffer_is_refused_not_overrun" {
+    val cap:  usize = 4;
+    var slab: [64]u8;
+    var i: usize = 0;
+    for (i < 64) {
+        slab[i] = 0xAB;
+        i = i + 1;
+    }
+
+    # shorter than any real absolute path, so this always takes the refusal path
+    if (getcwd(?slab[0], cap) != ERANGE) { ret 1; }
+
+    # nothing past the capacity the caller declared was touched
+    i = cap;
+    for (i < 64) {
+        if (slab[i] != 0xAB) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a buffer with room reports the path length and null-terminates at it
+test "std.system.os.getcwd:sufficient_buffer_reports_length" {
+    var buf: [1024]u8;
+    val n: i64 = getcwd(?buf[0], 1024);
+    if (n < 1)                        { ret 1; }
+    if (buf[n::usize] != 0)           { ret 1; }
+    if (str_len(?buf[0]) != n::usize) { ret 1; }
+    ret 0;
 }
 
 # look up an environment variable by name


### PR DESCRIPTION
Publishes the OS-layer filesystem contract fixes as std 0.24.0.

Every fix in this release is the same shape: a public docstring described one behaviour and at least one backend did another, with no caller in tree happening to notice. They were found by working #409 and then pulling the thread.

### Fixed
- **`os.rename` on windows replaces an existing destination** (#414). `MoveFileA` fails whenever the destination exists, which broke write-a-temp-then-rename-into-place in exactly the case it is used in. Now `MoveFileExA` with `MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH`. `COPY_ALLOWED` deliberately not set, since POSIX rename fails across devices rather than silently copying.
- **`os.getcwd` on darwin honours the caller's capacity** (#409). `F_GETPATH` carries no capacity and XNU writes up to `MAXPATHLEN` bytes whatever the caller sized its buffer, so pointing it at the caller's buffer overran anything smaller. Now read into scratch and copied out only when it fits.
- **`os.getcwd`'s return meant two different things** (#432). Linux included the terminator, darwin and windows excluded it, and all three docstrings said "length of path". Linux moves.
- **`os.getcwd` on windows reported success for a call that wrote nothing** (#433). `GetCurrentDirectoryA` overloads its return with the required size; that is now `ERANGE`.

### Why one release rather than four
`os.getcwd` had three separate divergences across three backends. Fixing any one alone leaves the docstring false, so they are one change to one contract.

### Consumer note
mach's `int` fixtures resolve `ref = "branch/main"`, so these reach mach only on this merge. mach#2592 landed in the meantime, so an int run now records the exact mach-std commit it built against and the release gate pins to mach's own lock, which makes this move visible rather than silent.

### Verification
- **764 passed, 0 failed** on linux-x86_64.
- `test/backends/verify.sh` green: windows-x86_64, darwin-x86_64 and darwin-aarch64 all cross-compile.
- The windows and darwin test bodies are target-gated and run on their own CI legs, not on the authoring host. Stated rather than claimed.

Closes #409, #414, #432, #433