### PR TITLE
fix(os): O_DIRECTORY is 0o200000 on every linux arch, not 0x4000

### DIFF
--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -852,6 +852,50 @@ test "std.filesystem.rename:replaces_existing_destination" {
     ret bad;
 }
 
+# read_dir lists a directory's children
+#
+# the regression for the O_DIRECTORY value. it was arch-gated to 0x4000 on aarch64
+# and riscv64, which is O_DIRECT, so the open failed EINVAL and read_dir could not
+# list anything at all on either. nothing exercised it, so it went unnoticed until a
+# riscv64 self-host build tried to enumerate a source tree
+test "std.filesystem.read_dir:lists_children" {
+    var buf: [8192]u8;
+    var st:  fixed.FixedState;
+    var alloc: A.Allocator;
+    if (O.is_some[*u8](fixed.make(?alloc, ?st, ?buf[0], 8192))) { ret 1; }
+
+    val d: Path = "/tmp/mach_std_fs_rd";
+    remove_all(?alloc, d);
+    if (O.is_some[str](create_dir(d, 0o755))) { ret 1; }
+
+    var bad: i32 = 0;
+    if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/a.txt", "a", 1, 0o644))) { bad = 1; }
+    if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/b.txt", "b", 1, 0o644))) { bad = 1; }
+
+    val rr: R.Result[Vector[str], str] = read_dir(?alloc, d);
+    if (R.is_err[Vector[str], str](rr)) { bad = 1; }
+    or {
+        var names: Vector[str] = R.unwrap_ok[Vector[str], str](rr);
+        # both children present, and "." / ".." not reported as children
+        var saw_a: bool = false;
+        var saw_b: bool = false;
+        var extra: i32  = 0;
+        var i: usize = 0;
+        for (i < names.len) {
+            if (str_equals(names.data[i], "a.txt"))      { saw_a = true; }
+            or (str_equals(names.data[i], "b.txt"))      { saw_b = true; }
+            or                                           { extra = extra + 1; }
+            i = i + 1;
+        }
+        if (!saw_a || !saw_b) { bad = 1; }
+        if (extra != 0)       { bad = 1; }
+        vector.dnit[str](?names);
+    }
+
+    remove_all(?alloc, d);
+    ret bad;
+}
+
 # seek repositions the read offset within an open file
 test "std.filesystem.seek:reposition_and_read" {
     var scratch: [16]u8;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -355,18 +355,13 @@ pub val O_EXCL:      i32 = 128;
 pub val O_TRUNC:     i32 = 512;
 pub val O_APPEND:    i32 = 1024;
 
-# O_DIRECTORY differs by arch: x86_64 = 0x10000, asm-generic (aarch64, riscv64) =
-# 0x4000. 0x10000 means O_DIRECT on the asm-generic arches, so the value must be
-# arch-gated.
-$if ($mach.build.arch == $mach.arch.x86_64) {
-pub val O_DIRECTORY: i32 = 0x10000;
-}
-$or ($mach.build.arch == $mach.arch.aarch64) {
-pub val O_DIRECTORY: i32 = 0x4000;
-}
-$or ($mach.build.arch == $mach.arch.riscv64) {
-pub val O_DIRECTORY: i32 = 0x4000;
-}
+# 0o200000 on every linux arch mach targets. x86_64, aarch64 and riscv64 all take
+# asm-generic's value for this flag, so it is NOT arch-gated. it was, with the two
+# non-x86 arches given 0x4000, which is O_DIRECT: opening a directory with it fails
+# EINVAL rather than doing anything, which is how it was found.
+pub val O_DIRECTORY: i32 = 0o200000;
+# not used by this layer, defined so the pair cannot be confused again
+pub val O_DIRECT:    i32 = 0o40000;
 
 pub val AT_FDCWD:            i32 = -100;
 pub val AT_SYMLINK_NOFOLLOW: i32 = 0x0100;


### PR DESCRIPTION
`O_DIRECTORY` was arch-gated, with aarch64 and riscv64 given `0x4000`:

```mach
# O_DIRECTORY differs by arch: x86_64 = 0x10000, asm-generic (aarch64, riscv64) =
# 0x4000. 0x10000 means O_DIRECT on the asm-generic arches, so the value must be
# arch-gated.
```

The comment has it exactly backwards. From `asm-generic/fcntl.h`, which x86_64, aarch64 and riscv64 all take these two flags from:

```
#define O_DIRECT	00040000	/* direct disk access hint */
#define O_DIRECTORY	00200000	/* must be a directory */
```

So `0x4000` **is** `O_DIRECT`, and `0o200000` (`0x10000`) is `O_DIRECTORY` on all three. The gate was both wrong and unnecessary.

## What it broke

`fs.read_dir` could not list a directory at all on aarch64 or riscv64. `O_DIRECT` on a directory is invalid, so the open fails `EINVAL` before anything is read. Traced under `qemu-riscv64`:

```
openat(AT_FDCWD,"./src",O_RDONLY|O_DIRECT) = -1 errno=22 (Invalid argument)
```

qemu's own strace decoder prints `O_DIRECT` for the flag we passed, which is the clearest possible statement of the bug.

## How it was found

mach#2539 makes `mach build` front-end every module under `src` rather than only the reachable ones, so the compiler enumerates the source tree. The riscv64 self-host int case (`regression/1852-rv64-self-host`) is the only place a riscv64-hosted compiler runs, and it failed with `error: invalid argument`. That is mach#2641, which is blocked on this.

Note aarch64 was equally broken and CI never noticed, because nothing called `read_dir` on it.

## Test

`std.filesystem.read_dir:lists_children` creates a directory with two files and asserts both are listed **and that `.` and `..` are not reported as children**, so it checks the listing rather than merely that the call returned. There was no `read_dir` test at all before, which is the actual reason an outright broken directory listing on two of three linux arches survived.

The fix is in the linux backend, which is target-gated, so the test runs on each linux leg's own CI job. The aarch64 leg is where it would have caught this.

`O_DIRECT` is now also defined, unused by this layer, so the pair cannot be confused again.

## Verified
- `mach test .` — 765 passed, 0 failed (764 before).
- `test/backends/verify.sh` — windows, darwin x86_64 and darwin aarch64 all cross-compile.
- The riscv64 half is settled by mach#2641's int leg, which is what surfaced it.
