### PR TITLE
fix(os): restore the arm64 arm of the O_DIRECTORY gate

### DIFF
--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -802,6 +802,60 @@ test "std.filesystem.create_dir:remove_dir_roundtrip" {
     ret bad;
 }
 
+# read_dir actually lists a directory, on every architecture
+#
+# There was no coverage of read_dir at all, which is why an O_DIRECTORY that was
+# really O_DIRECT could sit in the tree unnoticed: the open fails EINVAL before a
+# single entry is read, and no test opened a directory to notice. It has now been
+# wrong on riscv64 (the value copied from arm64) and then on arm64 (the gate
+# removed to fix riscv64), so the flag is worth a runtime assertion rather than a
+# comment. The aarch64 CI leg runs this suite under qemu, so this is the leg that
+# proves the arm64 arm, and the riscv64 probe proves the other.
+test "std.filesystem.read_dir:lists_entries" {
+    var buf: [32768]u8;
+    var st: fixed.FixedState;
+    var a: A.Allocator;
+    fixed.make(?a, ?st, ?buf[0], 32768);
+
+    val d: Path = "/tmp/mach_std_fs_readdir";
+    val f: Path = "/tmp/mach_std_fs_readdir/entry";
+    remove_all(?a, d);
+    if (O.is_some[str](create_dir(d, 0o755)))            { ret 1; }
+    if (O.is_some[str](write_bytes(f, "x", 1, 0o644)))   { remove_all(?a, d); ret 1; }
+
+    var bad: i32 = 0;
+    val r: R.Result[Vector[str], str] = read_dir(?a, d);
+    if (R.is_err[Vector[str], str](r)) { bad = 1; }
+    or {
+        val v: Vector[str] = R.unwrap_ok[Vector[str], str](r);
+        # exactly the one entry, and "." / ".." are not among them
+        if (v.len != 1::usize)                { bad = 1; }
+        or (!str_equals(v.data[0], "entry"))  { bad = 1; }
+    }
+
+    remove_all(?a, d);
+    ret bad;
+}
+
+# read_dir must refuse a non-directory rather than silently succeeding
+#
+# The companion to the test above: if O_DIRECTORY were inert rather than wrong, the
+# listing test could still pass while the flag did nothing.
+test "std.filesystem.read_dir:refuses_a_file" {
+    var buf: [8192]u8;
+    var st: fixed.FixedState;
+    var a: A.Allocator;
+    fixed.make(?a, ?st, ?buf[0], 8192);
+
+    val p: Path = "/tmp/mach_std_fs_readdir_file";
+    if (O.is_some[str](write_bytes(p, "x", 1, 0o644))) { ret 1; }
+
+    val r: R.Result[Vector[str], str] = read_dir(?a, p);
+    remove_file(p);
+    if (R.is_ok[Vector[str], str](r)) { ret 1; }
+    ret 0;
+}
+
 # rename moves the entry: the old path vanishes, the new one exists
 test "std.filesystem.rename:moves_entry" {
     val from: Path = "/tmp/mach_std_fs_ren_a";

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -355,13 +355,29 @@ pub val O_EXCL:      i32 = 128;
 pub val O_TRUNC:     i32 = 512;
 pub val O_APPEND:    i32 = 1024;
 
-# 0o200000 on every linux arch mach targets. x86_64, aarch64 and riscv64 all take
-# asm-generic's value for this flag, so it is NOT arch-gated. it was, with the two
-# non-x86 arches given 0x4000, which is O_DIRECT: opening a directory with it fails
-# EINVAL rather than doing anything, which is how it was found.
+# O_DIRECTORY and O_DIRECT trade places on arm64, so the gate is real and the pair
+# must move together. arm64 is the ONLY exception among the arches mach targets:
+# arch/arm64/include/uapi/asm/fcntl.h overrides asm-generic with the values arm32
+# has always used. riscv has no uapi/asm/fcntl.h at all, so like x86_64 it takes
+# asm-generic verbatim.
+#
+#            O_DIRECTORY   O_DIRECT
+#   arm64      0o40000     0o200000
+#   others     0o200000    0o40000
+#
+# Getting this wrong in either direction breaks directory opens on the arch you got
+# wrong, because the open then carries a direct-IO hint instead of the directory
+# flag and the kernel rejects it EINVAL. It has now been wrong in both directions:
+# riscv64 originally took the arm64 values by copy, and removing the gate outright
+# to fix that gave arm64 the asm-generic ones.
+$if ($mach.build.arch == $mach.arch.aarch64) {
+pub val O_DIRECTORY: i32 = 0o40000;
+pub val O_DIRECT:    i32 = 0o200000;
+}
+$or {
 pub val O_DIRECTORY: i32 = 0o200000;
-# not used by this layer, defined so the pair cannot be confused again
 pub val O_DIRECT:    i32 = 0o40000;
+}
 
 pub val AT_FDCWD:            i32 = -100;
 pub val AT_SYMLINK_NOFOLLOW: i32 = 0x0100;
@@ -1713,6 +1729,28 @@ pub fun getcwd(buf: *u8, size: usize) i64 {
     val n: i64 = syscall2(SYS_GETCWD, buf::usize, size);
     if (n < 1) { ret n; }
     ret n - 1;
+}
+
+# O_DIRECTORY and O_DIRECT are distinct, and O_DIRECTORY is the one that opens a
+# directory
+#
+# The two trade places on arm64 and nowhere else, so a wrong gate silently swaps
+# them and every directory open on the mis-gated arch fails EINVAL. Asserting
+# either against a literal would only restate whatever is written above, so this
+# pins the two properties that survive a value change: they differ, and the one
+# named O_DIRECTORY is the one the kernel accepts on a directory.
+test "std.system.os.open:O_DIRECTORY is the directory flag, not O_DIRECT" {
+    if (O_DIRECTORY == O_DIRECT) { ret 1; }
+
+    val fd: i64 = open(AT_FDCWD, "/tmp", O_RDONLY | O_DIRECTORY, 0);
+    if (fd < 0) { ret 1; }
+    close(fd::i32);
+
+    # and it must not be inert: the same open still has to refuse a non-directory
+    val bad: i64 = open(AT_FDCWD, "/dev/null", O_RDONLY | O_DIRECTORY, 0);
+    if (bad >= 0) { close(bad::i32); ret 1; }
+    if (bad != ENOTDIR) { ret 1; }
+    ret 0;
 }
 
 # the getcwd capacity contract, pinned on a per-PR runner


### PR DESCRIPTION
**`fs.read_dir` cannot list a directory on aarch64 on current `dev`.** This restores the arch gate #436 removed, keeping #436's riscv64 fix intact.

## What happened

#436 correctly identified that riscv64's `O_DIRECTORY` was wrong, and fixed it by deleting the gate and giving every linux arch asm-generic's value. That is right for x86_64 and riscv64 and wrong for arm64, which is **the one architecture here that overrides asm-generic**. `arch/arm64/include/uapi/asm/fcntl.h` carries arm32's values, and the two flags are simply swapped relative to everywhere else:

| | O_DIRECTORY | O_DIRECT |
|---|---|---|
| asm-generic (x86_64, riscv64) | `0o200000` | `0o40000` |
| arm64 override | `0o40000` | `0o200000` |

So the gate was necessary after all — it was wrong in its riscv64 arm, not wrong for existing. Removing it moved the breakage from riscv64 to arm64.

The original bug and #436 are the same mistake in opposite directions, which is why this puts both constants inside the gate: they trade places as a pair, and having `O_DIRECT` absent is part of what made the relationship easy to get wrong.

## Evidence

`fs.read_dir` plus the raw open, cross-built release and run under qemu.

Current `dev` (#436 as merged):

```
riscv64:  O_DIRECTORY = 10000   raw open ok                        fs.read_dir ok, 2 entries
aarch64:  O_DIRECTORY = 10000   raw open FAILED (invalid argument)  fs.read_dir FAILED
```

This PR:

```
riscv64:  O_DIRECTORY = 10000   raw open ok   fs.read_dir ok, 2 entries
aarch64:  O_DIRECTORY = 4000    raw open ok   fs.read_dir ok, 2 entries
```

Isolating the flag on each arch shows the swap directly. riscv64:

```
open(src, 0x4000 literal)   -> -22   (EINVAL: that is O_DIRECT)
open(src, 0x10000 literal)  -> 4     (that is O_DIRECTORY)
```

aarch64, the mirror image:

```
open(src, 0x4000 literal)   -> 5     (that is O_DIRECTORY)
open(src, 0x10000 literal)  -> -22   (EINVAL: that is O_DIRECT)
```

## CI already said this

This is not a qemu-fidelity argument. **#436's own `cross-arm64` check reported `FAILURE` and the PR was merged anyway:**

```
build           SUCCESS
cross-riscv64   SUCCESS
cross-arm64     FAILURE
cross-backends  SUCCESS
```

The test that fired is #436's own `read_dir:lists_children`, which is a good test and is kept unchanged here. Reproducing that failing state locally with the new assertions in place:

```
failures:
  std.system.os.open:O_DIRECTORY is the directory flag, not O_DIRECT
  std.filesystem.read_dir:lists_entries
  std.filesystem.read_dir:lists_children
765 passed, 3 failed, 768 total
```

With this PR: **768 passed, 0 failed on x86_64, and 768 / 0 on aarch64 under qemu.**

## Tests

Alongside #436's `lists_children`:

- `read_dir:lists_entries` — creates a directory with one entry and requires exactly that entry back, with `.` and `..` absent.
- `read_dir:refuses_a_file` — an inert `O_DIRECTORY` would let the listing tests pass while the flag did nothing.
- `os.open:O_DIRECTORY is the directory flag, not O_DIRECT` — pins the two properties that survive a value change: the constants differ, and the one named `O_DIRECTORY` is the one the kernel accepts on a directory. Asserting either against a literal would only restate whatever is written above it.

## Note on riscv64 coverage

riscv64 still has no library-level test coverage — its CI leg runs `test/riscv64/verify.sh` and the RELRO contract, not the suite, and mach-std declares no `linux-riscv64` target. I tried adding both; building the suite for riscv64 currently stops at `error: codegen: 128-bit vectors not yet supported on riscv64`, which is a compiler limitation rather than something fixable here. Until that lifts, riscv64 regressions in this repo are only caught downstream. Reported upstream separately.

## Context

Found while landing briar-systems/mach#2539, which makes `mach build` front-end every module under `src` and so walks the compiler's own source tree on riscv64 for the first time.
