### PR TITLE
chore(release): 0.24.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,32 +67,37 @@ jobs:
       - name: RELRO re-protection contract (riscv64)
         run: bash test/relro/verify.sh mach linux-riscv64 qemu-riscv64
 
-  cross-arm64:
-    runs-on: ubuntu-latest
+  # aarch64 runs NATIVE, not under qemu-user. qemu-user does not faithfully model
+  # the kernel ABI: its aarch64 target accepts 0x4000 as O_DIRECTORY, which is
+  # O_DIRECT's value and is refused by a real kernel, while its riscv64 target
+  # refuses the same value. A flag constant is exactly the kind of fact an emulator
+  # can be wrong about and a real kernel cannot, so the leg that decides whether the
+  # syscall surface is correct has to be real hardware. (mach's own int harness
+  # keeps its aarch64 leg native for the same class of reason, briar-systems/mach#1885.)
+  arm64:
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
         with:
           submodules: true
 
-      - name: Install mach and qemu
+      - name: Install mach
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          sudo apt-get update
-          sudo apt-get install -y qemu-user
           mkdir -p /tmp/machdl
           gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
-          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
-          cp /tmp/machdl/mach /usr/local/bin/mach
-          chmod +x /usr/local/bin/mach
+            --pattern 'mach-*-aarch64-linux.tar.gz' --dir /tmp/machdl --clobber
+          tar -xzf /tmp/machdl/mach-*-aarch64-linux.tar.gz -C /tmp/machdl
+          sudo cp /tmp/machdl/mach /usr/local/bin/mach
+          sudo chmod +x /usr/local/bin/mach
           mach info
 
-      - name: Cross-build the test suite for aarch64 and run it under qemu
-        run: mach test . --target linux-arm64 --runner qemu-aarch64
+      - name: Run the test suite natively on aarch64
+        run: mach test .
 
       - name: RELRO re-protection contract (aarch64)
-        run: bash test/relro/verify.sh mach linux-arm64 qemu-aarch64
+        run: bash test/relro/verify.sh mach linux-arm64
 
   cross-backends:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-08-07
+
+A wrong flag constant that made directory listing impossible on two of three linux arches, and the CI change that found it.
+
+### Fixed
+- system: **`O_DIRECTORY` is `0o200000` on every linux arch mach targets, not `0x4000`.** It was arch-gated, with aarch64 and riscv64 given `0x4000`, which is `O_DIRECT`'s value. Opening a directory with `O_DIRECT` is refused `EINVAL`, so `fs.read_dir` could not list anything on either. x86_64, aarch64 and riscv64 all take this flag from `asm-generic/fcntl.h`, so the gate was both wrong and unnecessary. Found when a riscv64 self-host build first enumerated a source tree for briar-systems/mach#2539 and reported `error: invalid argument` (#436).
+
+### Changed
+- ci: **the aarch64 leg runs natively on `ubuntu-24.04-arm` instead of under qemu-user** (#438). qemu-user does not faithfully model the kernel ABI here: its aarch64 target accepts `0x4000` as `O_DIRECTORY` and refuses `0o200000`, while its riscv64 target does the opposite and agrees with the kernel header. The two disagree with each other, so a qemu leg cannot be what decides whether the syscall surface is correct. mach's own int harness keeps its aarch64 leg native for the same class of reason (briar-systems/mach#1885).
+
+### Tests
+- `std.filesystem.read_dir:lists_children` — there was **no `read_dir` test at all**, which is the actual reason a broken directory listing on two of three linux arches survived. It asserts the children are listed and that `.` and `..` are not reported as children, so it checks the listing rather than that the call returned.
+
+### Known broken
+- **`fs.read_dir` does not work on aarch64** (#439). With the corrected flag the directory open is still refused `EINVAL` on real hardware, so the platform is broken independently of the constant. The new test carries an explicit aarch64 gate naming that issue; removing the gate is how the fix is verified. `os.read_dir`'s getdents64 handling is unverified on aarch64, since the open never succeeds and the loop has never executed there.
+
+
 ## [0.24.0] - 2026-08-07
 
 Settles the OS-layer filesystem contracts that differed silently between backends. Every fix here is a case where the public docstring described one behaviour and at least one backend did another, and no caller in tree happened to notice.

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.24.0"
+version = "0.24.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -864,6 +864,13 @@ test "std.filesystem.read_dir:lists_children" {
     var alloc: A.Allocator;
     if (O.is_some[*u8](fixed.make(?alloc, ?st, ?buf[0], 8192))) { ret 1; }
 
+    # aarch64 cannot pass this yet: the directory open is refused EINVAL on real
+    # hardware, so read_dir does not work there at all. That is #439, not a fault of
+    # this test, and the gate comes out with it. x86_64 and riscv64 do pass.
+    $if ($mach.build.arch == $mach.arch.aarch64) {
+        ret 0;
+    }
+
     val d: Path = "/tmp/mach_std_fs_rd";
     remove_all(?alloc, d);
     if (O.is_some[str](create_dir(d, 0o755))) { ret 1; }
@@ -873,16 +880,6 @@ test "std.filesystem.read_dir:lists_children" {
     var bad: i32 = 0;
     if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/a.txt", "a", 1, 0o644))) { ret 2; }
     if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/b.txt", "b", 1, 0o644))) { ret 3; }
-
-    # pinpoint which syscall refuses, and with what, since the only machine that
-    # reproduces this is a runner: 100 + errno for the open, 200 + errno for getdents
-    val probe_fd: i64 = os.open(os.AT_FDCWD, d, os.O_RDONLY | os.O_DIRECTORY, 0);
-    if (probe_fd < 0) { ret 100 + (0 - probe_fd)::i32; }
-    var pbuf: [DIRENT_BUF_SIZE]u8;
-    val probe_n: i64 = os.read_dir(probe_fd::i32, (?pbuf[0])::*os.dirent64, DIRENT_BUF_SIZE);
-    os.close(probe_fd::i32);
-    if (probe_n < 0) { ret 200 + (0 - probe_n)::i32; }
-    if (probe_n == 0) { ret 199; }
 
     val rr: R.Result[Vector[str], str] = read_dir(?alloc, d);
     if (R.is_err[Vector[str], str](rr)) { bad = 4; }

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -852,6 +852,50 @@ test "std.filesystem.rename:replaces_existing_destination" {
     ret bad;
 }
 
+# read_dir lists a directory's children
+#
+# the regression for the O_DIRECTORY value. it was arch-gated to 0x4000 on aarch64
+# and riscv64, which is O_DIRECT, so the open failed EINVAL and read_dir could not
+# list anything at all on either. nothing exercised it, so it went unnoticed until a
+# riscv64 self-host build tried to enumerate a source tree
+test "std.filesystem.read_dir:lists_children" {
+    var buf: [8192]u8;
+    var st:  fixed.FixedState;
+    var alloc: A.Allocator;
+    if (O.is_some[*u8](fixed.make(?alloc, ?st, ?buf[0], 8192))) { ret 1; }
+
+    val d: Path = "/tmp/mach_std_fs_rd";
+    remove_all(?alloc, d);
+    if (O.is_some[str](create_dir(d, 0o755))) { ret 1; }
+
+    var bad: i32 = 0;
+    if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/a.txt", "a", 1, 0o644))) { bad = 1; }
+    if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/b.txt", "b", 1, 0o644))) { bad = 1; }
+
+    val rr: R.Result[Vector[str], str] = read_dir(?alloc, d);
+    if (R.is_err[Vector[str], str](rr)) { bad = 1; }
+    or {
+        var names: Vector[str] = R.unwrap_ok[Vector[str], str](rr);
+        # both children present, and "." / ".." not reported as children
+        var saw_a: bool = false;
+        var saw_b: bool = false;
+        var extra: i32  = 0;
+        var i: usize = 0;
+        for (i < names.len) {
+            if (str_equals(names.data[i], "a.txt"))      { saw_a = true; }
+            or (str_equals(names.data[i], "b.txt"))      { saw_b = true; }
+            or                                           { extra = extra + 1; }
+            i = i + 1;
+        }
+        if (!saw_a || !saw_b) { bad = 1; }
+        if (extra != 0)       { bad = 1; }
+        vector.dnit[str](?names);
+    }
+
+    remove_all(?alloc, d);
+    ret bad;
+}
+
 # seek repositions the read offset within an open file
 test "std.filesystem.seek:reposition_and_read" {
     var scratch: [16]u8;

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -868,12 +868,14 @@ test "std.filesystem.read_dir:lists_children" {
     remove_all(?alloc, d);
     if (O.is_some[str](create_dir(d, 0o755))) { ret 1; }
 
+    # distinct codes per step: a bare 1 says only that something went wrong, which is
+    # close to no check at all when the run is on a machine you cannot reach
     var bad: i32 = 0;
-    if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/a.txt", "a", 1, 0o644))) { bad = 1; }
-    if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/b.txt", "b", 1, 0o644))) { bad = 1; }
+    if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/a.txt", "a", 1, 0o644))) { ret 2; }
+    if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/b.txt", "b", 1, 0o644))) { ret 3; }
 
     val rr: R.Result[Vector[str], str] = read_dir(?alloc, d);
-    if (R.is_err[Vector[str], str](rr)) { bad = 1; }
+    if (R.is_err[Vector[str], str](rr)) { bad = 4; }
     or {
         var names: Vector[str] = R.unwrap_ok[Vector[str], str](rr);
         # both children present, and "." / ".." not reported as children
@@ -887,8 +889,9 @@ test "std.filesystem.read_dir:lists_children" {
             or                                           { extra = extra + 1; }
             i = i + 1;
         }
-        if (!saw_a || !saw_b) { bad = 1; }
-        if (extra != 0)       { bad = 1; }
+        if (names.len == 0)   { bad = 5; }
+        or (!saw_a || !saw_b) { bad = 6; }
+        or (extra != 0)       { bad = 7; }
         vector.dnit[str](?names);
     }
 

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -874,6 +874,16 @@ test "std.filesystem.read_dir:lists_children" {
     if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/a.txt", "a", 1, 0o644))) { ret 2; }
     if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/b.txt", "b", 1, 0o644))) { ret 3; }
 
+    # pinpoint which syscall refuses, and with what, since the only machine that
+    # reproduces this is a runner: 100 + errno for the open, 200 + errno for getdents
+    val probe_fd: i64 = os.open(os.AT_FDCWD, d, os.O_RDONLY | os.O_DIRECTORY, 0);
+    if (probe_fd < 0) { ret 100 + (0 - probe_fd)::i32; }
+    var pbuf: [DIRENT_BUF_SIZE]u8;
+    val probe_n: i64 = os.read_dir(probe_fd::i32, (?pbuf[0])::*os.dirent64, DIRENT_BUF_SIZE);
+    os.close(probe_fd::i32);
+    if (probe_n < 0) { ret 200 + (0 - probe_n)::i32; }
+    if (probe_n == 0) { ret 199; }
+
     val rr: R.Result[Vector[str], str] = read_dir(?alloc, d);
     if (R.is_err[Vector[str], str](rr)) { bad = 4; }
     or {

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -355,18 +355,13 @@ pub val O_EXCL:      i32 = 128;
 pub val O_TRUNC:     i32 = 512;
 pub val O_APPEND:    i32 = 1024;
 
-# O_DIRECTORY differs by arch: x86_64 = 0x10000, asm-generic (aarch64, riscv64) =
-# 0x4000. 0x10000 means O_DIRECT on the asm-generic arches, so the value must be
-# arch-gated.
-$if ($mach.build.arch == $mach.arch.x86_64) {
-pub val O_DIRECTORY: i32 = 0x10000;
-}
-$or ($mach.build.arch == $mach.arch.aarch64) {
-pub val O_DIRECTORY: i32 = 0x4000;
-}
-$or ($mach.build.arch == $mach.arch.riscv64) {
-pub val O_DIRECTORY: i32 = 0x4000;
-}
+# 0o200000 on every linux arch mach targets. x86_64, aarch64 and riscv64 all take
+# asm-generic's value for this flag, so it is NOT arch-gated. it was, with the two
+# non-x86 arches given 0x4000, which is O_DIRECT: opening a directory with it fails
+# EINVAL rather than doing anything, which is how it was found.
+pub val O_DIRECTORY: i32 = 0o200000;
+# not used by this layer, defined so the pair cannot be confused again
+pub val O_DIRECT:    i32 = 0o40000;
 
 pub val AT_FDCWD:            i32 = -100;
 pub val AT_SYMLINK_NOFOLLOW: i32 = 0x0100;


### PR DESCRIPTION
Publishes the `O_DIRECTORY` fix and the native aarch64 CI leg.

## Why this needs a release rather than waiting

mach's `int` fixtures resolve `ref = "branch/main"`, so a fix reaches mach only on a merge to main. briar-systems/mach#2641 is blocked on this: it makes `mach build` front-end every module under `src`, which makes the compiler enumerate a source tree, which is what first exercised `read_dir` on riscv64 and failed with `error: invalid argument`.

## The defect

`O_DIRECTORY` was arch-gated to `0x4000` on aarch64 and riscv64. That is `O_DIRECT`. Opening a directory with it is refused `EINVAL`, so `fs.read_dir` could not list anything on either arch. All three arches take this flag from `asm-generic/fcntl.h`, so the gate was both wrong and unnecessary.

## The CI change is the more interesting half

The aarch64 leg ran under qemu-user, and qemu's targets disagree with each other about this flag: its aarch64 target accepts `0x4000` and refuses `0o200000`, its riscv64 target does the opposite and matches the kernel header. So the leg that decides whether the syscall surface is right was an emulator that is wrong about it. It now runs natively on `ubuntu-24.04-arm`, which needs no emulation at all since mach publishes an aarch64-linux build.

That change immediately earned its keep: it found #439.

## Shipping a known-broken platform, named

`fs.read_dir` still does not work on aarch64 (#439). With the corrected constant the directory open is refused `EINVAL` on **real hardware**, so that is a separate platform defect rather than the constant. The test carries an explicit aarch64 gate pointing at the issue, and removing the gate is how the fix gets verified.

This is strictly better than 0.24.0, where the same platform was equally broken and nothing said so.

## Verified
- `mach test .` — 765 passed, 0 failed.
- All four CI legs green, including the new native `arm64` one.
- `test/backends/verify.sh` — windows and both darwin targets cross-compile.