### PR TITLE
fix(os): arm swaps O_DIRECTORY and O_DIRECT, so aarch64 keeps 0o40000

### DIFF
--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -854,22 +854,15 @@ test "std.filesystem.rename:replaces_existing_destination" {
 
 # read_dir lists a directory's children
 #
-# the regression for the O_DIRECTORY value. it was arch-gated to 0x4000 on aarch64
-# and riscv64, which is O_DIRECT, so the open failed EINVAL and read_dir could not
-# list anything at all on either. nothing exercised it, so it went unnoticed until a
-# riscv64 self-host build tried to enumerate a source tree
+# the regression for the O_DIRECTORY value, which arm swaps with O_DIRECT relative to
+# asm-generic. riscv64 had been given arm's value, so the open failed EINVAL and
+# read_dir could not list anything there. nothing exercised it, so it went unnoticed
+# until a riscv64 self-host build tried to enumerate a source tree
 test "std.filesystem.read_dir:lists_children" {
     var buf: [8192]u8;
     var st:  fixed.FixedState;
     var alloc: A.Allocator;
     if (O.is_some[*u8](fixed.make(?alloc, ?st, ?buf[0], 8192))) { ret 1; }
-
-    # aarch64 cannot pass this yet: the directory open is refused EINVAL on real
-    # hardware, so read_dir does not work there at all. That is #439, not a fault of
-    # this test, and the gate comes out with it. x86_64 and riscv64 do pass.
-    $if ($mach.build.arch == $mach.arch.aarch64) {
-        ret 0;
-    }
 
     val d: Path = "/tmp/mach_std_fs_rd";
     remove_all(?alloc, d);

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -355,13 +355,25 @@ pub val O_EXCL:      i32 = 128;
 pub val O_TRUNC:     i32 = 512;
 pub val O_APPEND:    i32 = 1024;
 
-# 0o200000 on every linux arch mach targets. x86_64, aarch64 and riscv64 all take
-# asm-generic's value for this flag, so it is NOT arch-gated. it was, with the two
-# non-x86 arches given 0x4000, which is O_DIRECT: opening a directory with it fails
-# EINVAL rather than doing anything, which is how it was found.
+# O_DIRECTORY and O_DIRECT are arch-gated, and ARM SWAPS THEM relative to
+# asm-generic. asm-generic/fcntl.h defines each under `#ifndef` precisely so an arch
+# can override, and arm does: O_DIRECTORY 0o40000 / O_DIRECT 0o200000, the reverse of
+# everyone else. aarch64 inherits arm's pair. x86_64 and riscv64 take asm-generic's.
+#
+# Getting this backwards is not a compile error and not a wrong result - the open is
+# simply refused EINVAL, so directory listing stops working on the arch you guessed
+# wrong. Both directions of that have now been observed on real hardware, so do not
+# "simplify" this to one value: verify on the arch before changing it, and note that
+# qemu-user is not evidence here (its aarch64 and riscv64 targets disagree with each
+# other about exactly this).
+$if ($mach.build.arch == $mach.arch.aarch64) {
+pub val O_DIRECTORY: i32 = 0o40000;
+pub val O_DIRECT:    i32 = 0o200000;
+}
+$or {
 pub val O_DIRECTORY: i32 = 0o200000;
-# not used by this layer, defined so the pair cannot be confused again
 pub val O_DIRECT:    i32 = 0o40000;
+}
 
 pub val AT_FDCWD:            i32 = -100;
 pub val AT_SYMLINK_NOFOLLOW: i32 = 0x0100;


### PR DESCRIPTION
**Corrects a regression I introduced in 0.24.1** (#436), which broke directory listing on aarch64.

## What I got wrong

#436 unified `O_DIRECTORY` to `0o200000` on every linux arch, reasoning from `asm-generic/fcntl.h`. That header defines both flags under `#ifndef`, **precisely so an arch can override them**, and arm does:

| | O_DIRECTORY | O_DIRECT |
|---|---|---|
| asm-generic (x86_64, riscv64) | `0o200000` | `0o40000` |
| **arm, inherited by aarch64** | **`0o40000`** | **`0o200000`** |

They are swapped. So the original arch gate was **right about aarch64** and wrong only about riscv64, which does take asm-generic's values. I removed a correct special case along with an incorrect one.

## How it was caught

mach's own `test aarch64-linux` leg, which is **native**, went red the moment briar-systems/mach#2651 advanced its lock to 0.24.1:



Native hardware settled it in both directions: aarch64 passes with `0o40000` and fails with `0o200000`. Note that qemu-aarch64 had been telling me this the whole time, and I discounted it because qemu-riscv64 disagreed. Both were right about their own arch; the flag really is arch-dependent, which is the thing I had concluded it was not.

## Consequence

**mach-std#439 is not a defect.** `fs.read_dir` works on aarch64 with the correct constant, so the aarch64 gate that test was given comes out and the test runs everywhere. I will close that issue against this.

The comment now states the swap, says that getting it backwards is refused `EINVAL` rather than being a compile error or a wrong result, and warns against "simplifying" it again. It also records that qemu-user is not evidence here, since its two targets disagree with each other about exactly this flag.

## Verified
- `mach test .` — 765 passed, 0 failed on x86_64.
- `read_dir` passes under qemu-aarch64 again.
- The native `arm64` leg added in #438 is what proves it, and it is the reason this was caught in one release rather than shipping quietly.