### PR TITLE
chore(release): 0.24.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.2] - 2026-08-07
+
+Corrects a regression in 0.24.1 that broke directory listing on aarch64.
+
+### Fixed
+- system: **arm swaps `O_DIRECTORY` and `O_DIRECT` relative to asm-generic, so aarch64 keeps `0o40000`** (#441). 0.24.1 unified the flag to `0o200000` on every linux arch on the strength of `asm-generic/fcntl.h`. That header defines both under `#ifndef` precisely so an arch can override, and arm does: `O_DIRECTORY` `0o40000` and `O_DIRECT` `0o200000`, the reverse of everyone else, inherited by aarch64. So the original arch gate was right about aarch64 and wrong only about riscv64. Both values are now stated with the reason, and the comment warns against unifying them again.
+
+  Getting this backwards is not a compile error and not a wrong result: the open is refused `EINVAL`, so directory listing simply stops working on the arch that was guessed wrong. Both directions have now been observed on real hardware.
+
+### Changed
+- #439 is closed as a non-defect. `fs.read_dir` works on aarch64 with the correct constant, so the aarch64 gate 0.24.1 put on `read_dir:lists_children` is removed and the test runs on every arch again.
+
+### Note
+The native aarch64 CI leg added in 0.24.1 is what caught this, one release after it was introduced rather than silently. qemu-aarch64 had also been reporting it correctly all along; it was discounted because qemu-riscv64 disagreed, and both were right about their own arch.
+
+
 ## [0.24.1] - 2026-08-07
 
 A wrong flag constant that made directory listing impossible on two of three linux arches, and the CI change that found it.

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.24.1"
+version = "0.24.2"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -854,22 +854,15 @@ test "std.filesystem.rename:replaces_existing_destination" {
 
 # read_dir lists a directory's children
 #
-# the regression for the O_DIRECTORY value. it was arch-gated to 0x4000 on aarch64
-# and riscv64, which is O_DIRECT, so the open failed EINVAL and read_dir could not
-# list anything at all on either. nothing exercised it, so it went unnoticed until a
-# riscv64 self-host build tried to enumerate a source tree
+# the regression for the O_DIRECTORY value, which arm swaps with O_DIRECT relative to
+# asm-generic. riscv64 had been given arm's value, so the open failed EINVAL and
+# read_dir could not list anything there. nothing exercised it, so it went unnoticed
+# until a riscv64 self-host build tried to enumerate a source tree
 test "std.filesystem.read_dir:lists_children" {
     var buf: [8192]u8;
     var st:  fixed.FixedState;
     var alloc: A.Allocator;
     if (O.is_some[*u8](fixed.make(?alloc, ?st, ?buf[0], 8192))) { ret 1; }
-
-    # aarch64 cannot pass this yet: the directory open is refused EINVAL on real
-    # hardware, so read_dir does not work there at all. That is #439, not a fault of
-    # this test, and the gate comes out with it. x86_64 and riscv64 do pass.
-    $if ($mach.build.arch == $mach.arch.aarch64) {
-        ret 0;
-    }
 
     val d: Path = "/tmp/mach_std_fs_rd";
     remove_all(?alloc, d);

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -355,13 +355,25 @@ pub val O_EXCL:      i32 = 128;
 pub val O_TRUNC:     i32 = 512;
 pub val O_APPEND:    i32 = 1024;
 
-# 0o200000 on every linux arch mach targets. x86_64, aarch64 and riscv64 all take
-# asm-generic's value for this flag, so it is NOT arch-gated. it was, with the two
-# non-x86 arches given 0x4000, which is O_DIRECT: opening a directory with it fails
-# EINVAL rather than doing anything, which is how it was found.
+# O_DIRECTORY and O_DIRECT are arch-gated, and ARM SWAPS THEM relative to
+# asm-generic. asm-generic/fcntl.h defines each under `#ifndef` precisely so an arch
+# can override, and arm does: O_DIRECTORY 0o40000 / O_DIRECT 0o200000, the reverse of
+# everyone else. aarch64 inherits arm's pair. x86_64 and riscv64 take asm-generic's.
+#
+# Getting this backwards is not a compile error and not a wrong result - the open is
+# simply refused EINVAL, so directory listing stops working on the arch you guessed
+# wrong. Both directions of that have now been observed on real hardware, so do not
+# "simplify" this to one value: verify on the arch before changing it, and note that
+# qemu-user is not evidence here (its aarch64 and riscv64 targets disagree with each
+# other about exactly this).
+$if ($mach.build.arch == $mach.arch.aarch64) {
+pub val O_DIRECTORY: i32 = 0o40000;
+pub val O_DIRECT:    i32 = 0o200000;
+}
+$or {
 pub val O_DIRECTORY: i32 = 0o200000;
-# not used by this layer, defined so the pair cannot be confused again
 pub val O_DIRECT:    i32 = 0o40000;
+}
 
 pub val AT_FDCWD:            i32 = -100;
 pub val AT_SYMLINK_NOFOLLOW: i32 = 0x0100;


### PR DESCRIPTION
Corrects the aarch64 regression 0.24.1 introduced.

0.24.1 unified `O_DIRECTORY` to `0o200000` on every linux arch. arm swaps `O_DIRECTORY` and `O_DIRECT` relative to asm-generic, so aarch64 needs `0o40000` and directory listing broke there. The original arch gate was right about aarch64 and wrong only about riscv64.

Caught by mach's native `test aarch64-linux` leg going red the moment it advanced its lock to 0.24.1, and by mach-std's own native arm64 leg, which 0.24.1 added. One release of exposure rather than silent breakage.

#439 closes as a non-defect and its test gate is removed.

All four legs green including native arm64. `mach test .` 765 passed 0 failed.