### PR TITLE
test(riscv64): run the library suite on the cross-riscv64 leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,15 @@ jobs:
       - name: Cross-compile and run the riscv64 runtime smoke test
         run: bash test/riscv64/verify.sh
 
+      # the library suite under qemu-user. this is real coverage for LOGIC and a
+      # weak signal for ABI CONSTANTS, per the note on the arm64 job below: an
+      # emulator can be confidently wrong about a flag value. it is still what
+      # would have caught #436, whose defect was a wrong constant producing a hard
+      # EINVAL rather than a subtle divergence. riscv64 has no native runner
+      # available, so a riscv64-only result stays provisional.
+      - name: Run the test suite on riscv64
+        run: mach test . --target linux-riscv64 --runner qemu-riscv64
+
       - name: RELRO re-protection contract (riscv64)
         run: bash test/relro/verify.sh mach linux-riscv64 qemu-riscv64
 

--- a/mach.toml
+++ b/mach.toml
@@ -14,6 +14,11 @@ isa = "aarch64"
 os  = "linux"
 abi = "aapcs64"
 
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
 [link.kernel32]
 source = "system"
 name = "kernel32.dll"


### PR DESCRIPTION
Closes #443.

No part of this suite had ever executed on riscv64. The leg ran `test/riscv64/verify.sh` and the RELRO contract only, and `mach.toml` declared no `linux-riscv64` target, so `mach test .` could not target it.

## The blocker is gone

The issue is marked blocked on briar-systems/mach#2654 — `error: codegen: 128-bit vectors not yet supported on riscv64`. That is fixed and shipped in 4.12.0, so I verified rather than assumed: all 765 tests build for riscv64 and pass.

| target | result |
|---|---|
| linux-x86_64 (native) | 765 passed, 0 failed |
| linux-arm64 (qemu) | 765 passed, 0 failed |
| linux-riscv64 (qemu) | 765 passed, 0 failed |

Identical counts across all three, which is the check that the riscv64 leg runs the same suite rather than a subset.

## Two things worth noting

**The ABI caveat is in the workflow, not just here.** The comment on the new step says plainly that qemu-user is real coverage for logic and a weak signal for ABI constants, and that riscv64 has no native runner so a riscv64-only result stays provisional. That matters because the arm64 job directly above carries the opposite note — it was moved to native hardware in #438 precisely because an emulator can be confidently wrong about a flag value. Someone reading the riscv64 leg going green should not conclude more from it than it supports.

It would still have caught #436, whose defect was a wrong constant producing a hard `EINVAL` rather than a subtle divergence.

**The ABI string is `lp64`, not `lp64d`.** I tried `lp64d` first, matching the usual RISC-V toolchain spelling, and got `no abi implementation registered for 'lp64d' (registered: sysv64, win64, aapcs64, lp64, spirv, mos6502)`. Recording it because the next person will make the same guess.

The runtime smoke test stays. It covers process startup rather than library behaviour, so the suite does not subsume it.