### PR TITLE
fix(derive): a ^ record is refused by our own leaf arm

### DIFF
--- a/src/derive.mach
+++ b/src/derive.mach
@@ -176,25 +176,25 @@ pub fun check[T]() {
                                 $or (f4.type == i8  || f4.type == i16 || f4.type == i32 || f4.type == i64
                                   || f4.type == u8  || f4.type == u16 || f4.type == u32 || f4.type == u64
                                   || f4.type == f32 || f4.type == f64) { }
-                                $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because type comparison does not strip ^, unlike the shape predicates (briar-systems/mach#2694)"); }
+                                $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because nothing strips ^: not type comparison, and since briar-systems/mach#2692 not the shape predicates either (briar-systems/mach#2694)"); }
                             }
                         }
                         $or (f3.type == i8  || f3.type == i16 || f3.type == i32 || f3.type == i64
                           || f3.type == u8  || f3.type == u16 || f3.type == u32 || f3.type == u64
                           || f3.type == f32 || f3.type == f64) { }
-                        $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because type comparison does not strip ^, unlike the shape predicates (briar-systems/mach#2694)"); }
+                        $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because nothing strips ^: not type comparison, and since briar-systems/mach#2692 not the shape predicates either (briar-systems/mach#2694)"); }
                     }
                 }
                 $or (f2.type == i8  || f2.type == i16 || f2.type == i32 || f2.type == i64
                   || f2.type == u8  || f2.type == u16 || f2.type == u32 || f2.type == u64
                   || f2.type == f32 || f2.type == f64) { }
-                $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because type comparison does not strip ^, unlike the shape predicates (briar-systems/mach#2694)"); }
+                $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because nothing strips ^: not type comparison, and since briar-systems/mach#2692 not the shape predicates either (briar-systems/mach#2694)"); }
             }
         }
         $or (f1.type == i8  || f1.type == i16 || f1.type == i32 || f1.type == i64
           || f1.type == u8  || f1.type == u16 || f1.type == u32 || f1.type == u64
           || f1.type == f32 || f1.type == f64) { }
-        $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because type comparison does not strip ^, unlike the shape predicates (briar-systems/mach#2694)"); }
+        $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because nothing strips ^: not type comparison, and since briar-systems/mach#2692 not the shape predicates either (briar-systems/mach#2694)"); }
     }
 }
 

--- a/test/derive/verify.sh
+++ b/test/derive/verify.sh
@@ -175,17 +175,20 @@ rec Y1 { y: Y2; }
 ' "$ref_msg"
 
 # a `^`-wrapped RECORD field is the one shape the classification cannot catch:
-# $is_record strips `^` and answers true, then $fields refuses the same operand
-# (briar-systems/mach#2692). it still fails the build, so no secret is walked,
-# but the message is mach's rather than ours. pinned so that a mach fix which
-# turns this into a walk -- and therefore into a printed secret -- is caught here
-# instead of in a program's output.
-refuses "a ^ secret record field fails the build, with mach's own message" '
+# a `^`-wrapped record reaches our own fallthrough now. mach#2692 made the shape
+# predicates answer about the outermost constructor, so `$is_record(^SInner)` is
+# false and the field falls to the leaf arm rather than being classified as a
+# record and then dying on `$fields`. this case previously pinned mach's raw
+# message so exactly that change would be caught here, and it was.
+#
+# it stays pinned on OUR message: a future mach change that made a secret record
+# classify as a record again would walk it, and a walk is a printed secret.
+refuses "a ^ secret record field is refused by our own leaf arm" '
 rec SInner { x: i64; }
 rec HasSR { n: i64; s: ^SInner; }
 ' '
     var a: HasSR;
     slot = slot + (derive.hash[HasSR](?a))::i64;
-' "\$fields requires a record type"
+' "$leaf_msg"
 
 echo "OK: every std.derive refusal is pinned"


### PR DESCRIPTION
Closes #448.

mach 4.13.0 shipped briar-systems/mach#2692, which makes the comptime shape predicates answer about the outermost constructor. `$is_record(^SInner)` is now false, so a `^`-wrapped record field falls to `std.derive`'s own leaf arm instead of classifying as a record and then dying on `$fields`.

**CI was broken by the release, and this fixes it.** Verified against the actual 4.13.0 binary rather than a local build:

```
FAIL: a ^ secret record field fails the build, with mach's own message:
      refused, but not with the expected message
```

## The harness did its job

That case deliberately pinned mach's raw `$fields requires a record type` so that a mach change turning this shape into a walk - and therefore into a printed secret - would be caught here rather than in a program's output. The change landed and the case caught it on the first release that carried it. That is the harness working as designed, not a maintenance burden it imposed.

The case stays pinned, now on our own message, and the comment says why: a future mach change that classified a secret record as a record again would walk it, and a walk is a printed secret. The thing being guarded has not changed, only which message proves it.

## Also corrected

Four copies of the leaf `$error` said a `^` field lands there "because type comparison does not strip `^`, unlike the shape predicates". The second clause went false with the same release - nothing strips `^` now. Reworded to say so and to name #2692.

## Verification, all against the 4.13.0 release binary

- `test/derive/verify.sh` — 10/10, including the changed case
- `mach test .` — 784 passed, 0 failed

No behaviour change in `std.derive` itself. The refusal was already correct; only the message reaching the user changed, and it changed for the better - the `^Rec` case now gets our written explanation instead of a raw intrinsic error.