### PR TITLE
derive: delete the depth cap, collapsing each walk to recursion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**Requires mach 4.14.0 or newer, and 4.13.0 will NOT build this.** `eq[f.type]` — the walk re-entering itself at a field's type — is a spelling mach did not accept before briar-systems/mach#2691, which landed on mach `dev` after 4.13.0 was tagged. On an older toolchain this is a **parse** error ("expected a module alias before `.`") reported against `src/derive.mach`, and because parsing precedes comptime evaluation the module's own `$mach.version` gate cannot fire ahead of it. The gate states the requirement where `mach doc` finds it; this note is what makes an old toolchain diagnosable.
+
+### Changed
+
+#### derive: the depth cap is gone, and the walk is recursion rather than a ladder (#449)
+
+`std.derive` shipped as bounded structural descent four levels deep, with a comptime `$error` past the bound. That bound was never a design choice — mach could not re-enter a generic at a field's type, so the descent had to be a hand-written ladder, one nested `$each` per level per derive.
+
+briar-systems/mach#2691 makes the recursive form spellable, and each of the five walks collapses to its own outermost level with the descent arm calling itself:
+
+```mach
+pub fun eq[T](a: *T, b: *T) bool {
+    check[T]();
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) {
+            if (!eq[f.type](?a.[f], ?b.[f])) { ret false; }
+        }
+        $or (SCALARS) { if (a.[f] != b.[f]) { ret false; } }
+        $or { }
+    }
+    ret true;
+}
+```
+
+**This was a deletion, not a rewrite**, which is how the ladder was shaped: every level was the same arms over the same projection, so levels 2 through 4 came out of five functions and nothing else moved. `check[T]` recurses alongside the walk it guards.
+
+**Behaviour is unchanged, and that is the evidence rather than the claim.** All 784 existing tests pass with **no edits**, including `fmt: four levels of nesting render every leaf` byte for byte. Four tests were added for six-level nesting, which was a comptime error before.
+
+Two details preserve behaviour exactly:
+
+- **`hash` threads its accumulator through the descent** (`fold_fields[T](h, v)`) rather than hashing each nested record on its own and combining. A nested field therefore contributes exactly the bytes a flattened one would, and the digest is identical to what the bounded walk produced. Hashing nested records separately would also have satisfied the eq/hash contract while silently changing every digest.
+- **`fmt` splits the nested label from the nested value.** `write_label` writes `[, ]name=` and the recursive `fmt` call supplies `Type{...}`, which composes to the same `name=Type{...}` the per-level bracketing produced.
+
+Termination is structural and needs no depth counter: a descent instantiates at a field's type, a record's fields are finite, and a record cannot contain itself by value. Note this does **not** extend to following references — `rec Grow[T] { p: *Grow[*T]; }` is legal and has unboundedly many instances reachable through its pointer, so a reference-following derive (briar-systems/mach#2693) needs a termination story this one gets for free.
+
+### Fixed
+
+#### derive: the module header described pre-4.13.0 behaviour (#449)
+
+#450 corrected the four leaf `$error` messages for briar-systems/mach#2692 but not the prose above them, so the header still said the shape predicates strip `^`, still drew a contrast between type comparison and the predicates that no longer exists, and still described a `^`-wrapped record as "the one shape that escapes the classification" failing with a raw intrinsic error — which #450 had just made false. The header now states the rule once: **nothing strips `^`**, so `^u64` fails `f.type == u64` and `^Rec` fails `$is_record`, and both are refused by our own fallback.
+
+### Tests
+
+- Six-level `eq` / `hash` / `clone` / `fmt` cases, each perturbing one leaf at a time at every depth, so a walk that stops short reports two different values equal.
+- `test/derive/verify.sh` loses its depth-cap case, because the cap it pinned no longer exists, and its positive control now nests six deep rather than four. The other nine refusals are unchanged and still pass.
+
 ## [0.25.0] - 2026-08-07
 
 **Requires mach 4.13.0 or newer.** `std.derive`'s recursive tier uses reflection primitives first shipped in 4.12.0, and its `^` handling tracks the shape-predicate change in 4.13.0 (briar-systems/mach#2692). The module checks `$mach.version` and says so, since `mach.lock` records dependency commits and cannot pin a toolchain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-**Requires mach 4.14.0 or newer, and 4.13.0 will NOT build this.** `eq[f.type]` — the walk re-entering itself at a field's type — is a spelling mach did not accept before briar-systems/mach#2691, which landed on mach `dev` after 4.13.0 was tagged. On an older toolchain this is a **parse** error ("expected a module alias before `.`") reported against `src/derive.mach`, and because parsing precedes comptime evaluation the module's own `$mach.version` gate cannot fire ahead of it. The gate states the requirement where `mach doc` finds it; this note is what makes an old toolchain diagnosable.
+**Requires mach 4.14.0 or newer, and 4.13.0 will NOT build this.** `eq[f.type]` — the walk re-entering itself at a field's type — is a spelling mach did not accept before briar-systems/mach#2691, which landed on mach `dev` after 4.13.0 was tagged. On an older toolchain this is a **parse** error ("expected a module alias before `.`") reported against `src/derive.mach`, and because parsing precedes comptime evaluation the module's own `$mach.version` gate cannot fire ahead of it. That is the missing capability in briar-systems/mach#2714 — a manifest is read before any source is, so a minimum-toolchain key there would diagnose this cleanly. Until then the gate states the requirement where `mach doc` finds it, and this note is what makes an old toolchain diagnosable.
 
 ### Changed
 

--- a/src/derive.mach
+++ b/src/derive.mach
@@ -8,15 +8,16 @@
 #
 # the walk descends. a field whose own type is a record is walked in turn, so a
 # derive over `Player { pos: Vec3 { x, y, z } }` reaches the three floats rather
-# than refusing at `pos`. the descent is bounded -- see below.
+# than refusing at `pos`, at any nesting depth.
 #
 # ## the classification contract
 #
 # every derive here classifies each field the same way, and `check[T]` is that
-# classification written once. a derive's own ladder carries only its leaf
-# action and relies on `check[T]` for every refusal, which is why each ladder's
-# trailing `$or { }` is empty rather than defensive: a field that reaches it has
-# already failed the build.
+# classification written once. a derive's own walk carries only its leaf action
+# and relies on `check[T]` for every refusal, which is why each walk's trailing
+# `$or { }` is empty rather than defensive: a field that reaches it has already
+# failed the build. `check[T]` recurses alongside the walk it guards, so a nested
+# record is classified at every depth.
 #
 # | field shape        | gate                | what happens                     |
 # |--------------------|---------------------|----------------------------------|
@@ -31,57 +32,49 @@
 # `bool` and `char` fields qualify. the fallback catches arrays, vectors, and
 # `^` secrets.
 #
-# adding a derive is the drop-in this shape is for: write the ladder with your
-# own leaf action, call `check[T]` first, and every refusal and message comes
-# with it. the leaf action is free to allocate or to fail -- `fmt` already
+# adding a derive is the drop-in this shape is for: write the walk with your own
+# leaf action, call `check[T]` first, and every refusal and message comes with
+# it. the leaf action is free to allocate or to fail -- `fmt` already
 # returns a `Result` and returns early from any depth -- so a fallible or
 # allocating member takes its extra parameters and its return type as it needs
 # them, without the contract changing.
 #
-# ## the descent is bounded, and the bound is measured
+# ## the descent is recursion, and it terminates structurally
 #
-# this is bounded structural descent, not recursion. mach cannot re-enter a
-# generic at a field's type -- `eq[f.type]` does not parse, there is no inference
-# from the argument, and `$type_of` is not a type operand -- so each level of
-# descent is a `$each` block someone wrote, and the depth is however many were
-# written. do not build on this expecting unbounded depth.
+# each derive walks one level and re-enters itself at a record field's own type
+# (`eq[f.type](?a.[f], ?b.[f])`). there is no depth limit and none is needed: a
+# descent instantiates at a field's type, a record's fields are finite, and a
+# record cannot contain itself by value -- the compiler refuses that as a
+# recursive type of infinite size. a self-reference has to go through a pointer,
+# which is a different type and which `$is_record` does not select.
 #
-# four levels (`T` plus three of nesting) is measured, not rounded. across the
-# 500 records in mach-std and the mach compiler, the deepest by-value record
-# nesting is exactly four, reached by two records:
+# this replaces a hand-written ladder four levels deep. that bound was never a
+# design choice, only what could be spelled: mach could not re-enter a generic at
+# a field's type until briar-systems/mach#2691.
 #
-#   Loop.iv : InductionVar -> InductionVar.init : Value -> Value.bytes : ValueBytes
-#   PcgWorker.sess : Session -> Session.registry : TargetRegistry -> .isa : IsaRegistry
-#
-# mach-std's own deepest is three (Decompressor.inf : Inflater -> .state : State).
-# so the bound covers every record either codebase has, with the deepest sitting
-# exactly on it. a record nested deeper is a comptime `$error` naming the bound
-# and what to do about it.
-#
-# briar-systems/mach#2691 asks for the one-token lookahead that removes this.
-# when it lands the change is a deletion, not a rewrite: each ladder collapses to
-# its own outermost level with the descent arm calling the function itself, which
-# is why every level here is the same three arms over the same projection and why
-# `check[T]` is a separate function rather than inlined into each derive.
+# the property does NOT extend to following references. `rec Grow[T] { p:
+# *Grow[*T]; }` is legal and has unboundedly many distinct instances reachable
+# through its pointer, so a reference-following derive needs a termination story
+# this one gets for free. see briar-systems/mach#2693.
 #
 # ## secrets are refused, not skipped
 #
-# none of these helpers is secrecy-aware, and none can be: the shape predicates
-# strip `^` before answering, so no comptime surface can tell a walk that a field
-# is secret (briar-systems/mach#2694). a secrecy-aware derive -- skip in `fmt`,
-# refuse in `hash`, constant-time compare in `eq` -- waits on that.
+# none of these helpers is secrecy-aware, and none can be: no comptime surface
+# reports that a field is secret (briar-systems/mach#2694). a secrecy-aware derive
+# -- skip in `fmt`, refuse in `hash`, constant-time compare in `eq` -- waits on
+# that.
 #
-# what makes that safe rather than silent is the scalar gate. type comparison
-# does *not* strip `^`, unlike the predicates, so a `^u64` field fails
-# `f.type == u64`, falls to the fallback, and is refused at comptime. that is why
-# the leaf is an explicit whitelist and not an `$or` catch-all: inverting the
-# gate would let every secret scalar through, and `fmt` would print it.
+# what makes that safe rather than silent is that **nothing strips `^`**. type
+# comparison never did, and since briar-systems/mach#2692 the shape predicates do
+# not either, so `^u64` fails `f.type == u64` and `^Rec` fails `$is_record`.
+# both fall to the fallback and are refused at comptime, with our message rather
+# than a raw intrinsic error.
 #
-# a `^`-wrapped *record* field is the one shape that escapes the classification.
-# `$is_record` strips `^` and answers true, then `$fields` refuses the same
-# operand, so the walk fails with a raw intrinsic error instead of a written one.
-# that is briar-systems/mach#2692; it fails the build either way, so no secret is
-# printed, but the message is mach's rather than ours.
+# that is why the leaf is an explicit whitelist and the fallback is an `$error`.
+# under the current predicate rule a walk that ACTED on its fallback would
+# silently skip a secret instead of refusing it, so the refusal is what makes
+# "nothing classifies it" a safe answer rather than a dangerous one. inverting
+# either gate would let secrets through, and `fmt` would print them.
 #
 # ## references are detected, never followed
 #
@@ -97,16 +90,26 @@
 # `-0.0` and `+0.0` are equal and hash alike, while a field holding NaN makes a
 # record never equal to itself (NaN compares unequal to everything).
 
-# the reflection primitives this module is written against -- `$fields(f.type)`,
-# `$is_record` / `$is_union` / `$is_pointer`, and `$type_name` -- first shipped in
-# mach 4.12.0. there is no manifest surface that pins a toolchain (`mach.lock`
-# records dependency commits and is generated), so the requirement is stated
-# here, where it is checked against the compiler actually running.
+# the walk re-enters itself at a field's type (`eq[f.type](...)`), a spelling mach
+# did not accept before briar-systems/mach#2691. that landed on mach `dev` AFTER
+# 4.13.0 was tagged, so 4.13.0 does not carry it and 4.14.0 is the first release
+# that can build this module. there is no manifest surface that pins a toolchain
+# (`mach.lock` records dependency commits and is generated), so the requirement is
+# stated here.
+#
+# THIS GATE CANNOT FIRE FOR THAT SPELLING, and the honest note matters more than
+# the appearance of a guard: `eq[f.type]` is a PARSE error on an older compiler,
+# and parsing precedes comptime evaluation, so an older toolchain reports
+# "expected a module alias before `.`" against this file rather than the message
+# below. the gate is kept because it states the requirement where `mach doc` finds
+# it, and because it would fire for a future requirement that is not a parse
+# error. it is not what makes an old toolchain diagnosable -- the CHANGELOG and
+# this comment are.
 $if ($mach.version.major < 4) {
-    $error("std.derive: needs mach 4.12.0 or newer; the recursive walk is written against $fields(f.type), $is_record / $is_union / $is_pointer, and $type_name");
+    $error("std.derive: needs mach 4.14.0 or newer; the walk re-enters itself with `eq[f.type]`, which mach did not accept before briar-systems/mach#2691 -- note 4.13.0 does NOT carry it");
 }
-$or ($mach.version.major == 4 && $mach.version.minor < 12) {
-    $error("std.derive: needs mach 4.12.0 or newer; the recursive walk is written against $fields(f.type), $is_record / $is_union / $is_pointer, and $type_name");
+$or ($mach.version.major == 4 && $mach.version.minor < 14) {
+    $error("std.derive: needs mach 4.14.0 or newer; the walk re-enters itself with `eq[f.type]`, which mach did not accept before briar-systems/mach#2691 -- note 4.13.0 does NOT carry it");
 }
 $or { }
 
@@ -146,7 +149,7 @@ fun fold(h: u64, word: u64) u64 {
 # refuse every field shape the derives here do not walk
 #
 # this is the classification contract in one place. each derive calls it before
-# its own ladder, so a rejected record fails the build with a message written
+# its own walk, so a rejected record fails the build with a message written
 # against the field shape rather than through whichever intrinsic the leaf action
 # happened to reach first. it is `pub` so a hand-written derive can hold itself
 # to the same rule.
@@ -157,43 +160,13 @@ fun fold(h: u64, word: u64) u64 {
 # ---
 # [T]: the record type to classify
 pub fun check[T]() {
-    $each f1 in $fields(T) {
-        $if ($is_union(f1.type))   { $error("std.derive: a union field cannot be walked -- $fields refuses a union, since its variants overlap in storage and a member walk would report fields that do not all exist. give the union its own operation and call it beside the derive"); }
-        $or ($is_pointer(f1.type)) { $error("std.derive: a reference field is detected but not followed -- mach has $is_pointer but no $pointee_of (briar-systems/mach#2693), and address semantics versus deep semantics is the caller's choice. note that str is *char, so a str field lands here"); }
-        $or ($is_record(f1.type))  {
-            $each f2 in $fields(f1.type) {
-                $if ($is_union(f2.type))   { $error("std.derive: a union field cannot be walked -- $fields refuses a union, since its variants overlap in storage and a member walk would report fields that do not all exist. give the union its own operation and call it beside the derive"); }
-                $or ($is_pointer(f2.type)) { $error("std.derive: a reference field is detected but not followed -- mach has $is_pointer but no $pointee_of (briar-systems/mach#2693), and address semantics versus deep semantics is the caller's choice. note that str is *char, so a str field lands here"); }
-                $or ($is_record(f2.type))  {
-                    $each f3 in $fields(f2.type) {
-                        $if ($is_union(f3.type))   { $error("std.derive: a union field cannot be walked -- $fields refuses a union, since its variants overlap in storage and a member walk would report fields that do not all exist. give the union its own operation and call it beside the derive"); }
-                        $or ($is_pointer(f3.type)) { $error("std.derive: a reference field is detected but not followed -- mach has $is_pointer but no $pointee_of (briar-systems/mach#2693), and address semantics versus deep semantics is the caller's choice. note that str is *char, so a str field lands here"); }
-                        $or ($is_record(f3.type))  {
-                            $each f4 in $fields(f3.type) {
-                                $if ($is_union(f4.type))   { $error("std.derive: a union field cannot be walked -- $fields refuses a union, since its variants overlap in storage and a member walk would report fields that do not all exist. give the union its own operation and call it beside the derive"); }
-                                $or ($is_pointer(f4.type)) { $error("std.derive: a reference field is detected but not followed -- mach has $is_pointer but no $pointee_of (briar-systems/mach#2693), and address semantics versus deep semantics is the caller's choice. note that str is *char, so a str field lands here"); }
-                                $or ($is_record(f4.type))  { $error("std.derive: record nesting is deeper than the four levels std.derive descends -- the descent is a hand-written ladder, since a generic cannot be re-entered at a field's type (briar-systems/mach#2691). flatten the record, hoist the innermost record into its own derive call, or write that level by hand"); }
-                                $or (f4.type == i8  || f4.type == i16 || f4.type == i32 || f4.type == i64
-                                  || f4.type == u8  || f4.type == u16 || f4.type == u32 || f4.type == u64
-                                  || f4.type == f32 || f4.type == f64) { }
-                                $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because nothing strips ^: not type comparison, and since briar-systems/mach#2692 not the shape predicates either (briar-systems/mach#2694)"); }
-                            }
-                        }
-                        $or (f3.type == i8  || f3.type == i16 || f3.type == i32 || f3.type == i64
-                          || f3.type == u8  || f3.type == u16 || f3.type == u32 || f3.type == u64
-                          || f3.type == f32 || f3.type == f64) { }
-                        $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because nothing strips ^: not type comparison, and since briar-systems/mach#2692 not the shape predicates either (briar-systems/mach#2694)"); }
-                    }
-                }
-                $or (f2.type == i8  || f2.type == i16 || f2.type == i32 || f2.type == i64
-                  || f2.type == u8  || f2.type == u16 || f2.type == u32 || f2.type == u64
-                  || f2.type == f32 || f2.type == f64) { }
-                $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because nothing strips ^: not type comparison, and since briar-systems/mach#2692 not the shape predicates either (briar-systems/mach#2694)"); }
-            }
-        }
-        $or (f1.type == i8  || f1.type == i16 || f1.type == i32 || f1.type == i64
-          || f1.type == u8  || f1.type == u16 || f1.type == u32 || f1.type == u64
-          || f1.type == f32 || f1.type == f64) { }
+    $each f in $fields(T) {
+        $if ($is_union(f.type))   { $error("std.derive: a union field cannot be walked -- $fields refuses a union, since its variants overlap in storage and a member walk would report fields that do not all exist. give the union its own operation and call it beside the derive"); }
+        $or ($is_pointer(f.type)) { $error("std.derive: a reference field is detected but not followed -- mach has $is_pointer but no $pointee_of (briar-systems/mach#2693), and address semantics versus deep semantics is the caller's choice. note that str is *char, so a str field lands here"); }
+        $or ($is_record(f.type))  { check[f.type](); }
+        $or (f.type == i8  || f.type == i16 || f.type == i32 || f.type == i64
+          || f.type == u8  || f.type == u16 || f.type == u32 || f.type == u64
+          || f.type == f32 || f.type == f64) { }
         $or { $error("std.derive: field type is neither a scalar numeric nor a nested record -- an array, a vector, or a ^ secret needs caller-chosen semantics. a ^ field lands here because nothing strips ^: not type comparison, and since briar-systems/mach#2692 not the shape predicates either (briar-systems/mach#2694)"); }
     }
 }
@@ -211,44 +184,14 @@ pub fun check[T]() {
 # ret: true when every field, at every depth, compares equal
 pub fun eq[T](a: *T, b: *T) bool {
     check[T]();
-    # check[T] refused every shape but a record or a scalar, so the trailing
-    # `$or` arms below are unreachable rather than defensive
-    $each f1 in $fields(T) {
-        $if ($is_record(f1.type)) {
-            $each f2 in $fields(f1.type) {
-                $if ($is_record(f2.type)) {
-                    $each f3 in $fields(f2.type) {
-                        $if ($is_record(f3.type)) {
-                            $each f4 in $fields(f3.type) {
-                                $if ($is_record(f4.type)) { }
-                                $or (f4.type == i8  || f4.type == i16 || f4.type == i32 || f4.type == i64
-                                  || f4.type == u8  || f4.type == u16 || f4.type == u32 || f4.type == u64
-                                  || f4.type == f32 || f4.type == f64) {
-                                    if (a.[f1].[f2].[f3].[f4] != b.[f1].[f2].[f3].[f4]) { ret false; }
-                                }
-                                $or { }
-                            }
-                        }
-                        $or (f3.type == i8  || f3.type == i16 || f3.type == i32 || f3.type == i64
-                          || f3.type == u8  || f3.type == u16 || f3.type == u32 || f3.type == u64
-                          || f3.type == f32 || f3.type == f64) {
-                            if (a.[f1].[f2].[f3] != b.[f1].[f2].[f3]) { ret false; }
-                        }
-                        $or { }
-                    }
-                }
-                $or (f2.type == i8  || f2.type == i16 || f2.type == i32 || f2.type == i64
-                  || f2.type == u8  || f2.type == u16 || f2.type == u32 || f2.type == u64
-                  || f2.type == f32 || f2.type == f64) {
-                    if (a.[f1].[f2] != b.[f1].[f2]) { ret false; }
-                }
-                $or { }
-            }
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) {
+            if (!eq[f.type](?a.[f], ?b.[f])) { ret false; }
         }
-        $or (f1.type == i8  || f1.type == i16 || f1.type == i32 || f1.type == i64
-          || f1.type == u8  || f1.type == u16 || f1.type == u32 || f1.type == u64
-          || f1.type == f32 || f1.type == f64) {
-            if (a.[f1] != b.[f1]) { ret false; }
+        $or (f.type == i8  || f.type == i16 || f.type == i32 || f.type == i64
+          || f.type == u8  || f.type == u16 || f.type == u32 || f.type == u64
+          || f.type == f32 || f.type == f64) {
+            if (a.[f] != b.[f]) { ret false; }
         }
         $or { }
     }
@@ -267,50 +210,30 @@ pub fun eq[T](a: *T, b: *T) bool {
 # ret: the 64-bit hash
 pub fun hash[T](v: *T) u64 {
     check[T]();
-    # check[T] refused every shape but a record or a scalar, so the trailing
-    # `$or` arms below are unreachable rather than defensive
-    var h: u64 = FNV_OFFSET;
-    $each f1 in $fields(T) {
-        $if ($is_record(f1.type)) {
-            $each f2 in $fields(f1.type) {
-                $if ($is_record(f2.type)) {
-                    $each f3 in $fields(f2.type) {
-                        $if ($is_record(f3.type)) {
-                            $each f4 in $fields(f3.type) {
-                                $if ($is_record(f4.type)) { }
-                                $or (f4.type == i8  || f4.type == i16 || f4.type == i32 || f4.type == i64
-                                  || f4.type == u8  || f4.type == u16 || f4.type == u32 || f4.type == u64) {
-                                    h = fold(h, (v.[f1].[f2].[f3].[f4])::u64);
-                                }
-                                $or (f4.type == f64) { h = fold(h, (v.[f1].[f2].[f3].[f4] + 0.0):~ u64); }
-                                $or (f4.type == f32) { h = fold(h, ((v.[f1].[f2].[f3].[f4])::f64 + 0.0):~ u64); }
-                                $or { }
-                            }
-                        }
-                        $or (f3.type == i8  || f3.type == i16 || f3.type == i32 || f3.type == i64
-                          || f3.type == u8  || f3.type == u16 || f3.type == u32 || f3.type == u64) {
-                            h = fold(h, (v.[f1].[f2].[f3])::u64);
-                        }
-                        $or (f3.type == f64) { h = fold(h, (v.[f1].[f2].[f3] + 0.0):~ u64); }
-                        $or (f3.type == f32) { h = fold(h, ((v.[f1].[f2].[f3])::f64 + 0.0):~ u64); }
-                        $or { }
-                    }
-                }
-                $or (f2.type == i8  || f2.type == i16 || f2.type == i32 || f2.type == i64
-                  || f2.type == u8  || f2.type == u16 || f2.type == u32 || f2.type == u64) {
-                    h = fold(h, (v.[f1].[f2])::u64);
-                }
-                $or (f2.type == f64) { h = fold(h, (v.[f1].[f2] + 0.0):~ u64); }
-                $or (f2.type == f32) { h = fold(h, ((v.[f1].[f2])::f64 + 0.0):~ u64); }
-                $or { }
-            }
+    ret fold_fields[T](FNV_OFFSET, v);
+}
+
+# fold `v`'s fields into a running accumulator, descending into nested records
+#
+# the accumulator is threaded through the descent rather than each nested record
+# being hashed on its own and combined, so a nested field contributes exactly the
+# bytes a flattened one would, so the digest is unchanged from the bounded walk
+# this replaced.
+# ---
+# [T]: the record type to fold
+# h0:  the accumulator to fold into
+# v:   the record whose fields are folded
+# ret: the accumulator after every field, at every depth
+fun fold_fields[T](h0: u64, v: *T) u64 {
+    var h: u64 = h0;
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) { h = fold_fields[f.type](h, ?v.[f]); }
+        $or (f.type == i8  || f.type == i16 || f.type == i32 || f.type == i64
+          || f.type == u8  || f.type == u16 || f.type == u32 || f.type == u64) {
+            h = fold(h, (v.[f])::u64);
         }
-        $or (f1.type == i8  || f1.type == i16 || f1.type == i32 || f1.type == i64
-          || f1.type == u8  || f1.type == u16 || f1.type == u32 || f1.type == u64) {
-            h = fold(h, (v.[f1])::u64);
-        }
-        $or (f1.type == f64) { h = fold(h, (v.[f1] + 0.0):~ u64); }
-        $or (f1.type == f32) { h = fold(h, ((v.[f1])::f64 + 0.0):~ u64); }
+        $or (f.type == f64) { h = fold(h, (v.[f] + 0.0):~ u64); }
+        $or (f.type == f32) { h = fold(h, ((v.[f])::f64 + 0.0):~ u64); }
         $or { }
     }
     ret h;
@@ -333,64 +256,29 @@ pub fun hash[T](v: *T) u64 {
 # src: source record
 pub fun clone[T](dst: *T, src: *T) {
     check[T]();
-    # check[T] refused every shape but a record or a scalar, so the trailing
-    # `$or` arms below are unreachable rather than defensive
-    $each f1 in $fields(T) {
-        $if ($is_record(f1.type)) {
-            $each f2 in $fields(f1.type) {
-                $if ($is_record(f2.type)) {
-                    $each f3 in $fields(f2.type) {
-                        $if ($is_record(f3.type)) {
-                            $each f4 in $fields(f3.type) {
-                                $if ($is_record(f4.type)) { }
-                                $or (f4.type == i8  || f4.type == i16 || f4.type == i32 || f4.type == i64
-                                  || f4.type == u8  || f4.type == u16 || f4.type == u32 || f4.type == u64
-                                  || f4.type == f32 || f4.type == f64) {
-                                    dst.[f1].[f2].[f3].[f4] = src.[f1].[f2].[f3].[f4];
-                                }
-                                $or { }
-                            }
-                        }
-                        $or (f3.type == i8  || f3.type == i16 || f3.type == i32 || f3.type == i64
-                          || f3.type == u8  || f3.type == u16 || f3.type == u32 || f3.type == u64
-                          || f3.type == f32 || f3.type == f64) {
-                            dst.[f1].[f2].[f3] = src.[f1].[f2].[f3];
-                        }
-                        $or { }
-                    }
-                }
-                $or (f2.type == i8  || f2.type == i16 || f2.type == i32 || f2.type == i64
-                  || f2.type == u8  || f2.type == u16 || f2.type == u32 || f2.type == u64
-                  || f2.type == f32 || f2.type == f64) {
-                    dst.[f1].[f2] = src.[f1].[f2];
-                }
-                $or { }
-            }
-        }
-        $or (f1.type == i8  || f1.type == i16 || f1.type == i32 || f1.type == i64
-          || f1.type == u8  || f1.type == u16 || f1.type == u32 || f1.type == u64
-          || f1.type == f32 || f1.type == f64) {
-            dst.[f1] = src.[f1];
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) { clone[f.type](?dst.[f], ?src.[f]); }
+        $or (f.type == i8  || f.type == i16 || f.type == i32 || f.type == i64
+          || f.type == u8  || f.type == u16 || f.type == u32 || f.type == u64
+          || f.type == f32 || f.type == f64) {
+            dst.[f] = src.[f];
         }
         $or { }
     }
 }
 
-# write `[, ]name=Type{` for a nested record field
+# write a nested record field's label, `[, ]name=`
+#
+# the value that follows is written by `fmt` recursing at the field's type, which
+# supplies the `Type{...}` half.
 # ---
 # w:     target writer
 # first: true when no field has been written at this level yet
 # name:  the field's name
-# tname: the field type's spelling
 # ret:   bytes written, or an error message
-fun open_nested(w: *writer.Writer, first: bool, name: *u8, tname: *u8) R.Result[usize, str] {
-    var r: R.Result[usize, str];
-    if (first) { r = format.format(w, "{}={}", name, tname); }
-    or         { r = format.format(w, ", {}={}", name, tname); }
-    if (R.is_err[usize, str](r)) { ret r; }
-    val opened: R.Result[usize, str] = format.write_byte(w, '{');
-    if (R.is_err[usize, str](opened)) { ret opened; }
-    ret R.ok[usize, str](R.unwrap_ok[usize, str](r) + R.unwrap_ok[usize, str](opened));
+fun write_label(w: *writer.Writer, first: bool, name: *u8) R.Result[usize, str] {
+    if (first) { ret format.format(w, "{}=", name); }
+    ret format.format(w, ", {}=", name);
 }
 
 # write a record as `Type{field=value, ...}` to a writer
@@ -416,8 +304,6 @@ fun open_nested(w: *writer.Writer, first: bool, name: *u8, tname: *u8) R.Result[
 # ret: total bytes written, or an error message
 pub fun fmt[T](w: *writer.Writer, v: *T) R.Result[usize, str] {
     check[T]();
-    # check[T] refused every shape but a record or a scalar, so the trailing
-    # `$or` arms below are unreachable rather than defensive
     var total: usize = 0;
 
     val name: R.Result[usize, str] = format.format(w, "{}", $type_name(T));
@@ -428,87 +314,29 @@ pub fun fmt[T](w: *writer.Writer, v: *T) R.Result[usize, str] {
     if (R.is_err[usize, str](open)) { ret open; }
     total = total + R.unwrap_ok[usize, str](open);
 
-    var first1: bool = true;
-    $each f1 in $fields(T) {
-        $if ($is_record(f1.type)) {
-            val o1: R.Result[usize, str] = open_nested(w, first1, f1.name, $type_name(f1.type));
-            if (R.is_err[usize, str](o1)) { ret o1; }
-            total = total + R.unwrap_ok[usize, str](o1);
-            first1 = false;
-            var first2: bool = true;
-            $each f2 in $fields(f1.type) {
-                $if ($is_record(f2.type)) {
-                    val o2: R.Result[usize, str] = open_nested(w, first2, f2.name, $type_name(f2.type));
-                    if (R.is_err[usize, str](o2)) { ret o2; }
-                    total = total + R.unwrap_ok[usize, str](o2);
-                    first2 = false;
-                    var first3: bool = true;
-                    $each f3 in $fields(f2.type) {
-                        $if ($is_record(f3.type)) {
-                            val o3: R.Result[usize, str] = open_nested(w, first3, f3.name, $type_name(f3.type));
-                            if (R.is_err[usize, str](o3)) { ret o3; }
-                            total = total + R.unwrap_ok[usize, str](o3);
-                            first3 = false;
-                            var first4: bool = true;
-                            $each f4 in $fields(f3.type) {
-                                $if ($is_record(f4.type)) { }
-                                $or (f4.type == i8  || f4.type == i16 || f4.type == i32 || f4.type == i64
-                                  || f4.type == u8  || f4.type == u16 || f4.type == u32 || f4.type == u64
-                                  || f4.type == f32 || f4.type == f64) {
-                                    var r4: R.Result[usize, str];
-                                    if (first4) { r4 = format.format(w, "{}={}", f4.name, v.[f1].[f2].[f3].[f4]); }
-                                    or          { r4 = format.format(w, ", {}={}", f4.name, v.[f1].[f2].[f3].[f4]); }
-                                    first4 = false;
-                                    if (R.is_err[usize, str](r4)) { ret r4; }
-                                    total = total + R.unwrap_ok[usize, str](r4);
-                                }
-                                $or { }
-                            }
-                            val c3: R.Result[usize, str] = format.write_byte(w, '}');
-                            if (R.is_err[usize, str](c3)) { ret c3; }
-                            total = total + R.unwrap_ok[usize, str](c3);
-                        }
-                        $or (f3.type == i8  || f3.type == i16 || f3.type == i32 || f3.type == i64
-                          || f3.type == u8  || f3.type == u16 || f3.type == u32 || f3.type == u64
-                          || f3.type == f32 || f3.type == f64) {
-                            var r3: R.Result[usize, str];
-                            if (first3) { r3 = format.format(w, "{}={}", f3.name, v.[f1].[f2].[f3]); }
-                            or          { r3 = format.format(w, ", {}={}", f3.name, v.[f1].[f2].[f3]); }
-                            first3 = false;
-                            if (R.is_err[usize, str](r3)) { ret r3; }
-                            total = total + R.unwrap_ok[usize, str](r3);
-                        }
-                        $or { }
-                    }
-                    val c2: R.Result[usize, str] = format.write_byte(w, '}');
-                    if (R.is_err[usize, str](c2)) { ret c2; }
-                    total = total + R.unwrap_ok[usize, str](c2);
-                }
-                $or (f2.type == i8  || f2.type == i16 || f2.type == i32 || f2.type == i64
-                  || f2.type == u8  || f2.type == u16 || f2.type == u32 || f2.type == u64
-                  || f2.type == f32 || f2.type == f64) {
-                    var r2: R.Result[usize, str];
-                    if (first2) { r2 = format.format(w, "{}={}", f2.name, v.[f1].[f2]); }
-                    or          { r2 = format.format(w, ", {}={}", f2.name, v.[f1].[f2]); }
-                    first2 = false;
-                    if (R.is_err[usize, str](r2)) { ret r2; }
-                    total = total + R.unwrap_ok[usize, str](r2);
-                }
-                $or { }
-            }
-            val c1: R.Result[usize, str] = format.write_byte(w, '}');
-            if (R.is_err[usize, str](c1)) { ret c1; }
-            total = total + R.unwrap_ok[usize, str](c1);
+    var first: bool = true;
+    $each f in $fields(T) {
+        $if ($is_record(f.type)) {
+            # the label, then the field's own rendering. this call writes
+            # `Type{...}`, so the two together give `name=Type{...}`.
+            val lab: R.Result[usize, str] = write_label(w, first, f.name);
+            if (R.is_err[usize, str](lab)) { ret lab; }
+            total = total + R.unwrap_ok[usize, str](lab);
+            first = false;
+
+            val nested: R.Result[usize, str] = fmt[f.type](w, ?v.[f]);
+            if (R.is_err[usize, str](nested)) { ret nested; }
+            total = total + R.unwrap_ok[usize, str](nested);
         }
-        $or (f1.type == i8  || f1.type == i16 || f1.type == i32 || f1.type == i64
-          || f1.type == u8  || f1.type == u16 || f1.type == u32 || f1.type == u64
-          || f1.type == f32 || f1.type == f64) {
-            var r1: R.Result[usize, str];
-            if (first1) { r1 = format.format(w, "{}={}", f1.name, v.[f1]); }
-            or          { r1 = format.format(w, ", {}={}", f1.name, v.[f1]); }
-            first1 = false;
-            if (R.is_err[usize, str](r1)) { ret r1; }
-            total = total + R.unwrap_ok[usize, str](r1);
+        $or (f.type == i8  || f.type == i16 || f.type == i32 || f.type == i64
+          || f.type == u8  || f.type == u16 || f.type == u32 || f.type == u64
+          || f.type == f32 || f.type == f64) {
+            var r: R.Result[usize, str];
+            if (first) { r = format.format(w, "{}={}", f.name, v.[f]); }
+            or         { r = format.format(w, ", {}={}", f.name, v.[f]); }
+            first = false;
+            if (R.is_err[usize, str](r)) { ret r; }
+            total = total + R.unwrap_ok[usize, str](r);
         }
         $or { }
     }
@@ -535,6 +363,25 @@ rec N1 { mid: N2; n: i32; }
 rec N0 { deep: N1; tag: u8; }
 rec NEmpty {}
 rec NHolder { e: NEmpty; z: i64; }
+
+# six levels. this was a comptime `$error` before the walk became recursive, and
+# it is the case that proves the bound is gone rather than merely larger.
+rec D6 { a: i64; b: f64; }
+rec D5 { d: D6; k: u16; }
+rec D4 { d: D5; k: u16; }
+rec D3 { d: D4; k: u16; }
+rec D2 { d: D3; n: i32; }
+rec D1 { d: D2; tag: u8; }
+
+fun d1_fill(v: *D1) {
+    v.d.d.d.d.d.a = 11;
+    v.d.d.d.d.d.b = 2.5;
+    v.d.d.d.d.k = 22;
+    v.d.d.d.k = 33;
+    v.d.d.k = 44;
+    v.d.n = -55;
+    v.tag = 66;
+}
 
 # a fixed four-level value the nesting tests perturb one field at a time
 fun n0_fill(v: *N0) {
@@ -819,7 +666,7 @@ test "clone: every nested leaf is copied" {
     clone[N0](?dst, ?src);
     if (!eq[N0](?dst, ?src)) { ret 1; }
 
-    # named leaf by leaf, so a ladder that drops a level fails here rather than
+    # named leaf by leaf, so a walk that drops a level fails here rather than
     # passing on an eq that dropped the same level
     if (dst.deep.mid.inner.a != 11) { ret 1; }
     if (dst.deep.mid.inner.b != 2.5) { ret 1; }
@@ -852,5 +699,78 @@ test "clone: flat records and empty records" {
     var esrc: DEmpty;
     var edst: DEmpty;
     clone[DEmpty](?edst, ?esrc);
+    ret 0;
+}
+
+test "eq: six levels, deeper than the old bound" {
+    var a: D1; d1_fill(?a);
+    var b: D1; d1_fill(?b);
+    if (!eq[D1](?a, ?b)) { ret 1; }
+
+    # one leaf at a time, at every depth. a walk that stops short reports two
+    # different values equal.
+    b.d.d.d.d.d.a = 12;
+    if (eq[D1](?a, ?b)) { ret 1; }
+    d1_fill(?b);
+    b.d.d.d.d.d.b = 2.75;
+    if (eq[D1](?a, ?b)) { ret 1; }
+    d1_fill(?b);
+    b.d.d.d.d.k = 23;
+    if (eq[D1](?a, ?b)) { ret 1; }
+    d1_fill(?b);
+    b.d.d.d.k = 34;
+    if (eq[D1](?a, ?b)) { ret 1; }
+    d1_fill(?b);
+    b.d.d.k = 45;
+    if (eq[D1](?a, ?b)) { ret 1; }
+    d1_fill(?b);
+    b.d.n = -56;
+    if (eq[D1](?a, ?b)) { ret 1; }
+    d1_fill(?b);
+    b.tag = 67;
+    if (eq[D1](?a, ?b)) { ret 1; }
+    ret 0;
+}
+
+test "hash: six levels, a difference at any depth changes the hash" {
+    var a: D1; d1_fill(?a);
+    var b: D1; d1_fill(?b);
+    if (hash[D1](?a) != hash[D1](?b)) { ret 1; }
+    b.d.d.d.d.d.a = 12;
+    if (hash[D1](?a) == hash[D1](?b)) { ret 1; }
+    d1_fill(?b);
+    b.d.d.d.k = 34;
+    if (hash[D1](?a) == hash[D1](?b)) { ret 1; }
+    ret 0;
+}
+
+test "clone: six levels, every leaf copied and independent" {
+    var src: D1; d1_fill(?src);
+    var dst: D1;
+    clone[D1](?dst, ?src);
+    if (!eq[D1](?dst, ?src)) { ret 1; }
+    if (dst.d.d.d.d.d.a != 11) { ret 1; }
+    if (dst.d.d.d.d.d.b != 2.5) { ret 1; }
+    if (dst.d.d.d.d.k != 22) { ret 1; }
+    if (dst.d.d.d.k != 33) { ret 1; }
+    if (dst.d.d.k != 44) { ret 1; }
+    if (dst.d.n != -55) { ret 1; }
+    if (dst.tag != 66) { ret 1; }
+
+    src.d.d.d.d.d.a = 99;
+    if (dst.d.d.d.d.d.a != 11) { ret 1; }
+    ret 0;
+}
+
+test "fmt: six levels render every leaf" {
+    var scratch: [256]u8;
+    var cap: DCap; cap.data = ?scratch[0]; cap.len = 0; cap.cap = 256;
+    var w: writer.Writer; w.ctx = (?cap)::ptr; w.f_write = cap_write;
+
+    var v: D1; d1_fill(?v);
+    val r: R.Result[usize, str] = fmt[D1](?w, ?v);
+    if (R.is_err[usize, str](r)) { ret 1; }
+    scratch[cap.len] = 0;
+    if (!str_equals(?scratch[0], "D1{d=D2{d=D3{d=D4{d=D5{d=D6{a=11, b=2.5}, k=22}, k=33}, k=44}, n=-55}, tag=66}")) { ret 1; }
     ret 0;
 }

--- a/src/derive.mach
+++ b/src/derive.mach
@@ -97,14 +97,17 @@
 # (`mach.lock` records dependency commits and is generated), so the requirement is
 # stated here.
 #
-# THIS GATE CANNOT FIRE FOR THAT SPELLING, and the honest note matters more than
-# the appearance of a guard: `eq[f.type]` is a PARSE error on an older compiler,
-# and parsing precedes comptime evaluation, so an older toolchain reports
-# "expected a module alias before `.`" against this file rather than the message
-# below. the gate is kept because it states the requirement where `mach doc` finds
-# it, and because it would fire for a future requirement that is not a parse
-# error. it is not what makes an old toolchain diagnosable -- the CHANGELOG and
-# this comment are.
+# THIS GATE CANNOT FIRE FOR THAT SPELLING. `eq[f.type]` is a PARSE error on an
+# older compiler, and parsing precedes comptime evaluation, so an older toolchain
+# reports "expected a module alias before `.`" against this file rather than the
+# message below. that is not a flaw in the gate, it is the missing capability in
+# briar-systems/mach#2714: a manifest is read before any source is parsed, so a
+# minimum-toolchain key there would diagnose this cleanly, and mach has none.
+#
+# the gate is kept because it states the requirement where `mach doc` finds it and
+# because it would fire for a future requirement that is not a syntax one. until
+# #2714 lands it is not what makes an old toolchain diagnosable -- the CHANGELOG
+# and this comment are.
 $if ($mach.version.major < 4) {
     $error("std.derive: needs mach 4.14.0 or newer; the walk re-enters itself with `eq[f.type]`, which mach did not accept before briar-systems/mach#2691 -- note 4.13.0 does NOT carry it");
 }

--- a/test/derive/verify.sh
+++ b/test/derive/verify.sh
@@ -81,13 +81,14 @@ accepts() {
 union_msg="a union field cannot be walked"
 ref_msg="a reference field is detected but not followed"
 leaf_msg="field type is neither a scalar numeric nor a nested record"
-depth_msg="record nesting is deeper than the four levels std.derive descends"
 
-accepts "a four-level record is accepted by every derive" '
-rec P4 { a: i64; b: f64; }
-rec P3 { inner: P4; k: u16; }
-rec P2 { mid: P3; n: i32; }
-rec P1 { deep: P2; tag: u8; }
+accepts "a deeply nested record is accepted by every derive" '
+rec P6 { a: i64; b: f64; }
+rec P5 { d: P6; k: u16; }
+rec P4 { d: P5; k: u16; }
+rec P3 { d: P4; k: u16; }
+rec P2 { d: P3; n: i32; }
+rec P1 { d: P2; tag: u8; }
 ' '
     var a: P1;
     var b: P1;
@@ -140,17 +141,6 @@ rec HasK { n: i64; k: ^u64; }
     var b: HasK;
     if (derive.eq[HasK](?a, ?b)) { slot = slot + 1; }
 ' "$leaf_msg"
-
-refuses "fmt refuses nesting deeper than the ladder descends" '
-rec D5 { a: i64; }
-rec D4 { d: D5; }
-rec D3 { d: D4; }
-rec D2 { d: D3; }
-rec D1 { d: D2; }
-' '
-    var a: D1;
-    if (R.is_err[usize, str](derive.fmt[D1](?w, ?a))) { slot = slot + 1; }
-' "$depth_msg"
 
 # the classification runs at every level, not only the first
 refuses "clone refuses a union reached at depth three" '


### PR DESCRIPTION
Closes #449.

**Requires mach 4.14.0.** Verified against the downloaded release binary, not a local build — `v4.14.0` carries briar-systems/mach#2691 (`merge-base --is-ancestor` confirms), 4.13.0 does not.

## The deletion

`std.derive` shipped as bounded structural descent four levels deep with a comptime `$error` past the bound. That bound was never a design choice — mach could not re-enter a generic at a field's type, so the descent had to be a hand-written ladder, one nested `$each` per level per derive.

mach#2691 makes the recursive form spellable, and each of the five walks collapses to its own outermost level with the descent arm calling itself:

```mach
pub fun eq[T](a: *T, b: *T) bool {
    check[T]();
    $each f in $fields(T) {
        $if ($is_record(f.type)) {
            if (!eq[f.type](?a.[f], ?b.[f])) { ret false; }
        }
        $or (SCALARS) { if (a.[f] != b.[f]) { ret false; } }
        $or { }
    }
    ret true;
}
```

**This was a deletion, not a rewrite**, which is how the ladder was shaped: every level was the same arms over the same projection, so levels 2 through 4 came out of five functions and nothing else moved. `check[T]` recurses alongside the walk it guards. Net −177 lines in `src/derive.mach` before the added tests.

## Behaviour is unchanged, and the tests are the evidence

**All 784 existing tests pass with no edits**, including `fmt: four levels of nesting render every leaf` byte for byte. That is the claim, and it is unmodified tests making it rather than adjusted ones.

Two details were needed to keep it exact, and both are changes a weaker suite would have accepted while silently altering output:

- **`hash` threads its accumulator through the descent** (`fold_fields[T](h, v)`) rather than hashing each nested record on its own and combining. A nested field therefore contributes exactly the bytes a flattened one would, and every digest is identical to before. Combining per-record digests would still satisfy the eq/hash contract — two equal records hash alike, two different ones differ — while changing every hash value, and no existing test pins an absolute digest.
- **`fmt` splits the nested label from the nested value.** `write_label` writes `[, ]name=` and the recursive `fmt` supplies `Type{...}`, composing to the same `name=Type{...}` the per-level bracketing produced.

The only removed test is the harness's depth-cap case, because the cap it pinned no longer exists. That is deleting a test for a deleted feature, not adjusting one to accommodate the collapse.

## Termination

Structural, and no depth counter is needed: a descent instantiates at a field's type, a record's fields are finite, and a record cannot contain itself by value — the compiler refuses that as a recursive type of infinite size.

This does **not** extend to following references. `rec Grow[T] { p: *Grow[*T]; }` is legal and has unboundedly many distinct instances reachable through its pointer, so a reference-following derive (mach#2693) needs a termination story this one gets for free. Stated in the module header and on that issue.

## The header was describing behaviour that had already changed

#450 corrected the four leaf `$error` messages for mach#2692 but not the prose above them, so the header still said the shape predicates strip `^`, still drew a contrast between type comparison and the predicates that no longer exists, and still described a `^`-wrapped record as "the one shape that escapes the classification" failing with a raw intrinsic error — which #450's own renamed harness case had just made false. Code, harness and prose disagreed.

The header now states the rule once: **nothing strips `^`**. Type comparison never did, and since mach#2692 the predicates do not either, so `^u64` fails `f.type == u64` and `^Rec` fails `$is_record`, and both are refused by our own fallback. The section also now says why the whitelist and the refusing fallback are load-bearing: under the current predicate rule, a walk that *acted* on its fallback would silently skip a secret rather than refuse it.

## The version gate cannot do its job, and now says so

The `$mach.version` gate moves to 4.14.0, but it **cannot fire for this requirement** and the comment says so rather than implying a guard that works. `eq[f.type]` is a *parse* error on an older compiler, and parsing precedes comptime evaluation, so a 4.13.0 build gets five copies of `expected a module alias before '.'` pointed into this file and never reaches the `$error`.

That is not a flaw in the gate but a missing capability, filed as **briar-systems/mach#2714**: a manifest is read before any source is parsed, so a `[project].mach` minimum-toolchain key would diagnose it cleanly, including cascading from a dependency so a consumer is told which dependency demands the version. The gate is kept because it states the requirement where `mach doc` finds it and would fire for a future non-syntax requirement; until #2714 lands, the CHANGELOG is what actually reaches a user.

## Tests

Verified against the **downloaded 4.14.0 release binary**, which is what CI installs:

| leg | result |
|---|---|
| `mach test .` | **788 passed, 0 failed**, 18 skipped |
| `--target linux-arm64 --runner qemu-aarch64` | 788 passed, 0 failed, 18 skipped |
| `--target linux-riscv64 --runner qemu-riscv64` | 788 passed, 0 failed, 18 skipped |
| `test/derive/verify.sh` | 9 of 9 remaining cases pass |

784 → 788 is four added six-level cases for `eq` / `hash` / `clone` / `fmt`, each perturbing one leaf at a time at every depth so a walk that stops short reports two different values equal. Six levels was a comptime error before this.

`test/derive/verify.sh` loses its depth case and its positive control now nests six deep rather than four. The other nine refusals — union, reference, `str`, array, `^` scalar, `^` record, and the two reached at depth three — are unchanged.
