### PR TITLE
ci: seed from the latest published mach release, not any release

### DIFF
--- a/.github/actions/seed-mach/action.yml
+++ b/.github/actions/seed-mach/action.yml
@@ -1,0 +1,93 @@
+name: seed mach
+description: put the released mach compiler for this runner's host on PATH
+
+# every lane builds this library with a RELEASED mach, so which release that is decides
+# what the whole suite was compiled by. it resolves through
+# repos/briar-systems/mach/releases/latest, which serves the newest *published* release
+# and never a draft or a prerelease. an untagged `gh release download` instead takes
+# whatever release the client considers newest, so a draft holding one hand-uploaded
+# archive silently became the seed and broke every lane whose host archive it did not
+# carry (briar-systems/mach#2573, and briar-systems/mach-std#457 for this repo).
+#
+# the failure this prevents is not a broken build, which is loud. it is a GREEN suite
+# compiled by a compiler nobody chose. resolution lives here, once, so no call site can
+# reintroduce it.
+#
+# NOTE the repository is hardcoded rather than read from $GITHUB_REPOSITORY: the seed
+# comes from mach, and this is mach-std. mach's own copy of this action resolves its own
+# repository, and that difference is the whole reason this is a separate file.
+
+inputs:
+  token:
+    description: token used to read the release
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  tag:
+    description: tag of the release the seed came from
+    value: ${{ steps.resolve.outputs.tag }}
+
+runs:
+  using: composite
+  steps:
+    # the seed has to EXEC on the runner, whatever it is later asked to build for, so
+    # each lane takes its own host's archive. the name is derived from the resolved tag
+    # rather than written per job, so it cannot drift from `runs-on`.
+    - name: resolve the seed release
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        case "$RUNNER_OS/$RUNNER_ARCH" in
+          Linux/X64)     host=x86_64-linux;    ext=tar.gz ;;
+          Linux/ARM64)   host=aarch64-linux;   ext=tar.gz ;;
+          Windows/X64)   host=x86_64-windows;  ext=zip ;;
+          macOS/X64)     host=x86_64-darwin;   ext=tar.gz ;;
+          macOS/ARM64)   host=aarch64-darwin;  ext=tar.gz ;;
+          *) echo "::error::no mach seed archive is published for host $RUNNER_OS/$RUNNER_ARCH"; exit 1 ;;
+        esac
+
+        # first line is the tag, the rest are the release's asset names
+        listing="$(gh api "repos/briar-systems/mach/releases/latest" --jq '.tag_name, .assets[].name')"
+        tag="$(printf '%s\n' "$listing" | head -1)"
+        names="$(printf '%s\n' "$listing" | tail -n +2)"
+        asset="mach-${tag#v}-$host.$ext"
+
+        if ! printf '%s\n' "$names" | grep -Fxq "$asset"; then
+          echo "::error::the latest published mach release $tag carries no $asset — it holds: $(printf '%s' "$names" | tr '\n' ' ')"
+          exit 1
+        fi
+
+        # a relative directory keeps every path here portable to the windows runner's bash
+        mkdir -p .mach-seed
+        gh release download "$tag" -R briar-systems/mach -p "$asset" -D .mach-seed
+
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "asset=$asset" >> "$GITHUB_OUTPUT"
+        echo "seeding from $tag ($asset)"
+
+    - name: install the seed
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        ASSET: ${{ steps.resolve.outputs.asset }}
+      run: |
+        set -euo pipefail
+        tar -xzf ".mach-seed/$ASSET" -C .mach-seed mach
+        chmod +x .mach-seed/mach
+        echo "$PWD/.mach-seed" >> "$GITHUB_PATH"
+
+    # GITHUB_PATH only takes effect in later steps, so callers seed in one step and use
+    # the compiler in the next
+    - name: install the seed
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        ASSET: ${{ steps.resolve.outputs.asset }}
+      run: |
+        $dir = Join-Path $PWD '.mach-seed'
+        Expand-Archive -Path (Join-Path $dir $env:ASSET) -DestinationPath $dir -Force
+        Add-Content -Path $env:GITHUB_PATH -Value $dir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Install mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p /tmp/machdl
-          gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
-          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
-          cp /tmp/machdl/mach /usr/local/bin/mach
-          chmod +x /usr/local/bin/mach
-          mach info
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
 
+      - name: Report the seed
+        run: mach info
       - name: Build
         run: mach build .
 
@@ -57,20 +50,16 @@ jobs:
         with:
           submodules: true
 
-      - name: Install mach and qemu
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Install qemu
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user
-          mkdir -p /tmp/machdl
-          gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
-          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
-          cp /tmp/machdl/mach /usr/local/bin/mach
-          chmod +x /usr/local/bin/mach
-          mach info
 
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
+
+      - name: Report the seed
+        run: mach info
       - name: Cross-compile and run the riscv64 runtime smoke test
         run: bash test/riscv64/verify.sh
 
@@ -100,18 +89,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Install mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p /tmp/machdl
-          gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-aarch64-linux.tar.gz' --dir /tmp/machdl --clobber
-          tar -xzf /tmp/machdl/mach-*-aarch64-linux.tar.gz -C /tmp/machdl
-          sudo cp /tmp/machdl/mach /usr/local/bin/mach
-          sudo chmod +x /usr/local/bin/mach
-          mach info
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
 
+      - name: Report the seed
+        run: mach info
       - name: Run the test suite natively on aarch64
         run: mach test .
 
@@ -131,29 +113,18 @@ jobs:
         with:
           submodules: true
 
-      - name: Download mach
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p machdl
-          gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-x86_64-windows.zip' --dir machdl --clobber
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
 
-      # Expand-Archive rather than unzip: the archive is a zip and unzip is not
-      # part of the windows runner's guaranteed toolset.
-      - name: Install mach
-        shell: pwsh
-        run: |
-          $dir = Join-Path $PWD 'machdl'
-          Get-ChildItem -Path $dir -Filter '*.zip' | ForEach-Object {
-            Expand-Archive -Path $_.FullName -DestinationPath $dir -Force
-          }
-          & (Join-Path $dir 'mach.exe') info
+      - name: Report the seed
+        run: mach info
 
+      # the explicit path rather than the PATH entry: this probe runs under bash on
+      # the windows runner and takes the compiler as an argument, so it names the
+      # binary the seed step just installed.
       - name: Relative-target directory symlink
         shell: bash
-        run: bash test/symlink/verify.sh "$PWD/machdl/mach.exe" windows-x86_64
+        run: bash test/symlink/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
 
   cross-backends:
     runs-on: ubuntu-latest
@@ -162,17 +133,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Install mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p /tmp/machdl
-          gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
-          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
-          cp /tmp/machdl/mach /usr/local/bin/mach
-          chmod +x /usr/local/bin/mach
-          mach info
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
 
+      - name: Report the seed
+        run: mach info
       - name: Cross-compile the windows and darwin backends
         run: bash test/backends/verify.sh


### PR DESCRIPTION
Closes #457.

An untagged `gh release download` takes whatever release the client considers newest, **including a draft**. mach hit exactly this (briar-systems/mach#2573): a draft holding one hand-uploaded archive became the seed for every lane and broke each one whose host archive it did not carry.

**The failure this prevents is not a broken build, which is loud. It is a green suite compiled by a compiler nobody chose.** Same shape as the reporting-more-than-you-verify defects this family keeps finding, which is why it is worth fixing rather than tolerating.

Seeding now goes through one composite action resolving `repos/briar-systems/mach/releases/latest`, which serves the newest **published** release and never a draft or prerelease. The asset name is derived from the resolved tag and checked against the release's actual asset list, so a missing archive is a named error rather than a confusing downstream failure. Each job now reports the tag it seeded from, so the seed is visible in the log instead of implicit.

Two findings while doing it:

- **The vulnerable form was in six places, not the five the issue named.** The windows job seeded in two steps and the extra one was spelled `Download mach` rather than `Install mach`, so a name-based sweep misses it. Caught by grepping for the command instead of the step name.
- The host archive is now derived from `$RUNNER_OS/$RUNNER_ARCH` rather than hand-written per job, so a lane's archive cannot drift from its `runs-on`. That removes three hand-maintained patterns.

The repository is hardcoded rather than read from `$GITHUB_REPOSITORY`, because the seed comes from mach and this is mach-std. mach's own copy resolves its own repository, and that difference is why this is a separate file rather than a shared one.

CI on this PR is the verification: every leg has to seed through the new path to run at all.