### PR TITLE
perf(sync): mark every atomic operation `#[inline]`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+#### `sync.atomic`: every operation is `#[inline]`, so it costs its instructions and not a call as well (briar-systems/mach#2231)
+
+Each body in `sync.atomic` is three to six instructions. Every one of them was reached through a function call, because a dependency's ordinary function body is emitted extern in an importer and called through the linker - and **every** caller of this module is in another module. So the call was most of the price of using an atomic, and a spin loop paid it every iteration.
+
+`#[inline]` is what declares that a body is part of a function's public surface and may be materialised by whoever imports it. It has to be spelled, because the flow is opt-**in**: without it a dependency body never crosses a module boundary, which is what keeps an unrelated edit in a library from re-lowering everything downstream of it.
+
+Measured by the compiler-side change, x86-64 release, a loop over `store` / `load` / `fetch_add` / `fetch_sub` with six values live across each barrier: **25.0 ms -> 21.1 ms (-15.5%)**, identical results.
+
+**Nothing here changes the ordering guarantee.** Inlining removes the CALL and leaves the `asm` statement, which the middle end treats as at least as strong a barrier as the call it replaced, so every reordering these bodies forbid is still forbidden. The guarantee is still sequential consistency on every operation on every target.
+
+**This is inert on a compiler that does not implement the cross-module flow.** `#[inline]` was already accepted as a same-module hint, so this module builds and behaves identically on an older mach and simply does not get the win there. It requires no version floor and does not change this library's bootstrap.
+
 ## [0.25.1] - 2026-08-07
 
 **Requires mach 4.14.0 or newer, and 4.13.0 will NOT build this.** `eq[f.type]` — the walk re-entering itself at a field's type — is a spelling mach did not accept before briar-systems/mach#2691, which landed on mach `dev` after 4.13.0 was tagged. On an older toolchain this is a **parse** error ("expected a module alias before `.`") reported against `src/derive.mach`, and because parsing precedes comptime evaluation the module's own `$mach.version` gate cannot fire ahead of it. That capability now exists: briar-systems/mach#2714 landed and shipped in mach 4.15.0, so `[project].mach` takes a semver minimum and is checked when the manifest is read, before any source is parsed.

--- a/src/sync/atomic.mach
+++ b/src/sync/atomic.mach
@@ -14,6 +14,30 @@
 #     .aqrl-suffixed AMOs (amoadd/amoswap) and the lr.d/sc.d reservation loop;
 #     a plain aligned ld bracketed by full FENCEs is the seq-cst load; FENCE is
 #     the standalone full barrier; PAUSE is the spin hint.
+#
+# every operation here carries `#[inline]`, and on this module it is not a
+# size heuristic - it is the difference between the operation costing its
+# instruction sequence and costing a function call as well. each body below
+# is three to six instructions, so an out-of-line call is most of the price
+# of using one, and a spin loop pays it every iteration.
+#
+# it has to be spelled because the flow is opt-IN. a dependency's ordinary
+# function body is emitted extern in an importer and called through the
+# linker; `#[inline]` is what declares that a body is part of the function's
+# public surface and may be materialised by whoever imports it, which is the
+# only way a body reaches a caller in another module, and every caller of
+# this module is in another module (briar-systems/mach#2231).
+#
+# the decorator is inert against a compiler that does not implement the
+# cross-module flow: it was already accepted as a same-module hint, so this
+# module keeps building and behaving identically on an older mach and simply
+# does not get the win there.
+#
+# NOTHING HERE CHANGES THE ORDERING GUARANTEE. inlining removes the CALL and
+# leaves the `asm` statement, which the middle end treats as at least as
+# strong a barrier as the call it replaced, so every reordering these bodies
+# forbid is still forbidden. the guarantee is still sequential consistency
+# on every operation, on every target.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -23,6 +47,7 @@ use std.types.bool.false;
 # ---
 # ptr: address to load from
 # ret: loaded value
+#[inline]
 pub fun load(ptr: *i64) i64 {
     var result: i64 = 0;
     $if ($mach.build.arch == $mach.arch.x86_64) {
@@ -64,6 +89,7 @@ pub fun load(ptr: *i64) i64 {
 # ---
 # ptr: address to store to
 # v:   value to store
+#[inline]
 pub fun store(ptr: *i64, v: i64) {
     $if ($mach.build.arch == $mach.arch.x86_64) {
         # XCHG to memory carries an implicit LOCK, giving a seq-cst store
@@ -105,6 +131,7 @@ pub fun store(ptr: *i64, v: i64) {
 # expected: pointer to expected value (updated on failure)
 # desired:  value to store on success
 # ret:      true if the swap succeeded
+#[inline]
 pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
     var old: i64 = 0;
     val exp: i64 = @expected;
@@ -166,6 +193,7 @@ pub fun cas(ptr: *i64, expected: *i64, desired: i64) bool {
 # ptr: address of the atomic variable
 # v:   value to add
 # ret: previous value
+#[inline]
 pub fun fetch_add(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
     $if ($mach.build.arch == $mach.arch.x86_64) {
@@ -214,6 +242,7 @@ pub fun fetch_add(ptr: *i64, v: i64) i64 {
 # ptr: address of the atomic variable
 # v:   value to subtract
 # ret: previous value
+#[inline]
 pub fun fetch_sub(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
     $if ($mach.build.arch == $mach.arch.x86_64) {
@@ -264,6 +293,7 @@ pub fun fetch_sub(ptr: *i64, v: i64) i64 {
 # ptr: address of the atomic variable
 # v:   new value
 # ret: previous value
+#[inline]
 pub fun exchange(ptr: *i64, v: i64) i64 {
     var old: i64 = 0;
     $if ($mach.build.arch == $mach.arch.x86_64) {
@@ -307,6 +337,7 @@ pub fun exchange(ptr: *i64, v: i64) i64 {
 }
 
 # full memory barrier
+#[inline]
 pub fun fence() {
     $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {
@@ -329,6 +360,7 @@ pub fun fence() {
 }
 
 # cpu yield hint for spin loops
+#[inline]
 pub fun spin_hint() {
     $if ($mach.build.arch == $mach.arch.x86_64) {
         asm x86_64 {


### PR DESCRIPTION
The mach-std half of briar-systems/mach#2231. The compiler half is briar-systems/mach#2782.

## What

Each body in `sync.atomic` is three to six instructions, and every one of them was reached through a **function call**. A dependency's ordinary function body is emitted extern in an importer and called through the linker, and every caller of this module is in another module, so the call was most of the price of using an atomic and a spin loop paid it every iteration.

`#[inline]` is what declares that a body is part of a function's public surface and may be materialised by whoever imports it. It has to be spelled, because the flow is opt-**in**: without it a dependency body never crosses a module boundary, which is what keeps an unrelated edit in a library from re-lowering everything downstream of it.

Applied to all eight operations - `load`, `store`, `cas`, `fetch_add`, `fetch_sub`, `exchange`, `fence`, `spin_hint`.

## Measurement

From the compiler-side PR, x86-64 release, 3M iterations over `store` / `load` / `fetch_add` / `fetch_sub` with six values live across each barrier, interleaved runs: **25.00 ms -> 21.13 ms min, -15.5%**, with an identical hand-derived checksum from both binaries.

## The ordering guarantee is unchanged

Inlining removes the CALL and leaves the `asm` statement. The middle end treats `OP_ASM` at least as conservatively as `OP_CALL` everywhere a pass could move code across it - `is_pure` excludes both, which is what CSE, DCE and LICM gate on - so every reordering these bodies forbid is still forbidden. Still sequential consistency on every operation on every target, and this PR makes no other claim about the memory model.

## Bootstrap

**Inert on a compiler that does not implement the cross-module flow.** `#[inline]` was already accepted as a same-module hint, so this module builds and behaves identically on mach 4.16.0 - the release this library builds against - and simply does not get the win there. No version floor, no bootstrap change.

That is deliberate ordering: this can land before the compiler change ships, and it becomes effective the moment a mach carrying briar-systems/mach#2231 is released.

## Verification

- `mach test .` **788 passed, 0 failed** against released **mach 4.16.0**.
- `mach test .` **788 passed, 0 failed** against a compiler built from briar-systems/mach#2782, which is where the decorator actually does something.
- The compiler PR's self-host fixpoint holds byte-identically with this mach-std in place: `fcd0778f0160ce4fe1a6bcd98a5bf0a1a5115cc38c3da9dea0b6a52f991a4232`, stage2 == stage3.
