### PR TITLE
feat(os/darwin): route the filesystem layer through libSystem

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,107 @@ jobs:
         shell: bash
         run: bash test/symlink/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
 
+  # darwin runs NATIVE on both architectures, for the same reason the arm64 job
+  # above is native rather than emulated -- and with a sharper edge now that the
+  # backend calls libSystem instead of issuing raw traps.
+  #
+  # the darwin OS layer is the only place mach-std depends on a C-VARIADIC call,
+  # and apple arm64 is the only platform that passes the whole variadic tail on
+  # the stack. a wrongly-lowered `openat(..., mode)` there does not fail to link
+  # and does not crash: it creates a file with the wrong permission bits. that
+  # divergence exists on ONE of these two rows, so a pass on the other says
+  # nothing about it, and neither row can stand in for the other.
+  #
+  # `cross-backends` still cross-compiles darwin from linux and is not made
+  # redundant by this job -- it is the leg that catches a target-gated module
+  # silently dropping out of the build. it just cannot execute anything.
+  darwin:
+    name: darwin ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            runner: macos-15
+          - arch: x86_64
+            runner: macos-15-intel
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
+
+      - name: Report the seed
+        run: mach info
+
+      - name: Build
+        run: mach build .
+
+      - name: Run the test suite natively on darwin
+        run: mach test .
+
+      # std itself is a static artifact, so the dependency list only becomes
+      # observable once something LINKS it. this builds the backends smoke test
+      # natively -- an executable -- and inspects that.
+      #
+      # the image must name exactly one libSystem, under its install path. two
+      # LC_LOAD_DYLIB commands -- the implicit platform dependency plus a
+      # manifest entry spelled differently enough not to match it -- load and
+      # run here, so nothing else in this job would notice.
+      - name: One libSystem dependency, at its install path
+        run: |
+          set -euo pipefail
+          cd test/backends
+          mkdir -p dep
+          ln -sfn "$(cd ../.. && pwd)" dep/std
+          mach build . --profile debug
+          exe="$(find out -type f -name backends -print -quit)"
+          [ -n "$exe" ] || { echo "::error::no native darwin executable was produced"; exit 1; }
+          echo "inspecting $exe"
+          otool -L "$exe"
+          n="$(otool -L "$exe" | tail -n +2 | grep -c 'libSystem' || true)"
+          [ "$n" = "1" ] || { echo "::error::expected exactly 1 libSystem dependency, found $n"; exit 1; }
+          otool -L "$exe" | grep -q '/usr/lib/libSystem.B.dylib' \
+            || { echo "::error::libSystem is not named by its install path"; exit 1; }
+          # and it runs: the binary dyld-binds libSystem and reaches main
+          ./"$exe"
+
+      # the stat family is reached through the `$INODE64` variant symbol on
+      # x86_64 and the plain name on arm64. binding the plain name on x86_64
+      # would link, run, and quietly fill stat_t from a different struct
+      # layout, so the bound symbol name is asserted per architecture.
+      - name: The stat family binds the right symbol for this architecture
+        run: |
+          set -euo pipefail
+          exe="$(find test/backends/out -type f -name backends -print -quit)"
+          # the undefined-symbol list is the stable spelling across xcode
+          # versions; the bind-table dumpers move around, the symbol table does not
+          undef="$(nm -u "$exe")"
+          printf '%s\n' "$undef" | grep -F '_fstat' || true
+
+          if [ "${{ matrix.arch }}" = "x86_64" ]; then
+            if ! printf '%s\n' "$undef" | grep -qF '_fstat$INODE64'; then
+              echo "::error::x86_64 must bind _fstat\$INODE64, not the legacy 32-bit-inode _fstat"
+              exit 1
+            fi
+            if ! printf '%s\n' "$undef" | grep -qF '_fstatat$INODE64'; then
+              echo "::error::x86_64 must bind _fstatat\$INODE64"
+              exit 1
+            fi
+          else
+            if ! printf '%s\n' "$undef" | grep -qx '_fstat'; then
+              echo "::error::arm64 must bind the plain _fstat"
+              exit 1
+            fi
+            if printf '%s\n' "$undef" | grep -qF 'INODE64'; then
+              echo "::error::arm64 has no \$INODE64 variant; binding one is wrong"
+              exit 1
+            fi
+          fi
+
   cross-backends:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,16 @@ jobs:
       - name: Build
         run: mach build .
 
+      # gated against test/darwin/known-failures.txt rather than run bare. this
+      # lane's FIRST execution found eleven failures on both architectures, all
+      # of them predating this migration -- confirmed by running untouched `dev`
+      # on the same two runners. they are enumerated with evidence in that file.
+      #
+      # the gate fails on any failure not listed AND on any listed test that
+      # starts passing, so the list cannot become a mute button: it has to
+      # shrink to empty as the rest of #415 lands.
       - name: Run the test suite natively on darwin
-        run: mach test .
+        run: bash test/darwin/verify.sh
 
       # std itself is a static artifact, so the dependency list only becomes
       # observable once something LINKS it. this builds the backends smoke test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+#### darwin: the filesystem layer calls libSystem instead of raw BSD traps (#415)
+
+Apple does not guarantee syscall-number stability. `svc 0x80` / `syscall` works today and has been broken across macOS releases before, and libSystem is the only interface Apple supports. This moves the **filesystem and descriptor** primitives of the darwin backend onto it. Memory, time, process, sockets, threads, `read_dir`, and `terminal` still issue raw traps; see "what is deliberately left" below.
+
+**The errno contract inverts, so every error path was re-derived rather than re-pointed.** A raw BSD trap sets the carry flag and returns the *positive* errno in the result register. libSystem returns `-1` (or `nil`) and leaves the errno in thread-local storage, reached through `__error()`. Two facts follow that the old code never had to encode:
+
+- **errno is not cleared on success.** It may only be read once the return value has already reported failure. `fail_errno` is the single place the conversion happens and is only ever reached from inside a test of the documented sentinel.
+- **the sentinel is per-function, not "negative".** `lseek` returns a file offset, and its failure value is exactly `-1`; testing the sign would be a different predicate that happens to agree today.
+
+The layer's outward contract is unchanged — a count or descriptor on success, a negative errno on failure — so nothing above `std.system.os.darwin` moved.
+
+**`open`, `fcntl`, and the apple arm64 variadic ABI.** `openat` and `fcntl` are C-variadic, and apple arm64 passes *every* variadic argument on the stack with no register phase. A fixed-arity declaration lowers `mode` into `x2` while libSystem reads it off the stack — which links, runs, and creates a file with the wrong permission bits. They are declared with mach's C-variadic `ext fun` form (briar-systems/mach#2575) and, where a call needs no tail, called with none: two-argument `openat` without `O_CREAT`, and `F_GETFD` / `F_GETFL`. Passing a dummy zero would not be an equivalent spelling on that target. Every tail this layer passes is an int, never a float, which keeps `AL` at zero on the SysV x86_64 leg.
+
+**The stat family is arch-gated on `$INODE64`.** On x86_64 the plain `_fstat` is still the legacy 32-bit-`st_ino` struct and the 64-bit layout — the one `stat_t` describes — is reached through the `$INODE64` variant symbol. arm64 has only the plain name. Binding the plain name on x86_64 would link and run and quietly fill `stat_t` from a different field order, so the suffix is applied by an explicit gate and asserted in CI per architecture.
+
+**Cancellation: the plain entry points, deliberately.** libSystem exports a `$NOCANCEL` twin for every cancellation point. std has no cancellation model, never calls `pthread_cancel`, and exposes no way to, so a cancellation point never acts and the plain entry point does exactly what its twin does — while remaining the public symbol. The decision is recorded in one place rather than left to whatever the linker resolves.
+
+**Deletions.** `getcwd` was an `open(".")` + `fcntl(F_GETPATH)` dance with a `MAXPATHLEN` bounce buffer, because `F_GETPATH` carries no capacity and XNU writes up to `MAXPATHLEN` bytes whatever the caller sized its destination. `getcwd(3)` takes the capacity, so the scratch buffer, the copy loop, the `F_GETPATH` constant and `MAXPATHLEN` all go (#409, #413). The hand-written `pipe` asm in both arch modules — which existed only because the raw trap returns two descriptors in `x0`/`x1` and signals through the carry flag — collapses to one line, identical on both architectures. Fifteen `SYS_*` constants are gone.
+
+### Added
+
+#### CI runs the suite natively on both darwin architectures
+
+There was no darwin execution anywhere in this repo's CI: `cross-backends` compiles the darwin backends from linux and runs nothing. The suite now runs natively on `macos-15` (arm64) and `macos-15-intel`, matching the reasoning already applied to the arm64 linux job — a psABI fact is exactly what an emulator or a cross-build can be wrong about.
+
+The two rows are not interchangeable. The stack-passed variadic tail exists on apple arm64 and nowhere else, and the `$INODE64` suffix exists on x86_64 and nowhere else, so each divergence is invisible on the other row. CI additionally asserts that a linked darwin image names **exactly one** libSystem, at its install path — the implicit platform dependency plus a manifest entry spelled differently enough not to match it produces two `LC_LOAD_DYLIB` commands, which loads and runs and would otherwise go unnoticed.
+
+Tests assert observable effects, not return codes: a file created with `O_CREAT` is stat'd back and its mode compared **exactly** (with the umask pinned to zero, so a dropped variadic argument cannot pass), `FD_CLOEXEC` is set and read back and cleared and read back, a pipe carries bytes end to end, `lseek` reports the size the writes produced, and the claimed error paths are provoked for their **specific** errno — `EEXIST`, `ENOENT`, `EBADF`.
+
+### What is deliberately left, and why
+
+This is a partial migration and the mixed state is intentional. `read_dir` needs `getdirentries64`, which is not public API on darwin; replacing it means an `opendir`/`readdir` redesign that changes the primitive's shape rather than just its callee. The thread layer's `bsdthread_create` / `__ulock_*` is the highest-value part of this issue and carries its own risk, and it interacts with everything else here — see the follow-up issue for the ordering question it raises.
+
 ## [0.25.1] - 2026-08-07
 
 **Requires mach 4.14.0 or newer, and 4.13.0 will NOT build this.** `eq[f.type]` — the walk re-entering itself at a field's type — is a spelling mach did not accept before briar-systems/mach#2691, which landed on mach `dev` after 4.13.0 was tagged. On an older toolchain this is a **parse** error ("expected a module alias before `.`") reported against `src/derive.mach`, and because parsing precedes comptime evaluation the module's own `$mach.version` gate cannot fire ahead of it. That capability now exists: briar-systems/mach#2714 landed and shipped in mach 4.15.0, so `[project].mach` takes a semver minimum and is checked when the manifest is read, before any source is parsed.

--- a/mach.toml
+++ b/mach.toml
@@ -19,6 +19,32 @@ isa = "riscv64"
 os  = "linux"
 abi = "lp64"
 
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+# darwin's platform library, and the only supported way to reach the kernel:
+# apple does not promise syscall numbers. `name` is spelled as the full install
+# path on purpose. a dyld-loaded image implicitly links libSystem under exactly
+# that path, and a requirement that does not match it string-for-string is a
+# SECOND dependency rather than the same one - the image then carries two
+# LC_LOAD_DYLIB commands, one of them a bare leaf name dyld would have to
+# search for. `library` is the logical name `#[library("libSystem")]` pins to.
+[link.libsystem]
+source  = "system"
+name    = "/usr/lib/libSystem.B.dylib"
+library = "libSystem"
+os      = ["darwin"]
+isa     = ["*"]
+abi     = ["*"]
+export  = true
+
 [link.kernel32]
 source = "system"
 name = "kernel32.dll"
@@ -56,5 +82,5 @@ kind = "static"
 entry = "lib/libstd.mach"
 out = "lib/std"
 targets = ["*"]
-link = ["kernel32", "ws2_32", "advapi32", "synch"]
+link = ["kernel32", "ws2_32", "advapi32", "synch", "libsystem"]
 need = []

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -6,6 +6,7 @@
 use std.types.size.usize;
 
 use std.system.os.darwin.shared;
+use ls: std.system.os.darwin.libsystem;
 
 $if ($mach.build.os != $mach.os.darwin) {
     $error("std.system.os.darwin.aarch64: requires darwin target");
@@ -21,29 +22,18 @@ pub fun page_size() usize {
 
 # create a unidirectional pipe
 #
-# darwin pipe() returns two fds in x0/x1 and signals failure via the
-# carry flag, neither of which the syscall DSL captures, so this uses raw
-# asm. inline-asm branches must target symbols (issue #216), so the carry
-# flag is materialized into a register (`cset`) and the branching happens
-# in mach code instead of the asm block.
+# this was hand-written asm for one reason: the raw XNU pipe trap returns the
+# two descriptors in x0/x1 and signals failure through the carry flag, and the
+# syscall DSL captures neither. libSystem's pipe(2) is an ordinary C function
+# that writes both descriptors through the caller's array and reports failure
+# as -1, so the arch-specific asm has nothing left to do and the wrapper is now
+# identical on both darwin architectures - it lives here only because `pipe` is
+# part of the per-arch module's published surface.
 # ---
 # fds: pointer to two i32s; fds[0] = read end, fds[1] = write end
 # ret: 0 on success, or negative errno
 pub fun pipe(fds: *i32) i64 {
-    var fd0: i64 = 0;
-    var fd1: i64 = 0;
-    var fail: i64 = 0;
-    asm aarch64 {
-        mov x16, 42
-        svc 0x80
-        cset x9, cs              # x9 = 1 when carry set (error), else 0
-        str x9, {fail}
-        str x0, {fd0}
-        str x1, {fd1}
-    }
-    if (fail != 0) { ret -fd0; }
-    fds[0] = fd0::i32;
-    fds[1] = fd1::i32;
+    if (ls.pipe(fds) < 0) { ret ls.fail_errno(); }
     ret 0;
 }
 

--- a/src/system/os/darwin/libsystem.mach
+++ b/src/system/os/darwin/libsystem.mach
@@ -1,0 +1,194 @@
+# libSystem imports for the darwin backend
+#
+# apple does not guarantee syscall-number stability, so `svc 0x80` / `syscall`
+# is not a supportable distribution surface: libSystem is. every darwin OS
+# primitive that used to issue a raw trap binds a libSystem symbol declared
+# here instead.
+#
+# three things about this boundary are easy to get wrong, so they are settled
+# once, here, rather than at each call site.
+#
+# ## the errno contract
+#
+# a raw BSD trap sets the carry flag and returns the POSITIVE errno in the
+# result register. libSystem instead returns -1 (or nil, for the pointer-valued
+# entry points) and leaves the errno in thread-local storage. these are
+# different contracts, and the difference is not just where the number lives:
+#
+#   - errno is NOT cleared on success. reading it after a call that succeeded
+#     returns whatever the last failing call left behind. it may only be read
+#     once the RETURN VALUE has already said the call failed.
+#   - a success can be a negative number. `lseek` past 2^63 cannot happen, but
+#     the rule holds generally: the failure indicator is the documented
+#     sentinel for that specific function, never "the result is negative".
+#
+# `fail_errno` is the only way this module converts a failure, and it is only
+# ever reached from inside an `if` that already tested the sentinel. the darwin
+# OS layer keeps its existing outward contract - a negative errno - so nothing
+# above `std.system.os.darwin` changes shape.
+#
+# ## `__error`, and why it is not the thing we refuse to use
+#
+# `<errno.h>` defines `errno` as `(*__error())`. the underscores make it look
+# like the private `__open` / `__fcntl` family, but it is the opposite: it is
+# the documented, stable, public way to reach errno on darwin, and there is no
+# other one. the symbols this migration refuses are the private SYSCALL shims
+# (`__open`, `__fcntl`, ...) whose only purpose is to skip the cancellation
+# wrapper - taking those would leave us on exactly the unsupported surface the
+# migration exists to leave.
+#
+# ## cancellation: the plain entry points, deliberately
+#
+# libSystem exports a `$NOCANCEL` twin for every entry point that is a POSIX
+# cancellation point (`read$NOCANCEL`, `open$NOCANCEL`, ...). this module binds
+# the PLAIN names on purpose:
+#
+#   - std has no cancellation model. it never calls `pthread_cancel` and
+#     exposes no way for a caller to. a cancellation point only acts when a
+#     cancel is already pending, so with none ever requested the plain entry
+#     point does exactly what its `$NOCANCEL` twin does.
+#   - the plain name is the public one. `$NOCANCEL` is a suffixed variant symbol
+#     that exists to serve libpthread's internals; binding it would put the same
+#     "Apple never promised you this" question back into the layer whose whole
+#     purpose is to answer it.
+#
+# so the choice costs nothing today and keeps the supported surface. should std
+# ever grow real cancellation, the decision to revisit is here, in one place,
+# and not spread across sixty call sites.
+#
+# ## `$INODE64`, and why the stat family is arch-gated
+#
+# macOS grew a 64-bit `st_ino` in 10.5 without breaking the binaries compiled
+# against the 32-bit one. on x86_64 both layouts still ship: the PLAIN `_fstat`
+# is the legacy 32-bit-inode struct, and the 64-bit layout - the one `stat_t`
+# in shared.mach describes - is reached through the `$INODE64` variant symbol.
+# arm64 has no legacy to carry, so only the plain name exists there.
+#
+# binding the plain name on x86_64 would link and run and quietly fill the
+# caller's `stat_t` from a struct with a different field order. that is silent
+# corruption, not an error, which is why the suffix is applied by an explicit
+# arch gate rather than left to whatever the linker happens to resolve.
+
+use std.types.size.usize;
+
+$if ($mach.build.os != $mach.os.darwin) {
+    $error("std.system.os.darwin.libsystem: requires darwin target");
+}
+
+# the thread-local errno cell
+#
+# `errno` is a macro over this in C; there is no importable data symbol for it.
+# ---
+# ret: pointer to the calling thread's errno
+#[library("libSystem")]
+ext fun __error() *i32;
+
+# the calling thread's current errno, as a positive number
+#
+# only meaningful directly after a call whose return value already reported
+# failure - errno is not cleared by a successful call.
+# ---
+# ret: the current errno
+pub fun errno() i32 {
+    val cell: *i32 = __error();
+    ret @cell;
+}
+
+# the current errno negated, for a darwin OS primitive's return
+#
+# the darwin backend's outward contract is "a negative errno on failure", which
+# is what it returned when it read the number straight out of a trap's result
+# register. this is the single place that contract is reconstructed from the
+# libSystem one.
+#
+# a libSystem entry point that fails without setting errno is not supposed to
+# exist, but a zero here would be indistinguishable from success to every
+# caller, so it is reported as EINVAL rather than silently swallowed.
+# ---
+# ret: the negated errno, always < 0
+pub fun fail_errno() i64 {
+    val e: i32 = errno();
+    if (e == 0) { ret -22; }
+    ret -(e::i64);
+}
+
+# file descriptors and paths
+
+#[library("libSystem")]
+pub ext fun read(fd: i32, buf: *u8, count: usize) i64;
+
+#[library("libSystem")]
+pub ext fun write(fd: i32, buf: *u8, count: usize) i64;
+
+# `openat` is C-variadic: the mode argument is only read when the flags carry
+# O_CREAT. declaring it at a fixed arity of three would be silently wrong on
+# apple arm64, which passes the whole variadic tail on the stack while a fixed
+# third parameter would be lowered into x2 (see mach's doc/language/ext-fun.md).
+#[library("libSystem")]
+pub ext fun openat(dirfd: i32, path: *u8, flags: i32, ...) i32;
+
+#[library("libSystem")]
+pub ext fun close(fd: i32) i32;
+
+#[library("libSystem")]
+pub ext fun lseek(fd: i32, offset: i64, whence: i32) i64;
+
+# the stat family carries the `$INODE64` suffix on x86_64 only; see the module
+# header. the two arms are mutually exclusive, so the duplicate-attribution
+# check does not apply to them.
+$if ($mach.build.arch == $mach.arch.x86_64) {
+    #[library("libSystem")] #[symbol("_fstat$INODE64")]
+    pub ext fun fstat(fd: i32, st: *u8) i32;
+
+    #[library("libSystem")] #[symbol("_fstatat$INODE64")]
+    pub ext fun fstatat(dirfd: i32, path: *u8, st: *u8, flags: i32) i32;
+}
+$or {
+    #[library("libSystem")] #[symbol("_fstat")]
+    pub ext fun fstat(fd: i32, st: *u8) i32;
+
+    #[library("libSystem")] #[symbol("_fstatat")]
+    pub ext fun fstatat(dirfd: i32, path: *u8, st: *u8, flags: i32) i32;
+}
+
+#[library("libSystem")]
+pub ext fun unlinkat(dirfd: i32, path: *u8, flags: i32) i32;
+
+#[library("libSystem")]
+pub ext fun renameat(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun symlink(target: *u8, linkpath: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun mkdirat(dirfd: i32, path: *u8, mode: u32) i32;
+
+#[library("libSystem")]
+pub ext fun faccessat(dirfd: i32, path: *u8, mode: i32, flags: i32) i32;
+
+# `getcwd(3)` replaces the open(".") + fcntl(F_GETPATH) dance the raw-syscall
+# backend needed. it takes a capacity, so the caller's buffer size is honoured
+# by the callee instead of being defended against afterwards.
+# ---
+# ret: `buf` on success, or nil with errno set (ERANGE when size is too small)
+#[library("libSystem")]
+pub ext fun getcwd(buf: *u8, size: usize) *u8;
+
+#[library("libSystem")]
+pub ext fun pipe(fds: *i32) i32;
+
+# set the file-mode creation mask, returning the previous one
+#
+# cannot fail and does not touch errno. imported so a test can pin the mask to
+# a known value and then assert a created file's mode EXACTLY, rather than
+# asserting some umask-dependent subset of it - which is what makes the mode
+# assertion able to catch a dropped variadic argument.
+#[library("libSystem")]
+pub ext fun umask(mask: u32) u32;
+
+# `fcntl` is C-variadic. the two-argument commands (F_GETFL, F_GETFD) pass no
+# tail at all and are called with none; F_SETFD / F_SETFL / F_DUPFD pass a
+# single int. every tail this module ever passes is an int or a pointer, never
+# a float, which is what keeps `AL` at zero on the SysV x86_64 leg.
+#[library("libSystem")]
+pub ext fun fcntl(fd: i32, cmd: i32, ...) i32;

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -19,13 +19,11 @@ $if ($mach.build.os != $mach.os.darwin) {
 }
 
 use os_shared: std.system.os.shared;
+use ls: std.system.os.darwin.libsystem;
 
 # syscall numbers (BSD convention, same across darwin arches)
 val SYS_EXIT:             usize = 1;
 val SYS_FORK:             usize = 2;
-val SYS_READ:             usize = 3;
-val SYS_WRITE:            usize = 4;
-val SYS_OPEN:             usize = 5;
 val SYS_CLOSE:            usize = 6;
 val SYS_CHDIR:            usize = 12;
 val SYS_WAIT4:            usize = 7;
@@ -38,17 +36,7 @@ val SYS_MLOCK:            usize = 203;
 val SYS_MUNLOCK:          usize = 204;
 val SYS_EXECVE:           usize = 59;
 val SYS_VFORK:            usize = 66;
-val SYS_LSEEK:            usize = 199;
-val SYS_FSTAT64:          usize = 339;
 val SYS_GETDIRENTRIES64:  usize = 344;
-val SYS_OPENAT:           usize = 463;
-val SYS_MKDIRAT:          usize = 475;
-val SYS_RENAMEAT:         usize = 465;
-val SYS_UNLINKAT:         usize = 472;
-val SYS_FACCESSAT:        usize = 466;
-val SYS_FSTATAT64:        usize = 470;
-val SYS_SYMLINK:          usize = 57;
-val SYS_PIPE:             usize = 42;
 val SYS_SELECT:           usize = 93;
 val SYS_GETTIMEOFDAY:     usize = 116;
 val SYS_CLOCK_GETTIME:    usize = 427;
@@ -68,15 +56,19 @@ val SYS_SETSOCKOPT:       usize = 105;
 val SYS_GETRLIMIT:        usize = 194;
 val RLIMIT_NOFILE:        usize = 8;
 val SYS_DUP2:             usize = 90;
-val SYS_FCNTL:            usize = 92;
 
 val SIGABRT: i32 = 6;
 
-# fcntl flags
-val F_GETPATH:  usize = 50;
-# XNU writes a F_GETPATH result of up to this many bytes whatever the caller
-# sized its destination, so a F_GETPATH destination is never smaller
-val MAXPATHLEN: usize = 1024;
+# fcntl commands
+#
+# F_GETPATH and its MAXPATHLEN companion are gone: they existed only because
+# the raw-syscall backend had no getcwd, and getcwd(3) replaces both.
+pub val F_GETFD: i32 = 1;
+pub val F_SETFD: i32 = 2;
+pub val F_GETFL: i32 = 3;
+pub val F_SETFL: i32 = 4;
+
+pub val FD_CLOEXEC: i32 = 1;
 
 # mmap protection
 val PROT_NONE:  i32 = 0;
@@ -639,12 +631,20 @@ pub fun environ() **u8 {
 }
 
 # filesystem
+#
+# every primitive below calls libSystem and rebuilds this module's outward
+# contract - a count/descriptor on success, a NEGATIVE errno on failure - from
+# libSystem's (-1 plus a thread-local errno). errno is read only after the
+# return value has already reported failure, because a successful call does not
+# clear it; see std.system.os.darwin.libsystem.
 
 pub fun read(fd: i32, buf: *u8, count: usize) i64 {
     var retries: usize = 0;
     for (retries < EINTR_MAX_RETRIES) {
-        val res: i64 = syscall3(SYS_READ, fd::isize::usize, buf::usize, count);
-        if (res != EINTR) { ret res; }
+        val res: i64 = ls.read(fd, buf, count);
+        if (res >= 0) { ret res; }
+        val e: i64 = ls.fail_errno();
+        if (e != EINTR) { ret e; }
         retries = retries + 1;
     }
     ret EINTR;
@@ -653,33 +653,64 @@ pub fun read(fd: i32, buf: *u8, count: usize) i64 {
 pub fun write(fd: i32, buf: *u8, count: usize) i64 {
     var retries: usize = 0;
     for (retries < EINTR_MAX_RETRIES) {
-        val res: i64 = syscall3(SYS_WRITE, fd::isize::usize, buf::usize, count);
-        if (res != EINTR) { ret res; }
+        val res: i64 = ls.write(fd, buf, count);
+        if (res >= 0) { ret res; }
+        val e: i64 = ls.fail_errno();
+        if (e != EINTR) { ret e; }
         retries = retries + 1;
     }
     ret EINTR;
 }
 
+# open a path relative to a directory descriptor
+#
+# `mode` is only consulted by the kernel when `flags` carries O_CREAT, so it is
+# passed in the variadic tail only in that case. the two forms are not
+# interchangeable spellings of one call: apple arm64 passes the whole variadic
+# tail on the stack, so the no-O_CREAT form genuinely passes nothing rather
+# than passing an ignored register.
+# ---
+# dirfd: directory descriptor the path resolves against, or AT_FDCWD
+# path:  null-terminated path
+# flags: O_* flags
+# mode:  permission bits for a created file; ignored without O_CREAT
+# ret:   the new descriptor, or negative errno
 pub fun open(dirfd: i32, path: *u8, flags: i32, mode: i32) i64 {
     var retries: usize = 0;
     for (retries < EINTR_MAX_RETRIES) {
-        val res: i64 = syscall4(SYS_OPENAT, dirfd::isize::usize, path::usize, flags::u32::usize, mode::u32::usize);
-        if (res != EINTR) { ret res; }
+        var res: i32 = 0;
+        if ((flags & O_CREAT) != 0) {
+            res = ls.openat(dirfd, path, flags, mode::u32);
+        }
+        or {
+            res = ls.openat(dirfd, path, flags);
+        }
+        if (res >= 0) { ret res::i64; }
+        val e: i64 = ls.fail_errno();
+        if (e != EINTR) { ret e; }
         retries = retries + 1;
     }
     ret EINTR;
 }
 
+# close a descriptor
+#
+# a failed close does NOT mean the descriptor is still open: darwin has already
+# released it by the time an error is reported. callers must not retry, and
+# none do - the return exists to surface a deferred write error.
 pub fun close(fd: i32) i64 {
-    ret syscall1(SYS_CLOSE, fd::isize::usize);
+    if (ls.close(fd) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 pub fun stat(fd: i32, st: *stat_t) i64 {
-    ret syscall2(SYS_FSTAT64, fd::isize::usize, st::usize);
+    if (ls.fstat(fd, st::usize::*u8) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 pub fun stat_path(dirfd: i32, path: *u8, st: *stat_t, flags: i32) i64 {
-    ret syscall4(SYS_FSTATAT64, dirfd::isize::usize, path::usize, st::usize, flags::u32::usize);
+    if (ls.fstatat(dirfd, path, st::usize::*u8, flags) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 # read the type/permission bits from a filled stat buffer as a 32-bit word
@@ -694,11 +725,13 @@ pub fun stat_mode(st: *stat_t) u32 {
 }
 
 pub fun unlink(dirfd: i32, path: *u8, flags: i32) i64 {
-    ret syscall3(SYS_UNLINKAT, dirfd::isize::usize, path::usize, flags::u32::usize);
+    if (ls.unlinkat(dirfd, path, flags) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
-    ret syscall4(SYS_RENAMEAT, olddir::isize::usize, oldpath::usize, newdir::isize::usize, newpath::usize);
+    if (ls.renameat(olddir, oldpath, newdir, newpath) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 # create a symbolic link at linkpath pointing to target
@@ -710,11 +743,13 @@ pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
 # linkpath: path of the link to create
 # ret:      0 on success, or negative errno
 pub fun symlink(target: *u8, linkpath: *u8) i64 {
-    ret syscall2(SYS_SYMLINK, target::usize, linkpath::usize);
+    if (ls.symlink(target, linkpath) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 pub fun make_dir(dirfd: i32, path: *u8, mode: i32) i64 {
-    ret syscall3(SYS_MKDIRAT, dirfd::isize::usize, path::usize, mode::u32::usize);
+    if (ls.mkdirat(dirfd, path, mode::u32) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 # darwin uses getdirentries64 instead of getdents64
@@ -724,11 +759,66 @@ pub fun read_dir(fd: i32, dirp: *dirent64, count: usize) i64 {
 }
 
 pub fun access(dirfd: i32, path: *u8, mode: i32, flags: i32) i64 {
-    ret syscall4(SYS_FACCESSAT, dirfd::isize::usize, path::usize, mode::u32::usize, flags::u32::usize);
+    if (ls.faccessat(dirfd, path, mode, flags) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
+# reposition a descriptor's offset
+#
+# lseek's failure sentinel is exactly -1, not "negative": the success value is
+# a file offset, which is never negative but IS returned as a signed 64-bit
+# number that a caller may legitimately compare against. testing for the
+# documented sentinel rather than for a sign keeps that distinction.
+# ---
+# ret: the resulting absolute offset, or negative errno
 pub fun seek(fd: i32, offset: i64, whence: i32) i64 {
-    ret syscall3(SYS_LSEEK, fd::isize::usize, offset::isize::usize, whence::u32::usize);
+    val res: i64 = ls.lseek(fd, offset, whence);
+    if (res == -1) { ret ls.fail_errno(); }
+    ret res;
+}
+
+# read a descriptor's descriptor-level flags (FD_CLOEXEC)
+#
+# F_GETFD is a TWO-argument fcntl: it reads no third argument, so none is
+# passed. that is not a micro-optimisation - on apple arm64 the variadic tail
+# is stack-passed, so "pass a dummy zero" and "pass nothing" put genuinely
+# different bytes at the callee's stack slot. the two forms are kept distinct
+# everywhere fcntl is called.
+# ---
+# ret: the flag word, or negative errno
+pub fun fd_flags(fd: i32) i64 {
+    val r: i32 = ls.fcntl(fd, F_GETFD);
+    if (r < 0) { ret ls.fail_errno(); }
+    ret r::i64;
+}
+
+# set a descriptor's descriptor-level flags
+#
+# F_SETFD is a three-argument fcntl: exactly one int rides the variadic tail.
+# ---
+# ret: 0 on success, or negative errno
+pub fun set_fd_flags(fd: i32, flags: i32) i64 {
+    if (ls.fcntl(fd, F_SETFD, flags) < 0) { ret ls.fail_errno(); }
+    ret 0;
+}
+
+# read a descriptor's file-status flags (access mode, O_APPEND, O_NONBLOCK)
+#
+# F_GETFL, like F_GETFD, takes no third argument.
+# ---
+# ret: the status flag word, or negative errno
+pub fun file_flags(fd: i32) i64 {
+    val r: i32 = ls.fcntl(fd, F_GETFL);
+    if (r < 0) { ret ls.fail_errno(); }
+    ret r::i64;
+}
+
+# set a descriptor's file-status flags
+# ---
+# ret: 0 on success, or negative errno
+pub fun set_file_flags(fd: i32, flags: i32) i64 {
+    if (ls.fcntl(fd, F_SETFL, flags) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 # process
@@ -1027,32 +1117,310 @@ pub fun cpu_count() i64 {
 
 # get the current working directory
 #
-# F_GETPATH carries no capacity and XNU writes up to MAXPATHLEN bytes into the
-# destination whatever the caller sized it, so it must never be handed a buffer
-# that could be smaller. the path is read into a MAXPATHLEN scratch and copied
-# out only when it fits, which is what makes `size` mean what the signature says
-# it means. a path too long for the caller is ERANGE, as it is on linux (#409).
+# this used to be an open(".") + fcntl(F_GETPATH) dance with a MAXPATHLEN
+# bounce buffer, because F_GETPATH carries no capacity: XNU writes up to
+# MAXPATHLEN bytes into the destination whatever the caller sized it, so the
+# result had to be caught in a large scratch and copied out only when it fit.
+#
+# getcwd(3) TAKES the capacity, so the callee honours `size` itself and a path
+# that does not fit comes back as ERANGE from libSystem rather than as an
+# overrun this function has to defend against afterwards. the scratch buffer,
+# the copy loop, and the F_GETPATH constant all go away with it (#409, #413).
 # ---
 # buf:  destination buffer
 # size: buffer capacity in bytes, including room for the terminator
 # ret:  length of path on success, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
-    var scratch: [MAXPATHLEN]u8;
-    val fd: i64 = syscall2(SYS_OPEN, "."::usize, O_RDONLY::u32::usize);
-    if (fd < 0) { ret fd; }
-    val res: i64 = syscall3(SYS_FCNTL, fd::usize, F_GETPATH, (?scratch[0])::usize);
-    syscall1(SYS_CLOSE, fd::usize);
-    if (res < 0) { ret res; }
+    if (ls.getcwd(buf, size)::usize == 0) { ret ls.fail_errno(); }
+    ret str_len(buf)::i64;
+}
 
-    val n: usize = str_len(?scratch[0]);
-    if (n + 1 > size) { ret ERANGE; }
-    var i: usize = 0;
-    for (i < n) {
-        buf[i] = scratch[i];
-        i = i + 1;
+# libSystem migration tests
+#
+# these assert the OBSERVABLE EFFECT of each migrated call, not that it
+# returned a non-negative number. the mode assertions in particular are the
+# regression for the apple arm64 variadic ABI: `mode` rides the STACK there,
+# with no register phase, so a wrongly-lowered call hands openat whatever
+# happened to be at the callee's stack slot. that does not fail to link and
+# does not crash - it creates a file with the wrong permissions. only reading
+# the mode back catches it.
+
+# build "/tmp/mach-std-415-<pid>-<tag>" into buf, returning its length
+fun tmp_path(buf: *u8, tag: u8) usize {
+    val prefix: str = "/tmp/mach-std-415-";
+    var n: usize = 0;
+    for (n < str_len(prefix)) { buf[n] = prefix[n]; n = n + 1; }
+    var pid: i64 = getpid();
+    if (pid < 0) { pid = 0; }
+    var digits: [24]u8;
+    var d: usize = 0;
+    if (pid == 0) { digits[0] = '0'::u8; d = 1; }
+    for (pid > 0) {
+        digits[d] = ('0'::u8) + (pid % 10)::u8;
+        pid = pid / 10;
+        d = d + 1;
     }
+    for (d > 0) { d = d - 1; buf[n] = digits[d]; n = n + 1; }
+    buf[n] = '-'::u8; n = n + 1;
+    buf[n] = tag;     n = n + 1;
     buf[n] = 0;
-    ret n::i64;
+    ret n;
+}
+
+# O_CREAT carries `mode` in the variadic tail, and the file really gets it
+#
+# the mask is pinned to 0 for the duration so the expected mode is exact: a
+# subset assertion would still pass if the tail were dropped and openat read a
+# stale stack slot that happened to have the right bits set.
+test "std.system.os.darwin.libsystem:open_creat_applies_the_variadic_mode" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'a'::u8);
+    unlink(AT_FDCWD, ?path[0], 0);
+
+    val saved: u32 = ls.umask(0);
+    val fd: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_RDWR, 0o741);
+    ls.umask(saved);
+    if (fd < 0) { ret 1; }
+    close(fd::i32);
+
+    var st: stat_t;
+    val r: i64 = stat_path(AT_FDCWD, ?path[0], ?st, 0);
+    unlink(AT_FDCWD, ?path[0], 0);
+    if (r != 0) { ret 1; }
+
+    # the exact bits asked for, not merely "some file exists"
+    if ((stat_mode(?st) & 0o777) != 0o741) { ret 1; }
+    if ((stat_mode(?st) & S_IFMT) != S_IFREG) { ret 1; }
+    ret 0;
+}
+
+# a second O_CREAT|O_EXCL on the same path is EEXIST, not "an error"
+test "std.system.os.darwin.libsystem:open_excl_twice_is_eexist" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'b'::u8);
+    unlink(AT_FDCWD, ?path[0], 0);
+
+    val first: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_EXCL | O_WRONLY, 0o600);
+    if (first < 0) { ret 1; }
+    close(first::i32);
+
+    val second: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_EXCL | O_WRONLY, 0o600);
+    unlink(AT_FDCWD, ?path[0], 0);
+    if (second != EEXIST) { ret 1; }
+    ret 0;
+}
+
+# opening a path that is not there is ENOENT specifically
+#
+# this is the two-argument openat form: no O_CREAT, so nothing rides the
+# variadic tail at all.
+test "std.system.os.darwin.libsystem:open_missing_path_is_enoent" {
+    if (open(AT_FDCWD, "/tmp/mach-std-415-definitely-absent/x", O_RDONLY, 0) != ENOENT) {
+        ret 1;
+    }
+    ret 0;
+}
+
+# a bad descriptor is EBADF, and errno survives being read through __error
+test "std.system.os.darwin.libsystem:close_bad_descriptor_is_ebadf" {
+    if (close(-1) != EBADF) { ret 1; }
+    ret 0;
+}
+
+# F_SETFD really sets the flag F_GETFD then reads back
+#
+# F_SETFD passes one int in the variadic tail; F_GETFD passes none. a round
+# trip through both proves the two forms are lowered distinctly - if the
+# no-tail form were lowered as if it had a tail, or vice versa, the flag word
+# read back would not be the one written.
+test "std.system.os.darwin.libsystem:fcntl_fd_cloexec_round_trip" {
+    var fds: [2]i32;
+    if (ls.pipe(?fds[0]) < 0) { ret 1; }
+
+    var rc: i32 = 0;
+    if (fd_flags(fds[0]) != 0) { rc = 1; }
+
+    if (rc == 0 && set_fd_flags(fds[0], FD_CLOEXEC) != 0) { rc = 1; }
+    if (rc == 0 && fd_flags(fds[0]) != FD_CLOEXEC::i64) { rc = 1; }
+
+    # and clearing it takes effect too, so the previous read was not just a
+    # constant that happened to match
+    if (rc == 0 && set_fd_flags(fds[0], 0) != 0) { rc = 1; }
+    if (rc == 0 && fd_flags(fds[0]) != 0) { rc = 1; }
+
+    close(fds[0]);
+    close(fds[1]);
+    ret rc;
+}
+
+# O_APPEND set at open time is visible through F_GETFL
+test "std.system.os.darwin.libsystem:fcntl_getfl_reports_open_flags" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'c'::u8);
+    unlink(AT_FDCWD, ?path[0], 0);
+
+    val fd: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_WRONLY | O_APPEND, 0o600);
+    if (fd < 0) { ret 1; }
+
+    var rc: i32 = 0;
+    val fl: i64 = file_flags(fd::i32);
+    if (fl < 0)                          { rc = 1; }
+    if (rc == 0 && (fl & O_APPEND::i64) == 0) { rc = 1; }
+
+    close(fd::i32);
+    unlink(AT_FDCWD, ?path[0], 0);
+    ret rc;
+}
+
+# a pipe actually carries bytes end to end
+test "std.system.os.darwin.libsystem:pipe_round_trips_bytes" {
+    var fds: [2]i32;
+    if (ls.pipe(?fds[0]) < 0) { ret 1; }
+
+    var out: [4]u8;
+    out[0] = 'm'::u8; out[1] = 'a'::u8; out[2] = 'c'::u8; out[3] = 'h'::u8;
+
+    var rc: i32 = 0;
+    if (write(fds[1], ?out[0], 4) != 4) { rc = 1; }
+
+    var back: [4]u8;
+    back[0] = 0; back[1] = 0; back[2] = 0; back[3] = 0;
+    if (rc == 0 && read(fds[0], ?back[0], 4) != 4) { rc = 1; }
+    if (rc == 0 && (back[0] != 'm'::u8 || back[1] != 'a'::u8
+                 || back[2] != 'c'::u8 || back[3] != 'h'::u8)) { rc = 1; }
+
+    close(fds[0]);
+    close(fds[1]);
+    ret rc;
+}
+
+# written bytes come back after a seek, and seek reports the absolute offset
+test "std.system.os.darwin.libsystem:write_seek_read_round_trip" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'd'::u8);
+    unlink(AT_FDCWD, ?path[0], 0);
+
+    val fd: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_RDWR, 0o600);
+    if (fd < 0) { ret 1; }
+    val d: i32 = fd::i32;
+
+    var rc: i32 = 0;
+    var out: [5]u8;
+    out[0] = 'h'::u8; out[1] = 'e'::u8; out[2] = 'l'::u8; out[3] = 'l'::u8; out[4] = 'o'::u8;
+    if (write(d, ?out[0], 5) != 5) { rc = 1; }
+
+    # SEEK_END reports the size the writes produced
+    if (rc == 0 && seek(d, 0, SEEK_END) != 5) { rc = 1; }
+    if (rc == 0 && seek(d, 1, SEEK_SET) != 1) { rc = 1; }
+
+    var back: [4]u8;
+    if (rc == 0 && read(d, ?back[0], 4) != 4) { rc = 1; }
+    if (rc == 0 && (back[0] != 'e'::u8 || back[1] != 'l'::u8
+                 || back[2] != 'l'::u8 || back[3] != 'o'::u8)) { rc = 1; }
+
+    # and stat agrees about the size, through the $INODE64-gated fstat
+    var st: stat_t;
+    if (rc == 0 && stat(d, ?st) != 0) { rc = 1; }
+    if (rc == 0 && st.st_size != 5)   { rc = 1; }
+
+    close(d);
+    unlink(AT_FDCWD, ?path[0], 0);
+    ret rc;
+}
+
+# mkdir creates a directory, and stat says so
+test "std.system.os.darwin.libsystem:make_dir_creates_a_directory" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'e'::u8);
+    unlink(AT_FDCWD, ?path[0], AT_REMOVEDIR);
+
+    val saved: u32 = ls.umask(0);
+    val r: i64 = make_dir(AT_FDCWD, ?path[0], 0o751);
+    ls.umask(saved);
+    if (r != 0) { ret 1; }
+
+    var st: stat_t;
+    var rc: i32 = 0;
+    if (stat_path(AT_FDCWD, ?path[0], ?st, 0) != 0) { rc = 1; }
+    if (rc == 0 && (stat_mode(?st) & S_IFMT) != S_IFDIR) { rc = 1; }
+    if (rc == 0 && (stat_mode(?st) & 0o777) != 0o751)    { rc = 1; }
+
+    unlink(AT_FDCWD, ?path[0], AT_REMOVEDIR);
+    ret rc;
+}
+
+# rename moves the file: the new name resolves and the old one is ENOENT
+test "std.system.os.darwin.libsystem:rename_moves_the_file" {
+    var from: [64]u8;
+    var to:   [64]u8;
+    tmp_path(?from[0], 'f'::u8);
+    tmp_path(?to[0],   'g'::u8);
+    unlink(AT_FDCWD, ?from[0], 0);
+    unlink(AT_FDCWD, ?to[0],   0);
+
+    val fd: i64 = open(AT_FDCWD, ?from[0], O_CREAT | O_WRONLY, 0o600);
+    if (fd < 0) { ret 1; }
+    close(fd::i32);
+
+    var rc: i32 = 0;
+    if (rename(AT_FDCWD, ?from[0], AT_FDCWD, ?to[0]) != 0) { rc = 1; }
+
+    var st: stat_t;
+    if (rc == 0 && stat_path(AT_FDCWD, ?to[0], ?st, 0) != 0)        { rc = 1; }
+    if (rc == 0 && stat_path(AT_FDCWD, ?from[0], ?st, 0) != ENOENT) { rc = 1; }
+
+    unlink(AT_FDCWD, ?from[0], 0);
+    unlink(AT_FDCWD, ?to[0],   0);
+    ret rc;
+}
+
+# a symlink resolves to its target, and AT_SYMLINK_NOFOLLOW sees the link
+test "std.system.os.darwin.libsystem:symlink_is_a_link_to_its_target" {
+    var target: [64]u8;
+    var link:   [64]u8;
+    tmp_path(?target[0], 'h'::u8);
+    tmp_path(?link[0],   'i'::u8);
+    unlink(AT_FDCWD, ?target[0], 0);
+    unlink(AT_FDCWD, ?link[0],   0);
+
+    val fd: i64 = open(AT_FDCWD, ?target[0], O_CREAT | O_WRONLY, 0o600);
+    if (fd < 0) { ret 1; }
+    close(fd::i32);
+
+    var rc: i32 = 0;
+    if (symlink(?target[0], ?link[0]) != 0) { rc = 1; }
+
+    var st: stat_t;
+    # following the link lands on a regular file
+    if (rc == 0 && stat_path(AT_FDCWD, ?link[0], ?st, 0) != 0)      { rc = 1; }
+    if (rc == 0 && (stat_mode(?st) & S_IFMT) != S_IFREG)            { rc = 1; }
+    # not following it shows the link itself
+    if (rc == 0 && stat_path(AT_FDCWD, ?link[0], ?st, AT_SYMLINK_NOFOLLOW) != 0) { rc = 1; }
+    if (rc == 0 && (stat_mode(?st) & S_IFMT) != S_IFLNK)            { rc = 1; }
+
+    unlink(AT_FDCWD, ?link[0],   0);
+    unlink(AT_FDCWD, ?target[0], 0);
+    ret rc;
+}
+
+# errno is not cleared by a successful call, so a success must never consult it
+#
+# the trap this guards: provoke a failure to leave a non-zero errno behind,
+# then make a call that SUCCEEDS. a wrapper that read errno unconditionally
+# instead of only after its sentinel fired would report the stale ENOENT here.
+test "std.system.os.darwin.libsystem:stale_errno_does_not_poison_a_success" {
+    if (open(AT_FDCWD, "/tmp/mach-std-415-definitely-absent/x", O_RDONLY, 0) != ENOENT) {
+        ret 1;
+    }
+    if (ls.errno() != 2) { ret 1; }
+
+    var fds: [2]i32;
+    if (ls.pipe(?fds[0]) < 0) { ret 1; }
+    var rc: i32 = 0;
+    if (fd_flags(fds[0]) != 0) { rc = 1; }
+    close(fds[0]);
+    close(fds[1]);
+    ret rc;
 }
 
 # a destination too small for the path is refused rather than overrun

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -6,6 +6,7 @@
 use std.types.size.usize;
 
 use std.system.os.darwin.shared;
+use ls: std.system.os.darwin.libsystem;
 
 $if ($mach.build.os != $mach.os.darwin) {
     $error("std.system.os.darwin.x86_64: requires darwin target");
@@ -21,30 +22,18 @@ pub fun page_size() usize {
 
 # create a unidirectional pipe
 #
-# darwin pipe() returns two fds in rax/rdx and signals failure via the
-# carry flag, neither of which the syscall DSL captures, so this uses raw
-# asm. the inline-asm encoder only branches to symbols (issue #216), so the
-# carry flag is materialized into a register (`setc`) and the branching
-# happens in mach code instead of the asm block.
+# this was hand-written asm for one reason: the raw XNU pipe trap returns the
+# two descriptors in rax/rdx and signals failure through the carry flag, and the
+# syscall DSL captures neither. libSystem's pipe(2) is an ordinary C function
+# that writes both descriptors through the caller's array and reports failure
+# as -1, so the arch-specific asm has nothing left to do and the wrapper is now
+# identical on both darwin architectures - it lives here only because `pipe` is
+# part of the per-arch module's published surface.
 # ---
 # fds: pointer to two i32s; fds[0] = read end, fds[1] = write end
 # ret: 0 on success, or negative errno
 pub fun pipe(fds: *i32) i64 {
-    var fd0: i64 = 0;
-    var fd1: i64 = 0;
-    var fail: i64 = 0;
-    asm x86_64 {
-        mov eax, 0x200002A
-        syscall
-        mov rcx, 0
-        setc cl
-        mov {fail}, rcx
-        mov {fd0}, rax
-        mov {fd1}, rdx
-    }
-    if (fail != 0) { ret -fd0; }
-    fds[0] = fd0::i32;
-    fds[1] = fd1::i32;
+    if (ls.pipe(fds) < 0) { ret ls.fail_errno(); }
     ret 0;
 }
 

--- a/test/darwin/known-failures.txt
+++ b/test/darwin/known-failures.txt
@@ -1,0 +1,36 @@
+# tests that already fail on darwin BEFORE the libSystem migration (#415)
+#
+# this file is not a mute button. the darwin suite had never been executed by CI
+# until #462 added a native macOS lane, and its first run found eleven failures
+# on BOTH architectures, identically. they were confirmed to predate the
+# migration by running the untouched `dev` tree on the same two runners: dev
+# reports 777 passed / 11 failed, and the exact same eleven names.
+#
+# every one of them is in a subsystem still issuing raw BSD traps, which is the
+# thesis of #415 stated as a test result:
+#
+#   chrono.time    -- clock_gettime through syscall 427. `now()` comes back
+#                     below the epoch, so the number the trap returns is not a
+#                     time. macOS has exported clock_gettime(3) from libSystem
+#                     since 10.12.
+#   process.exec   -- fork / execve / wait4 through raw traps.
+#   sync.thread    -- bsdthread_create + bsdthread_register, the private
+#                     kernel<->libpthread handshake #415 calls out by name as
+#                     the most fragile thing on the least stable surface.
+#
+# the verify script fails the build on any failure NOT listed here, and equally
+# on any listed test that starts PASSING. so this cannot silently rot: fixing
+# one forces its removal, and regressing a new one is caught. the list must
+# reach empty as the rest of #415 lands, and it is the checklist for doing so.
+
+time: now returns non-zero
+time: since returns positive for past time
+time: monotonic returns non-zero
+std.process.exec.run:success_exits_zero
+std.process.exec.run:failure_exits_one
+std.process.exec.spawn:wait_matches_run
+std.process.exec.run:repeated_spawns_stay_correct
+std.process.exec.wait_any:reaps_each_child_once
+thread: spawn and join
+thread: is_done after join
+thread: spawn_with delivers distinct userdata

--- a/test/darwin/verify.sh
+++ b/test/darwin/verify.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# run the suite natively on darwin and gate it against known-failures.txt.
+#
+# darwin carries a set of failures that predate the libSystem migration (#415);
+# they are enumerated, with evidence, in known-failures.txt. this script exists
+# so that set can be tolerated WITHOUT tolerating anything else:
+#
+#   - a failure that is not on the list fails the build (a regression)
+#   - a listed test that PASSES fails the build (the list has gone stale and
+#     must shrink)
+#
+# both directions matter. only checking the first turns the list into a mute
+# button that silently outlives the bugs it describes.
+#
+# usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -uo pipefail
+
+mach="${1:-mach}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+cd "$root"
+
+known="$here/known-failures.txt"
+
+# strip comments and blank lines
+expected="$(grep -vE '^[[:space:]]*(#|$)' "$known" | sed 's/[[:space:]]*$//' | sort -u)"
+
+out="$(mktemp)"
+"$mach" test . 2>&1 | tee "$out"
+
+if ! grep -qE '[0-9]+ passed, [0-9]+ failed' "$out"; then
+    echo "::error::the suite produced no result line -- it did not run to completion"
+    exit 1
+fi
+
+# "  FAIL  <name>  ./src/...:NN  (exit 1)" -> "<name>"
+actual="$(sed -n 's/^[[:space:]]*FAIL[[:space:]]\{1,\}\(.*\)[[:space:]]\{2,\}\.\/[^[:space:]]*[[:space:]]*(exit [0-9]*)[[:space:]]*$/\1/p' "$out" \
+          | sed 's/[[:space:]]*$//' | sort -u)"
+
+rc=0
+
+unexpected="$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual"))"
+if [ -n "$unexpected" ]; then
+    echo "::error::darwin test failures that are NOT known-pre-existing:"
+    printf '  %s\n' $unexpected
+    rc=1
+fi
+
+fixed="$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual"))"
+if [ -n "$fixed" ]; then
+    echo "::error::these are listed in known-failures.txt but PASSED -- remove them from the list:"
+    printf '  %s\n' $fixed
+    rc=1
+fi
+
+if [ "$rc" = "0" ]; then
+    n="$(printf '%s\n' "$expected" | grep -c . || true)"
+    echo "OK: no new darwin failures; $n known pre-existing failures still outstanding (#415)"
+fi
+
+rm -f "$out"
+exit "$rc"


### PR DESCRIPTION
Refs #415. First of several — this lands the **filesystem and descriptor** primitives completely, plus the native darwin CI lane everything after it needs.

## Read this first: darwin was already broken, and nothing was watching

This repo's CI has never executed a darwin binary. `cross-backends` cross-compiles the darwin backends from linux and runs nothing. This PR adds a native lane on `macos-15` (arm64) and `macos-15-intel`, and **its first run found eleven failures** — on both architectures, identically.

They are not mine. I ran untouched `dev` on the same two runners as a control (#463, since closed): **777 passed / 11 failed / 788 total**, the same eleven names. All eleven sit in subsystems still issuing raw BSD traps:

| module | failing | mechanism |
|---|---|---|
| `std.chrono.time` | 3 | `clock_gettime` via syscall 427 — `now()` returns below the Unix epoch |
| `std.process.exec` | 5 | `fork` / `execve` / `wait4` |
| `std.sync.thread` | 3 | `bsdthread_create` + `bsdthread_register` (1 of 4 tests passing) |

#415 is filed as low priority on the reasoning that "raw syscalls work right now". That is true of **mach**, whose darwin lane self-hosts. It is not true of **mach-std**. Detail and a suggested resequencing are in [my comment on #415](https://github.com/briar-systems/mach-std/issues/415#issuecomment-5224587701).

They are enumerated with that evidence in `test/darwin/known-failures.txt`. The gate fails on any failure **not** on the list and equally on any listed test that **starts passing**, so it cannot become a mute button — it has to shrink to empty as the rest of #415 lands.

## Why this seam

#415's sequencing had "prove it links" as its own step, then the primitives. I merged them: a declaration block with no call sites proves nothing you cannot prove by reading it, and the errno contract is the actual risk. So this is *one complete domain, migrated and asserted*. The layer's outward contract — a count or descriptor on success, a negative errno on failure — is unchanged, so nothing above `std.system.os.darwin` moved.

**The mixed state is deliberate.** Memory, time, process, sockets, threads, `read_dir` and `terminal` still issue raw traps.

## Verified by execution

All on the two macOS runners in this PR, green:

- **789 passed / 11 failed / 800 total** on both rows — the same 11, plus **12 new tests all passing**.
- Tests assert observable effects, not return codes:
  - `O_CREAT` creates a file whose mode is stat'd back and compared **exactly**, umask pinned to 0 for the duration. This is the one that catches a dropped variadic argument; a subset assertion would still pass on a stale stack slot.
  - `mkdir` likewise: mode *and* `S_IFDIR`.
  - `FD_CLOEXEC` set → read back → cleared → read back, so the read is not a constant that happened to match.
  - `O_APPEND` given at open time is visible through `F_GETFL`.
  - a pipe carries four specific bytes end to end.
  - write → `SEEK_END` reports 5 → `SEEK_SET` 1 → read back the right four bytes → `fstat` agrees on the size.
  - rename: new name resolves, old name is `ENOENT`. symlink: follows to `S_IFREG`, `AT_SYMLINK_NOFOLLOW` sees `S_IFLNK`.
  - error paths provoked for their **specific** errno: `EEXIST`, `ENOENT`, `EBADF`.
  - a stale errno left by a failure does not poison a subsequent success.
- `otool -L` on a natively linked executable: exactly **one** `/usr/lib/libSystem.B.dylib`, and the binary **runs**.
- `nm -u` per row: `_fstat$INODE64` / `_fstatat$INODE64` on x86_64, plain `_fstat` / `_fstatat` on arm64 with no `INODE64` anywhere.
- linux / arm64-linux / riscv64: 788 passed, 0 failed — unchanged.

## Verified by cross-compilation and disassembly (locally, on linux)

- The emitted **arm64** call is `sub sp, sp, #0x10` / `str x17, [sp]` / `bl _open` — the variadic tail is genuinely **stack-passed**, not in `x2`.
- The emitted **x86_64** call is `movl $mode, %edx` + `movl $0x0, %eax` — ordinary SysV rule with **`AL` = 0**, as expected given no float ever crosses this boundary.

## Verified by inspection only

That the plain (cancelable) entry points behave identically to their `$NOCANCEL` twins in a process that never calls `pthread_cancel`. Reasoned, not measured; the reasoning is in the `libsystem.mach` header, in one place rather than spread across call sites.

## Three findings worth reading

**1. `#[library("libSystem")]` does not work by itself on either arch, for two different reasons.** On arm64 the implicit platform dependency is recorded under its *loader path* and carries no logical alias, so the pin fails with "not among the link's dependencies". On x86_64 there is no implicit dependency at all — it only attaches to PIE images, and darwin x86_64 is not PIE — so it fails as a plain undefined symbol. An explicit `[link.libsystem]` fixes both.

**2. The manifest `name` must be the full install path.** Spelled as a leaf (`libSystem.B.dylib`) the requirement does not match the implicit dependency and the image gets **two** `LC_LOAD_DYLIB` commands, one a bare name dyld would have to search for. It links clean; only `otool -L` shows it, which is why that check is now in CI.

**3. `$INODE64` was not in #415's inventory and is a silent-corruption hazard.** On x86_64 the plain `_fstat` is still the legacy 32-bit-`st_ino` struct. Binding it would have linked, run, and filled `stat_t` from a different field order. Arch-gated and asserted per row.

## Not done here

`read_dir` needs `getdirentries64`, which is not public API on darwin — replacing it is an `opendir`/`readdir` redesign that changes the primitive's shape, not just its callee. Threads, memory, time, sockets and terminal are untouched; see the resequencing note on #415, which argues threads should come next rather than last.
