### PR TITLE
ci: baseline darwin probe (do not merge)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,35 @@ jobs:
         shell: bash
         run: bash test/symlink/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
 
+  # BASELINE PROBE, not for merge. runs the existing suite natively on darwin
+  # with the raw-syscall backend exactly as it stands on dev, to establish which
+  # failures predate the libSystem migration in #462.
+  darwin:
+    name: darwin ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            runner: macos-15
+          - arch: x86_64
+            runner: macos-15-intel
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
+
+      - name: Report the seed
+        run: mach info
+
+      - name: Run the test suite natively on darwin
+        run: mach test .
+
   cross-backends:
     runs-on: ubuntu-latest
     steps:

--- a/mach.toml
+++ b/mach.toml
@@ -19,6 +19,16 @@ isa = "riscv64"
 os  = "linux"
 abi = "lp64"
 
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
 [link.kernel32]
 source = "system"
 name = "kernel32.dll"


### PR DESCRIPTION
Throwaway probe opened only to run the existing suite natively on darwin at `dev`, with the raw-syscall backend untouched. Its purpose is to attribute the 11 failures seen in #462: if they reproduce here, they predate the libSystem migration. I will close this once it has reported.