### PR TITLE
feat(os/darwin): create threads with pthread_create, not bsdthread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### darwin: threads are pthreads, not bsdthreads (#415)
+
+`bsdthread_create` / `bsdthread_register` was never an ABI. `bsdthread_register` publishes a workqueue callback the kernel invokes, versioned against the libpthread that shipped with the OS — an internal kernel↔libpthread protocol this backend was impersonating. It is what #415 singles out as the most fragile code on the least stable part of the surface, and on current macOS it does not work: all three `std.sync.thread` tests were failing before this change, and had been failing unnoticed because nothing had ever run this suite on darwin.
+
+**This had to come before the rest of the migration, not after it.** libSystem reaches errno through `__error()`, a thread-local resolved against the pthread structure libpthread installs for threads it created. A raw bsdthread never had one, because the start routine never performed libpthread's own `_pthread_set_self` handshake. Every libSystem call already migrated would therefore have carried an unvalidated errno path the moment it ran off the main thread. `pthread_create` makes every thread a real pthread and the question stops existing.
+
+**pthread does not use errno, and that is the trap.** Every other libSystem entry point reports failure as `-1` and leaves the reason in errno. The pthread family returns the error number *directly* and leaves errno untouched, so the `if (rc < 0) { ret fail_errno(); }` shape used everywhere else is wrong twice over — the branch never fires, and if it did it would report an unrelated stale errno. The pthread wrappers negate `rc` itself and never call `fail_errno`.
+
+**The OS-layer contract is unchanged; stack ownership moved.** `thread_spawn` still takes a caller-allocated region and a completion flag, and `thread_wait`/`thread_wake` are still address-keyed. The caller's region is now a *context block* only — pthread allocates and frees the real stack — which is exactly how the windows backend has always used it. The block is released by the new thread itself, so an unjoined thread still reclaims it, matching what `bsdthread_terminate` did. Threads are created **detached**, because joining waits on the completion flag rather than calling `pthread_join`, and a joinable pthread would leave its descriptor unreaped.
+
+**The address-keyed wait is a table of condition variables.** darwin's futex equivalent, `__ulock_wait`, is as private as the bsdthread traps; the public replacement `os_sync_wait_on_address` is macOS 14.4+ and adopting it would quietly raise this library's deployment floor. So the wait is built from pthread condition variables in a fixed table hashed by address. Buckets are genuinely shared, and the consequences are handled rather than hoped away: `thread_wake` **broadcasts**, because a signal could hand the one wakeup to a waiter on an unrelated address; and the lost-wakeup race is closed by lock discipline, since the waiter re-reads the address under the bucket mutex that `pthread_cond_wait` releases atomically and that `thread_wake` must hold to broadcast.
+
+Deleted with it: both hand-written `asm` trampolines (including the x86_64 stack-realignment fixup that existed only because the kernel *jumped* to the entry rather than calling it), the workqueue callback, and six `SYS_*` constants.
+
+
+
 #### darwin: the filesystem layer calls libSystem instead of raw BSD traps (#415)
 
 Apple does not guarantee syscall-number stability. `svc 0x80` / `syscall` works today and has been broken across macOS releases before, and libSystem is the only interface Apple supports. This moves the **filesystem and descriptor** primitives of the darwin backend onto it. Memory, time, process, sockets, threads, `read_dir`, and `terminal` still issue raw traps; see "what is deliberately left" below.

--- a/src/system/os/darwin/libsystem.mach
+++ b/src/system/os/darwin/libsystem.mach
@@ -177,6 +177,94 @@ pub ext fun getcwd(buf: *u8, size: usize) *u8;
 #[library("libSystem")]
 pub ext fun pipe(fds: *i32) i32;
 
+# threads
+#
+# ## pthread does NOT use errno, and that is the trap in this section
+#
+# every entry point above reports failure as -1 and leaves the reason in
+# errno. **the pthread family does neither.** it returns the error number
+# DIRECTLY as its result: 0 on success, otherwise an `errno.h` value. errno
+# itself is left completely untouched.
+#
+# so `if (rc < 0) { ret fail_errno(); }` - the shape every other wrapper in
+# this module uses - is wrong twice over for a pthread call. `rc` is never
+# negative, so the branch never fires and a failure returns as success; and if
+# it did fire it would report whatever unrelated errno was lying around. the
+# pthread wrappers negate `rc` itself and never call `fail_errno`.
+#
+# ## why pthread at all, rather than the bsdthread traps
+#
+# `bsdthread_create` / `bsdthread_register` is not an ABI. `bsdthread_register`
+# publishes a workqueue callback the kernel invokes, versioned against the
+# libpthread that shipped with the OS - an internal kernel<->libpthread
+# protocol we were impersonating. It is the least stable part of the surface
+# this migration exists to leave, and on current macOS it no longer works: the
+# thread tests were failing before this change.
+#
+# it also blocked everything else. libSystem reaches errno through `__error()`,
+# a thread-local lookup that resolves against the pthread structure libpthread
+# installs for a thread it created. a raw bsdthread never had one, because the
+# start routine never performed libpthread's own `_pthread_set_self` handshake.
+# every libSystem call in this module would therefore have had an unvalidated
+# errno path the moment it ran off the main thread. `pthread_create` makes
+# every thread a real pthread and the question stops existing - which is why
+# this is the FIRST domain migrated after the filesystem, not the last.
+
+# opaque pthread object sizes, from <sys/_pthread/_pthread_types.h> on LP64.
+# each object is a `long sig` followed by an opaque byte array:
+#   _PTHREAD_MUTEX_SIZE 56, _PTHREAD_COND_SIZE 40,
+#   _PTHREAD_ATTR_SIZE  56, _PTHREAD_ONCE_SIZE  8
+# these are public ABI - changing one would break every compiled C program on
+# the system - so they are spelled as constants rather than probed. they are
+# asserted against the runtime's own behaviour by the tests in shared.mach.
+pub val PTHREAD_MUTEX_BYTES: usize = 64;
+pub val PTHREAD_COND_BYTES:  usize = 48;
+pub val PTHREAD_ATTR_BYTES:  usize = 64;
+pub val PTHREAD_ONCE_BYTES:  usize = 16;
+
+# pthread_attr_setdetachstate states (<pthread.h>)
+pub val PTHREAD_CREATE_JOINABLE: i32 = 1;
+pub val PTHREAD_CREATE_DETACHED: i32 = 2;
+
+# `start` is a `void *(*)(void *)` passed as a bare address, matching how the
+# windows backend hands CreateThread its trampoline.
+#[library("libSystem")]
+pub ext fun pthread_create(thread: *usize, attr: *u8, start: usize, arg: ptr) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_attr_init(attr: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_attr_destroy(attr: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_attr_setstacksize(attr: *u8, size: usize) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_attr_setdetachstate(attr: *u8, state: i32) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_mutex_init(m: *u8, attr: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_mutex_lock(m: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_mutex_unlock(m: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_cond_init(c: *u8, attr: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_cond_wait(c: *u8, m: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_cond_broadcast(c: *u8) i32;
+
+# `init` is a `void (*)(void)` passed as a bare address.
+#[library("libSystem")]
+pub ext fun pthread_once(once: *u8, init: usize) i32;
+
 # set the file-mode creation mask, returning the previous one
 #
 # cannot fail and does not touch errno. imported so a test can pin the mask to

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -92,10 +92,6 @@ val SEEK_SET: i32 = 0;
 val SEEK_CUR: i32 = 1;
 val SEEK_END: i32 = 2;
 
-# thread creation (bsdthread)
-
-# ulock (futex equivalent)
-
 # kernel ABI types
 
 # darwin stat64 structure for file metadata

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -93,14 +93,8 @@ val SEEK_CUR: i32 = 1;
 val SEEK_END: i32 = 2;
 
 # thread creation (bsdthread)
-val SYS_BSDTHREAD_CREATE:    usize = 360;
-val SYS_BSDTHREAD_TERMINATE: usize = 361;
-val SYS_BSDTHREAD_REGISTER:  usize = 366;
 
 # ulock (futex equivalent)
-val SYS_ULOCK_WAIT: usize = 515;
-val SYS_ULOCK_WAKE: usize = 516;
-val UL_COMPARE_AND_WAIT64: usize = 5;
 
 # kernel ABI types
 
@@ -1494,121 +1488,422 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
 }
 
 # threads
-
-var thread_registered: i64 = 0;
-
-# the bsdthread body: run the user function, flag completion, wake a joiner, and
-# terminate the thread (releasing its stack). the kernel never reaches this
-# directly - `thread_start` below is the registered entry and tails in through a
-# `call`/`b`, so the platform function-entry ABI (notably x86_64 stack alignment)
-# holds before any real work runs.
-# ---
-# self:      kernel thread self pointer (unused)
-# kport:     mach thread port, passed to bsdthread_terminate
-# func:      user function to run on the thread
-# arg:       pointer to the [done, stack_base, stack_size, user] context at the stack base
-# stacksize: kernel stack size (unused; the real size travels in the context)
-# pflags:    kernel pthread flags (unused)
-#[symbol("_std_darwin_thread_start_impl")]
-fun thread_start_impl(self: usize, kport: usize, func: usize, arg: usize, stacksize: usize, pflags: usize) {
-    val ctx: *usize = arg::*usize;
-    val done_addr: usize = ctx[0];
-    val stack_base: usize = ctx[1];
-    val stack_size: usize = ctx[2];
-    val user: usize = ctx[3];
-    val fn_ptr: fun(*u8) = func::fun(*u8);
-    fn_ptr(user::*u8);
-    val done: *i64 = done_addr::*i64;
-    @done = 1;
-    syscall3(SYS_ULOCK_WAKE, UL_COMPARE_AND_WAIT64, done_addr, 0);
-    syscall4(SYS_BSDTHREAD_TERMINATE, stack_base, stack_size, kport, 0);
-}
-
-# the bsdthread_create kernel entry point (registered via bsdthread_register)
 #
-# the kernel JUMPS here with the six thread arguments in registers and the thread's
-# initial stack pointer set to the stack top passed to bsdthread_create - it does
-# not `call`, so on x86_64 the stack lands 16-aligned rather than the (rsp+8)%16==0
-# the SysV ABI guarantees at a function entry (the return address a `call` would
-# have pushed). a compiled body would then run every stack access, and the user
-# function it calls, on a stack skewed by 8, so the first 16-byte-aligned SSE spill
-# faults. realign the stack and enter the compiled body through a `call`, which
-# restores the entry contract - the same fixup `_start` applies. aarch64 keeps SP
-# 16-aligned across a branch (a return address never lands on the stack), so it
-# tails straight into the body. naked: the inline asm owns the stack, no prologue.
-#[symbol("_std_darwin_thread_start")]
-fun thread_start() {
-    $if ($mach.build.arch == $mach.arch.x86_64) {
-        asm x86_64 {
-            and rsp, -16
-            call _std_darwin_thread_start_impl
-            hlt
-        }
-    }
-    $or ($mach.build.arch == $mach.arch.aarch64) {
-        asm aarch64 {
-            b _std_darwin_thread_start_impl
-        }
-    }
-}
+# pthread, not bsdthread. `bsdthread_register` published a workqueue callback
+# the kernel invokes, versioned against the libpthread that shipped with the
+# OS: an internal kernel<->libpthread protocol this module was impersonating
+# rather than an ABI. It stopped working - the three `std.sync.thread` tests
+# were failing on darwin before this change - and it was also the reason the
+# rest of the migration could not proceed, because libSystem reaches errno
+# through a thread-local that only exists on a thread libpthread created.
+#
+# the shape of the OS-layer contract is unchanged: `thread_spawn` still takes a
+# caller-allocated region and a completion flag, and `thread_wait`/`thread_wake`
+# are still address-keyed. what changed underneath is who owns the stack. the
+# caller's region is now a CONTEXT BLOCK only - pthread allocates and frees the
+# real stack from `stack_size` - which is exactly how the windows backend has
+# always used it (see `thread_trampoline` there). the context block is released
+# by the new thread itself, so an unjoined thread still reclaims it, matching
+# what `bsdthread_terminate` used to do.
 
-# workqueue thread callback (unused, required by bsdthread_register)
-fun thread_wq_start(self: usize, kport: usize, saddr: usize, arg: usize, cnt: usize, flags: usize) {
-    syscall4(SYS_BSDTHREAD_TERMINATE, 0, 0, 0, 0);
-}
+# ## the address-keyed wait, and why it is a table of condition variables
+#
+# `thread_wait`/`thread_wake` are a futex-shaped contract: linux has `futex`
+# and windows has `WaitOnAddress`, both of which take the address directly.
+# darwin's equivalent is `__ulock_wait`/`__ulock_wake`, which is private - as
+# private as the bsdthread traps - so it is not available to us. the public
+# replacement, `os_sync_wait_on_address`, is macOS 14.4+ and adopting it would
+# quietly raise this library's deployment floor.
+#
+# so the address-keyed wait is built from pthread condition variables, which
+# are public and have existed forever. a fixed table of (mutex, cond) pairs is
+# hashed by address. that is a real hash table, with real collisions: two
+# distinct addresses can share a bucket. the consequences are handled rather
+# than hoped away -
+#
+#   - `thread_wake` BROADCASTS. with a shared bucket, `signal` could hand the
+#     one wakeup to a waiter on an unrelated address and lose ours.
+#   - a waiter therefore sees wakeups that are not for it. the contract already
+#     documents spurious wakeups, and the only consumer (`sync.thread.join`)
+#     re-tests its flag in a loop, which is what a condition variable requires
+#     of every caller anyway.
+#
+# the lost-wakeup race is closed by the lock discipline, not by luck: the
+# waiter re-reads the address UNDER the bucket mutex and `pthread_cond_wait`
+# releases that mutex atomically, while `thread_wake` must acquire the same
+# mutex before it can broadcast. so a wake can never land in the window
+# between the waiter's test and its sleep.
 
-fun ensure_thread_registered() {
-    if (atomic.load(?thread_registered) != 0) { ret; }
+val WAIT_BUCKETS: usize = 64;
+
+var wait_mutexes: [4096]u8;   # WAIT_BUCKETS * PTHREAD_MUTEX_BYTES (64 * 64)
+var wait_conds:   [3072]u8;   # WAIT_BUCKETS * PTHREAD_COND_BYTES  (64 * 48)
+
+# 0 = untouched, 1 = one thread is initializing, 2 = ready
+var wait_ready: i64 = 0;
+
+# initialize the bucket table exactly once, whoever gets there first
+#
+# a plain compare-and-swap would let the loser proceed on half-built mutexes,
+# so the loser waits for the winner to publish state 2 rather than assuming the
+# swap it lost meant the work was done.
+fun ensure_wait_tables() {
+    if (atomic.load(?wait_ready) == 2) { ret; }
     var expected: i64 = 0;
-    if (!atomic.cas(?thread_registered, ?expected, 1)) { ret; }
-    val start: fun() = thread_start;
-    val wq: fun(usize, usize, usize, usize, usize, usize) = thread_wq_start;
-    syscall6(SYS_BSDTHREAD_REGISTER, start::usize, wq::usize, 64, 0, 0, 0);
+    if (atomic.cas(?wait_ready, ?expected, 1)) {
+        var i: usize = 0;
+        for (i < WAIT_BUCKETS) {
+            ls.pthread_mutex_init(?wait_mutexes[i * ls.PTHREAD_MUTEX_BYTES], nil);
+            ls.pthread_cond_init(?wait_conds[i * ls.PTHREAD_COND_BYTES], nil);
+            i = i + 1;
+        }
+        atomic.store(?wait_ready, 2);
+        ret;
+    }
+    for (atomic.load(?wait_ready) != 2) { atomic.spin_hint(); }
 }
 
-# create a new thread via bsdthread_create
+# pick a bucket for a futex address
 #
-# registers the thread start callback on first call, then creates a
-# thread that calls f(arg). the kernel passes f and the context pointer
-# through to the registered callback, which calls f(arg), sets *done_ptr
-# to 1, wakes waiters, and terminates the thread. arg travels in the
-# fourth context word alongside done_ptr and the stack bounds.
+# the low three bits are dead (the word is 8-byte aligned), so they are shifted
+# off before mixing rather than being allowed to collapse the table to a
+# fraction of its buckets.
+fun wait_bucket(addr: usize) usize {
+    var h: usize = addr >> 3;
+    h = h ^ (h >> 11);
+    ret h % WAIT_BUCKETS;
+}
+
+# the pthread start routine
+#
+# receives the caller's context block, whose five words are [fn, done, base,
+# size, user]. it runs on a stack pthread allocated, NOT on the context block,
+# which is why the block can be released here: nothing this function or the
+# user body touches lives in it once the five words have been copied out.
+# releasing it here rather than in `join` means a thread nobody joins still
+# reclaims its memory, which is the behaviour `bsdthread_terminate` gave.
+#
+# declared returning `usize` where C says `void *`: the value is discarded (the
+# thread is detached) and a 64-bit zero in the return register is the same
+# thing a `return NULL` puts there.
+# ---
+# arg: the context block address, as handed to pthread_create
+# ret: always 0, never read
+fun thread_entry(arg: ptr) usize {
+    val ctx: *usize = arg::usize::*usize;
+    val fn_addr:    usize = ctx[0];
+    val done_addr:  usize = ctx[1];
+    val stack_base: usize = ctx[2];
+    val stack_size: usize = ctx[3];
+    val user:       usize = ctx[4];
+
+    deallocate(stack_base::ptr, stack_size);
+
+    val fn_ptr: fun(*u8) = fn_addr::fun(*u8);
+    fn_ptr(user::*u8);
+
+    val done: *i64 = done_addr::*i64;
+    atomic.store(done, 1);
+    thread_wake(done);
+    ret 0;
+}
+
+# create a new thread via pthread_create
+#
+# the thread is created DETACHED. joining is done by `sync.thread.join`, which
+# waits on the completion flag rather than calling pthread_join, so a joinable
+# pthread would leave its descriptor unreaped forever. detaching hands that
+# cleanup to libpthread and keeps the flag as the single synchronisation point.
+#
+# note the error contract: pthread_* return the error number directly and do
+# NOT set errno, so these results are negated as they stand and `fail_errno`
+# is deliberately not used anywhere in this function.
 # ---
 # f:          entry function to execute in the new thread
 # arg:        opaque pointer passed through to f
 # done_ptr:   pointer to a completion flag (set to 1 when thread exits)
-# stack_base: base address of the pre-allocated stack region
-# stack_size: size of the stack in bytes
-# ret:        thread ID on success, or negative errno on failure
+# stack_base: base of a caller-allocated region used as the context block;
+#             released by the new thread, or by the caller if this call fails
+# stack_size: size of the stack pthread will allocate for the thread
+# ret:        thread handle on success, or negative errno on failure
 pub fun thread_spawn(f: fun(*u8), arg: *u8, done_ptr: *i64, stack_base: usize, stack_size: usize) i64 {
-    ensure_thread_registered();
     val ctx: *usize = stack_base::*usize;
-    ctx[0] = done_ptr::usize;
-    ctx[1] = stack_base;
-    ctx[2] = stack_size;
-    ctx[3] = arg::usize;
-    val stack_top: usize = stack_base + stack_size;
-    ret syscall5(SYS_BSDTHREAD_CREATE, f::usize, ctx::usize, stack_top, 0, 0);
+    ctx[0] = f::usize;
+    ctx[1] = done_ptr::usize;
+    ctx[2] = stack_base;
+    ctx[3] = stack_size;
+    ctx[4] = arg::usize;
+
+    var attr: [64]u8;
+    var rc: i32 = ls.pthread_attr_init(?attr[0]);
+    if (rc != 0) { ret -(rc::i64); }
+
+    rc = ls.pthread_attr_setstacksize(?attr[0], stack_size);
+    if (rc == 0) {
+        rc = ls.pthread_attr_setdetachstate(?attr[0], ls.PTHREAD_CREATE_DETACHED);
+    }
+
+    var tid: usize = 0;
+    if (rc == 0) {
+        val entry: fun(ptr) usize = thread_entry;
+        rc = ls.pthread_create(?tid, ?attr[0], entry::usize, stack_base::ptr);
+    }
+    ls.pthread_attr_destroy(?attr[0]);
+
+    if (rc != 0) { ret -(rc::i64); }
+
+    # a darwin user-space pointer never sets the top bit, so the handle is
+    # always positive and cannot be mistaken for the negative-errno failure
+    # this function's contract returns.
+    ret tid::i64;
 }
 
 # block until the value at addr changes from expected
 #
-# wraps __ulock_wait with UL_COMPARE_AND_WAIT64. returns immediately
-# if *addr does not equal expected. spurious wakeups are possible.
+# returns immediately if *addr does not equal expected. spurious wakeups are
+# possible and are expected: bucket sharing means a wake for a different
+# address can land here (see the bucket-table note above), so every caller must
+# re-test its own condition in a loop.
 # ---
 # addr:     pointer to the futex word
 # expected: value to compare against
 # ret:      0 on wake, or negative errno
 pub fun thread_wait(addr: *i64, expected: i64) i64 {
-    ret syscall4(SYS_ULOCK_WAIT, UL_COMPARE_AND_WAIT64, addr::usize, expected::usize, 0);
+    ensure_wait_tables();
+    val b: usize = wait_bucket(addr::usize);
+    val m: *u8 = ?wait_mutexes[b * ls.PTHREAD_MUTEX_BYTES];
+    val c: *u8 = ?wait_conds[b * ls.PTHREAD_COND_BYTES];
+
+    var rc: i32 = ls.pthread_mutex_lock(m);
+    if (rc != 0) { ret -(rc::i64); }
+
+    # the re-test happens under the bucket mutex, and pthread_cond_wait drops
+    # that mutex atomically. thread_wake cannot broadcast without holding it,
+    # so no wake fits between this load and the sleep.
+    var wr: i32 = 0;
+    if (atomic.load(addr) == expected) {
+        wr = ls.pthread_cond_wait(c, m);
+    }
+
+    val ur: i32 = ls.pthread_mutex_unlock(m);
+    if (wr != 0) { ret -(wr::i64); }
+    if (ur != 0) { ret -(ur::i64); }
+    ret 0;
 }
 
-# wake one thread blocked on a ulock wait at addr
+# wake threads blocked in thread_wait on addr
+#
+# broadcasts rather than signals: buckets are shared by address hash, so a
+# signal could be delivered to a waiter on an unrelated address and the wake
+# this call was meant to deliver would be lost.
 # ---
 # addr: pointer to the futex word
-# ret:  number of threads woken, or negative errno
+# ret:  0 on success, or negative errno
 pub fun thread_wake(addr: *i64) i64 {
-    ret syscall3(SYS_ULOCK_WAKE, UL_COMPARE_AND_WAIT64, addr::usize, 0);
+    ensure_wait_tables();
+    val b: usize = wait_bucket(addr::usize);
+    val m: *u8 = ?wait_mutexes[b * ls.PTHREAD_MUTEX_BYTES];
+    val c: *u8 = ?wait_conds[b * ls.PTHREAD_COND_BYTES];
+
+    var rc: i32 = ls.pthread_mutex_lock(m);
+    if (rc != 0) { ret -(rc::i64); }
+
+    val br: i32 = ls.pthread_cond_broadcast(c);
+    val ur: i32 = ls.pthread_mutex_unlock(m);
+    if (br != 0) { ret -(br::i64); }
+    if (ur != 0) { ret -(ur::i64); }
+    ret 0;
+}
+
+# pthread migration tests
+#
+# the OS-layer thread primitives, asserted for effect. `std.sync.thread` covers
+# the portable API on top of these; what is tested here is what is specific to
+# the darwin implementation and could be wrong without the portable tests
+# noticing - the opaque object sizes, the release of the context block, and the
+# bucket sharing in the address-keyed wait.
+
+val TEST_REGION: usize = 2097152;
+
+rec TestThread {
+    done: i64;
+    base: usize;
+}
+
+fun tt_spawn(f: fun(*u8), arg: *u8, t: *TestThread) i64 {
+    t.done = 0;
+    t.base = 0;
+    val base: usize = allocate(TEST_REGION)::usize;
+    if (base == 0) { ret -1; }
+    t.base = base;
+    val r: i64 = thread_spawn(f, arg, ?t.done, base, TEST_REGION);
+    if (r < 0) {
+        deallocate(base::ptr, TEST_REGION);
+        t.base = 0;
+    }
+    ret r;
+}
+
+fun tt_join(t: *TestThread) {
+    for (atomic.load(?t.done) == 0) {
+        thread_wait(?t.done, 0);
+    }
+}
+
+var tw_flag: i64 = 0;
+
+fun tw_setter(arg: *u8) {
+    atomic.store(?tw_flag, 7);
+}
+
+fun tw_add100(arg: *u8) {
+    val slot: *i64 = arg::*i64;
+    atomic.store(slot, atomic.load(slot) + 100);
+}
+
+# PTHREAD_MUTEX_BYTES is big enough for what pthread_mutex_init writes
+#
+# this asserts the SIZE, not the constant. an under-sized figure would let
+# pthread scribble past the object into whatever follows it in the bucket
+# table, so the check is that a guard region behind a real, initialized,
+# locked and unlocked mutex is still untouched.
+test "std.system.os.darwin.libsystem:pthread_mutex_fits_its_declared_size" {
+    var slab: [192]u8;
+    var i: usize = 0;
+    for (i < 192) { slab[i] = 0xC7; i = i + 1; }
+
+    if (ls.pthread_mutex_init(?slab[0], nil) != 0) { ret 1; }
+    if (ls.pthread_mutex_lock(?slab[0]) != 0)      { ret 1; }
+    if (ls.pthread_mutex_unlock(?slab[0]) != 0)    { ret 1; }
+
+    i = ls.PTHREAD_MUTEX_BYTES;
+    for (i < 192) {
+        if (slab[i] != 0xC7) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# PTHREAD_COND_BYTES is big enough for what pthread_cond_init writes
+test "std.system.os.darwin.libsystem:pthread_cond_fits_its_declared_size" {
+    var slab: [192]u8;
+    var i: usize = 0;
+    for (i < 192) { slab[i] = 0xD3; i = i + 1; }
+
+    if (ls.pthread_cond_init(?slab[0], nil) != 0)      { ret 1; }
+    if (ls.pthread_cond_broadcast(?slab[0]) != 0)      { ret 1; }
+
+    i = ls.PTHREAD_COND_BYTES;
+    for (i < 192) {
+        if (slab[i] != 0xD3) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a spawned thread runs its body, and the waiter is released by its wake
+test "std.system.os.darwin.libsystem:thread_spawn_runs_body_and_wakes_waiter" {
+    atomic.store(?tw_flag, 0);
+    var t: TestThread;
+    if (tt_spawn(tw_setter, nil, ?t) < 0) { ret 1; }
+    tt_join(?t);
+    if (atomic.load(?tw_flag) != 7) { ret 1; }
+    ret 0;
+}
+
+# the context block is released by the thread, not leaked
+#
+# `thread_entry` frees the caller's region before it runs the body, so by the
+# time the completion flag is set the region is already unmapped. mprotect over
+# an unmapped range fails, which is the observable. nothing allocates between
+# the join and the probe, so the range cannot have been handed to something
+# else in the meantime.
+test "std.system.os.darwin.libsystem:thread_releases_its_context_block" {
+    atomic.store(?tw_flag, 0);
+    var t: TestThread;
+    if (tt_spawn(tw_setter, nil, ?t) < 0) { ret 1; }
+    val base: usize = t.base;
+    tt_join(?t);
+    if (atomic.load(?tw_flag) != 7) { ret 1; }
+
+    if (protect(base::ptr, TEST_REGION, PROT_READ::u32) >= 0) { ret 1; }
+    ret 0;
+}
+
+# each thread gets its own userdata pointer and every one of them runs
+test "std.system.os.darwin.libsystem:threads_receive_distinct_userdata" {
+    var slots: [4]i64;
+    var ts:    [4]TestThread;
+    var i: usize = 0;
+    for (i < 4) { slots[i] = i::i64; i = i + 1; }
+
+    i = 0;
+    for (i < 4) {
+        if (tt_spawn(tw_add100, (?slots[i])::*u8, ?ts[i]) < 0) { ret 1; }
+        i = i + 1;
+    }
+
+    i = 0;
+    for (i < 4) { tt_join(?ts[i]); i = i + 1; }
+
+    i = 0;
+    for (i < 4) {
+        if (slots[i] != (i::i64) + 100) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# thread_wait does not block when the word already differs from `expected`
+#
+# the guard that keeps `join` from sleeping on an already-finished thread. a
+# wait that ignored the comparison would hang here rather than fail.
+test "std.system.os.darwin.libsystem:thread_wait_returns_when_value_differs" {
+    var word: i64 = 5;
+    if (thread_wait(?word, 0) != 0) { ret 1; }
+    if (word != 5) { ret 1; }
+    ret 0;
+}
+
+# two waiters whose words share a bucket are both delivered
+#
+# the buckets are a hash table over addresses, so distinct words collide. this
+# builds a genuine collision rather than assuming one, and drives both to
+# completion. a `signal` in thread_wake instead of a `broadcast` can hand the
+# single wakeup to the wrong waiter here and stall.
+test "std.system.os.darwin.libsystem:colliding_wait_addresses_are_both_woken" {
+    var slots: [256]i64;
+    var i: usize = 0;
+    for (i < 256) { slots[i] = 0; i = i + 1; }
+
+    # find two distinct words that hash to the same bucket
+    var a: usize = 0;
+    var b: usize = 0;
+    var found: bool = false;
+    i = 0;
+    for (i < 256 && !found) {
+        var j: usize = i + 1;
+        for (j < 256 && !found) {
+            if (wait_bucket((?slots[i])::usize) == wait_bucket((?slots[j])::usize)) {
+                a = i; b = j; found = true;
+            }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    if (!found) { ret 1; }
+
+    var ta: TestThread;
+    var tb: TestThread;
+    if (tt_spawn(tw_add100, (?slots[a])::*u8, ?ta) < 0) { ret 1; }
+    if (tt_spawn(tw_add100, (?slots[b])::*u8, ?tb) < 0) { ret 1; }
+
+    tt_join(?ta);
+    tt_join(?tb);
+
+    if (slots[a] != 100) { ret 1; }
+    if (slots[b] != 100) { ret 1; }
+    ret 0;
 }
 
 # sockets

--- a/test/darwin/known-failures.txt
+++ b/test/darwin/known-failures.txt
@@ -14,14 +14,17 @@
 #                     time. macOS has exported clock_gettime(3) from libSystem
 #                     since 10.12.
 #   process.exec   -- fork / execve / wait4 through raw traps.
-#   sync.thread    -- bsdthread_create + bsdthread_register, the private
-#                     kernel<->libpthread handshake #415 calls out by name as
-#                     the most fragile thing on the least stable surface.
 #
 # the verify script fails the build on any failure NOT listed here, and equally
 # on any listed test that starts PASSING. so this cannot silently rot: fixing
 # one forces its removal, and regressing a new one is caught. the list must
 # reach empty as the rest of #415 lands, and it is the checklist for doing so.
+#
+# ## removed so far
+#
+# sync.thread (3) -- bsdthread_create + bsdthread_register, the private
+#   kernel<->libpthread handshake #415 named as the most fragile thing on the
+#   least stable surface. migrated to pthread_create; all three now pass.
 
 time: now returns non-zero
 time: since returns positive for past time
@@ -31,6 +34,3 @@ std.process.exec.run:failure_exits_one
 std.process.exec.spawn:wait_matches_run
 std.process.exec.run:repeated_spawns_stay_correct
 std.process.exec.wait_any:reaps_each_child_once
-thread: spawn and join
-thread: is_done after join
-thread: spawn_with delivers distinct userdata


### PR DESCRIPTION
Refs #415. Second of several, and the one that had to come first among the remaining domains.

## Why threads before time and process

libSystem reaches errno through `__error()`, a thread-local resolved against the pthread structure libpthread installs for a thread **it** created. A raw `bsdthread_create` thread never had one, because the start routine never performed libpthread's own `_pthread_set_self` handshake. Everything already migrated in #462 therefore carried an unvalidated errno path the moment it ran off the main thread — and errno is the riskiest part of this whole migration, because the syscall contract and the libSystem contract genuinely differ.

`pthread_create` makes every thread a real pthread and the question stops existing. It is validated once, up front, instead of being inherited by every subsequent domain.

It is also simply broken today: `bsdthread_register` publishes a workqueue callback the kernel invokes, versioned against the libpthread that shipped with the OS — an internal protocol we were impersonating, not an ABI. All three `std.sync.thread` tests were failing on darwin before this change.

**`_pthread_set_self` turned out not to be needed at all**, so there was no private-API wall to stop at: using `pthread_create` means libpthread does that setup itself, which is the entire point.

## The sharp edge: pthread does not use errno

Every other libSystem entry point returns `-1` and leaves the reason in errno. **The pthread family returns the error number directly and leaves errno untouched.** So the shape used everywhere else in this module —

```mach
if (rc < 0) { ret ls.fail_errno(); }
```

— is wrong *twice over* for a pthread call: `rc` is never negative so the branch never fires and a failure returns as success, and if it did fire it would report whatever unrelated errno was lying around. The pthread wrappers negate `rc` itself and never call `fail_errno`. This is called out at the top of the threads section in `libsystem.mach`, since it is the one place in the file where the house rule is inverted.

## What moved, and what did not

The OS-layer contract is **unchanged**: `thread_spawn` still takes a caller-allocated region and a completion flag; `thread_wait`/`thread_wake` are still address-keyed. Linux and windows are untouched.

What moved is **stack ownership**. The caller's region is now a context block only and pthread owns the real stack — which is exactly how the windows backend has always used it. The block is released by the new thread itself, so an unjoined thread still reclaims it, matching what `bsdthread_terminate` did. Threads are created **detached**, because `join` waits on the completion flag rather than calling `pthread_join`, and a joinable pthread would leave its descriptor unreaped forever.

## The address-keyed wait

darwin's futex equivalent `__ulock_wait` is as private as the bsdthread traps. The public replacement `os_sync_wait_on_address` is macOS 14.4+ and adopting it would quietly raise this library's deployment floor, so I did not.

Instead the wait is built from pthread condition variables in a fixed table hashed by address. Buckets are **genuinely shared**, and the consequences are handled rather than hoped away:

- **`thread_wake` broadcasts, it does not signal.** With a shared bucket, a signal could hand the one wakeup to a waiter on an unrelated address and lose ours.
- **The lost-wakeup race is closed by lock discipline, not by luck.** The waiter re-reads the address *under* the bucket mutex, `pthread_cond_wait` releases that mutex atomically, and `thread_wake` must acquire the same mutex before it can broadcast — so no wake fits between the waiter's test and its sleep.
- Spurious wakeups are therefore real and expected. The contract already documented them and the only consumer re-tests in a loop, which a condition variable requires anyway.

## Tests

Seven new tests at the OS layer, covering what is darwin-specific and could be wrong without the portable `std.sync.thread` tests noticing:

- **Object sizes are asserted, not declared.** `PTHREAD_MUTEX_BYTES` / `PTHREAD_COND_BYTES` are checked by initializing, locking and unlocking a *real* mutex inside a guard-filled slab and verifying the guard bytes past the declared size are untouched. An undersized constant would scribble into the neighbouring bucket; asserting the constant against itself would prove nothing.
- **The context block is actually released.** `thread_entry` frees the caller's region before running the body, so after the join `mprotect` over that range must fail. Nothing allocates between the join and the probe.
- Spawn runs the body and the wake releases the waiter.
- Each thread receives its own userdata pointer and all four run.
- `thread_wait` returns rather than blocking when the word already differs — the guard that stops `join` sleeping on a finished thread.
- **A real bucket collision is constructed, not assumed**, by scanning for two words that hash to the same bucket, then driving both to completion. A `signal` instead of a `broadcast` can stall here.

## Deletions

Both hand-written `asm` trampolines — including the x86_64 stack-realignment fixup that existed only because the kernel *jumped* to the registered entry instead of calling it — plus the workqueue callback, the registration handshake, and six `SYS_*` constants.

## Known-failures list shrinks

`test/darwin/known-failures.txt` drops from 11 to 8: the three `sync.thread` entries are removed. The gate fails if a listed test starts passing, so this removal is forced rather than optional — which is the property that keeps the list shrinking.

## Verified by execution

Both macOS runners, green:

- `std.sync.thread` **1 ok / 3 FAIL → 4 ok** on both rows.
- `std.system.os.darwin.shared` 14 → **21 ok**.
- Suite totals 789/11/800 → **799 passed / 8 failed / 807**.
- Gate reports `no new darwin failures; 8 known pre-existing failures still outstanding`.
- All 11 pthread symbols bind from the single `/usr/lib/libSystem.B.dylib` (checked in the bind table of both cross-built images).
- No `bsdthread_*` or `__ulock_*` trap remains anywhere in the source. Verified by grep, not by inspecting the images: those were inline `svc`/`syscall` instructions rather than dynamic imports, so a bind-table check would have said nothing either way. Raw traps *do* still exist in the darwin backend — 18 sites, all in the domains this PR does not touch (time, process, sockets, memory, `read_dir`).
- linux, arm64-linux, riscv64: 788/0 — unchanged.
