### PR TITLE
feat(os/darwin): read the clocks and sleep through libSystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### darwin: the clocks and `sleep` go through libSystem (#415)
+
+**darwin has no `clock_gettime` trap at all.** The backend called syscall 427 and read the result as a time; whatever that number is on current macOS, it is not one — `now()` came back *below the unix epoch*. The three `std.chrono.time` tests had been failing for as long as nothing was running them. `clock_gettime(3)` is public, has shipped since macOS 10.12, and is implemented in userspace over `mach_absolute_time()` and the commpage rather than as a trap, which is why hunting for a syscall number was never going to work. 10.12 is older than any macOS running on hardware these targets support, so this moves no deployment floor — unlike `os_sync_wait_on_address`, which is why the thread layer went a different way.
+
+The `CLOCK_REALTIME` / `CLOCK_MONOTONIC` constants needed no change: they were always written against darwin's own `<time.h>` values, even while the call underneath did not exist.
+
+**`sleep` moves to `nanosleep(3)`.** The note it carried — "darwin has no nanosleep syscall" — was true of the trap table and false of libSystem, so it went through `select` with a `timeval` timeout and lost sub-microsecond resolution on the way. It now also handles `EINTR` by resuming with the *remaining* time, so an interrupted sleep ends at about the requested moment instead of stretching towards double it. `rec timeval` and three more `SYS_*` constants go with it.
+
+**A broken clock is not a clock that errors — it is one that returns a plausible-looking number**, so none of the seven new tests checks a return code. Each pins the clock against something independent: the epoch against a timestamp the *filesystem* just wrote (same kernel clock, completely different path), the unit against a measured 50ms sleep (which is what catches microseconds, milliseconds, or raw mach ticks), and `tv_nsec` against its documented range. Monotonicity is checked across 200 reads, and an unknown clock id is provoked for `EINVAL`.
+
+
+
 #### darwin: threads are pthreads, not bsdthreads (#415)
 
 `bsdthread_create` / `bsdthread_register` was never an ABI. `bsdthread_register` publishes a workqueue callback the kernel invokes, versioned against the libpthread that shipped with the OS — an internal kernel↔libpthread protocol this backend was impersonating. It is what #415 singles out as the most fragile code on the least stable part of the surface, and on current macOS it does not work: all three `std.sync.thread` tests were failing before this change, and had been failing unnoticed because nothing had ever run this suite on darwin.

--- a/src/system/os/darwin/libsystem.mach
+++ b/src/system/os/darwin/libsystem.mach
@@ -177,6 +177,40 @@ pub ext fun getcwd(buf: *u8, size: usize) *u8;
 #[library("libSystem")]
 pub ext fun pipe(fds: *i32) i32;
 
+# time
+#
+# darwin has no `clock_gettime` BSD trap at all. the backend used to call
+# syscall 427 and read the result as a time; whatever that number is on current
+# macOS, it is not one - `now()` came back BELOW the unix epoch, and the three
+# `std.chrono.time` tests had been failing on darwin for as long as nothing was
+# running them.
+#
+# `clock_gettime(3)` is real, public, and has shipped since macOS 10.12; it is
+# implemented in userspace over `mach_absolute_time()` and the commpage rather
+# than as a trap, which is exactly why looking for a syscall number for it was
+# never going to work. 10.12 is older than any macOS that runs on hardware
+# these targets support, so binding it moves no floor - unlike
+# `os_sync_wait_on_address`, which is why the thread layer went a different way.
+#
+# `timespec` here is the same layout `shared.mach` declares; it is taken as
+# `*u8` only to keep this module free of a dependency back on that one.
+#[library("libSystem")]
+pub ext fun clock_gettime(clock_id: i32, ts: *u8) i32;
+
+# suspend the calling thread for the requested interval
+#
+# the old backend said "darwin has no nanosleep syscall" and reached for
+# `select` with a timeout instead. that is true of the TRAP table and false of
+# libSystem, which exports nanosleep(3). taking it also gets the remaining-time
+# argument, so an interrupted sleep can resume for what is left rather than
+# returning early or restarting the full interval.
+# ---
+# req: requested interval
+# rem: filled with the unslept remainder when interrupted; may be nil
+# ret: 0, or -1 with errno set (EINTR when a signal cut the sleep short)
+#[library("libSystem")]
+pub ext fun nanosleep(req: *u8, rem: *u8) i32;
+
 # threads
 #
 # ## pthread does NOT use errno, and that is the trap in this section

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -37,9 +37,6 @@ val SYS_MUNLOCK:          usize = 204;
 val SYS_EXECVE:           usize = 59;
 val SYS_VFORK:            usize = 66;
 val SYS_GETDIRENTRIES64:  usize = 344;
-val SYS_SELECT:           usize = 93;
-val SYS_GETTIMEOFDAY:     usize = 116;
-val SYS_CLOCK_GETTIME:    usize = 427;
 val SYS_GETPID:           usize = 20;
 val SYS_KILL:             usize = 37;
 val SYS___SYSCTL:         usize = 202;
@@ -119,13 +116,6 @@ pub rec stat_t {
     _reserved0:        i32;
     _reserved1:        i64;
     _reserved2:        i64;
-}
-
-# gettimeofday result
-rec timeval {
-    tv_sec:  i64;
-    tv_usec: i32;
-    _pad:    i32;
 }
 
 # time specification with seconds and nanoseconds
@@ -1070,21 +1060,34 @@ pub fun getpid() i64 {
 
 # suspend execution for the given number of nanoseconds
 #
-# darwin has no nanosleep syscall; uses select with a timeval timeout.
+# uses nanosleep(3). the previous note here - "darwin has no nanosleep
+# syscall" - was true of the trap table and false of libSystem, so this went
+# through `select` with a timeout and lost the sub-microsecond resolution to
+# `timeval` on the way.
+#
+# a signal that cuts the sleep short leaves the unslept remainder in `rem`, and
+# the retry resumes with THAT rather than restarting the full interval, so an
+# interrupted sleep still ends at about the requested time instead of
+# stretching towards double it.
 # ---
 # nsec: nanoseconds to sleep
 pub fun sleep(nsec: i64) {
     if (nsec <= 0) { ret; }
-    var sec: i64 = nsec / 1000000000;
-    var usec: i64 = (nsec % 1000000000 + 999) / 1000;
-    if (usec >= 1000000) {
-        sec = sec + 1;
-        usec = usec - 1000000;
+    var req: timespec;
+    req.tv_sec  = nsec / 1000000000;
+    req.tv_nsec = nsec % 1000000000;
+
+    var rem: timespec;
+    rem.tv_sec  = 0;
+    rem.tv_nsec = 0;
+
+    var retries: usize = 0;
+    for (retries < EINTR_MAX_RETRIES) {
+        if (ls.nanosleep((?req)::usize::*u8, (?rem)::usize::*u8) == 0) { ret; }
+        if (ls.fail_errno() != EINTR) { ret; }
+        req = rem;
+        retries = retries + 1;
     }
-    var tv: timeval;
-    tv.tv_sec = sec;
-    tv.tv_usec = usec::i32;
-    syscall5(SYS_SELECT, 0, 0, 0, 0, (?tv)::usize);
 }
 
 # the number of CPUs available to this process
@@ -2103,14 +2106,169 @@ pub fun random_fill(buf: *u8, len: usize) i64 {
 # time
 
 # read a clock into a timespec
-# uses the kernel clock_gettime syscall (available since macOS 10.12).
-# CLOCK_MONOTONIC returns true monotonic time via the kernel's nanouptime.
+#
+# CLOCK_REALTIME (0) and CLOCK_MONOTONIC (6) are darwin's own `clockid_t`
+# values from <time.h>, not linux's - they happen to have been correct already,
+# because the constants were always written against darwin's header even while
+# the call underneath was a trap that does not exist.
 # ---
 # clock_id: CLOCK_REALTIME or CLOCK_MONOTONIC
 # ts:       output timespec
 # ret:      0 on success, or negative errno
 pub fun clock_gettime(clock_id: i32, ts: *timespec) i64 {
-    ret syscall2(SYS_CLOCK_GETTIME, clock_id::u32::usize, ts::usize);
+    if (ls.clock_gettime(clock_id, ts::usize::*u8) < 0) { ret ls.fail_errno(); }
+    ret 0;
+}
+
+# clock migration tests
+#
+# a broken clock is not a clock that errors - it is a clock that returns a
+# plausible-looking number. the old backend's `clock_gettime` returned 0
+# happily and produced a time below the unix epoch. so none of these check a
+# return code: each one pins the clock against something independent.
+#
+#   epoch  -- compared against a timestamp the FILESYSTEM wrote, which comes
+#             from the same kernel wall clock by a completely different path
+#   unit   -- compared against a measured sleep, which is what catches a clock
+#             reporting microseconds, milliseconds, or raw mach ticks
+#   field  -- tv_nsec held to its documented range, which a tick count spilled
+#             into the struct would violate
+
+# both clocks report nanoseconds in tv_nsec, not some other unit
+#
+# a tick count or a microsecond value dropped into this field lands outside
+# [0, 1e9) almost immediately, so this is a cheap unit check independent of
+# how long anything takes.
+test "std.system.os.darwin.libsystem:clock_tv_nsec_is_within_one_second" {
+    var rt: timespec;
+    if (clock_gettime(CLOCK_REALTIME, ?rt) != 0) { ret 1; }
+    if (rt.tv_nsec < 0 || rt.tv_nsec >= 1000000000) { ret 1; }
+
+    var mt: timespec;
+    if (clock_gettime(CLOCK_MONOTONIC, ?mt) != 0) { ret 1; }
+    if (mt.tv_nsec < 0 || mt.tv_nsec >= 1000000000) { ret 1; }
+    ret 0;
+}
+
+# CLOCK_REALTIME agrees with the timestamp the filesystem just wrote
+#
+# the strongest reference available without a network: create a file, read its
+# mtime back through fstat, and require the wall clock to agree. both numbers
+# come from the same kernel clock by entirely different routes, so an epoch
+# error, a unit error, or a stuck clock all break the comparison. the old
+# implementation - which returned a time below 1970 - fails this outright.
+test "std.system.os.darwin.libsystem:realtime_agrees_with_a_filesystem_timestamp" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'k'::u8);
+    unlink(AT_FDCWD, ?path[0], 0);
+
+    val fd: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_RDWR, 0o600);
+    if (fd < 0) { ret 1; }
+
+    var st: stat_t;
+    val sr: i64 = stat(fd::i32, ?st);
+    close(fd::i32);
+    unlink(AT_FDCWD, ?path[0], 0);
+    if (sr != 0) { ret 1; }
+
+    var now: timespec;
+    if (clock_gettime(CLOCK_REALTIME, ?now) != 0) { ret 1; }
+
+    var delta: i64 = now.tv_sec - st.st_mtime;
+    if (delta < 0) { delta = -delta; }
+    # generous enough never to flake on a loaded runner, tight enough that a
+    # wrong epoch or unit cannot slip through
+    if (delta > 60) { ret 1; }
+    ret 0;
+}
+
+# the wall clock sits in a plausible span of years
+#
+# guards the direction the filesystem comparison cannot: if BOTH the clock and
+# the filesystem were wrong in the same way the check above would still pass.
+# the lower bound is a date already in the past when this was written.
+test "std.system.os.darwin.libsystem:realtime_is_a_plausible_wall_clock" {
+    var ts: timespec;
+    if (clock_gettime(CLOCK_REALTIME, ?ts) != 0) { ret 1; }
+    # 2023-01-01 .. 2100-01-01
+    if (ts.tv_sec < 1672531200) { ret 1; }
+    if (ts.tv_sec > 4102444800) { ret 1; }
+    ret 0;
+}
+
+# the monotonic clock advances by about the interval we actually slept
+#
+# this is the unit check with teeth. sleep for 50ms and require the clock to
+# report an advance in the same ballpark: a clock counting microseconds would
+# report ~50, a clock counting mach ticks something wildly larger, and a stuck
+# clock zero. it also proves `sleep` itself works, which the old select-based
+# implementation could not be assumed to.
+test "std.system.os.darwin.libsystem:monotonic_advances_by_the_interval_slept" {
+    var before: timespec;
+    if (clock_gettime(CLOCK_MONOTONIC, ?before) != 0) { ret 1; }
+
+    sleep(50000000);
+
+    var after: timespec;
+    if (clock_gettime(CLOCK_MONOTONIC, ?after) != 0) { ret 1; }
+
+    val elapsed: i64 = (after.tv_sec - before.tv_sec) * 1000000000
+                     + (after.tv_nsec - before.tv_nsec);
+
+    # at least the interval requested, and not so much more that the units
+    # could be wrong; a heavily loaded runner still lands far inside 5s
+    if (elapsed < 40000000)   { ret 1; }
+    if (elapsed > 5000000000) { ret 1; }
+    ret 0;
+}
+
+# the wall clock advances across a sleep too, at the same rate
+#
+# a realtime clock that is merely a constant would satisfy the epoch checks
+# above forever. this requires it to actually move, and to move by roughly what
+# the monotonic clock says elapsed.
+test "std.system.os.darwin.libsystem:realtime_advances_across_a_sleep" {
+    var before: timespec;
+    if (clock_gettime(CLOCK_REALTIME, ?before) != 0) { ret 1; }
+
+    sleep(50000000);
+
+    var after: timespec;
+    if (clock_gettime(CLOCK_REALTIME, ?after) != 0) { ret 1; }
+
+    val elapsed: i64 = (after.tv_sec - before.tv_sec) * 1000000000
+                     + (after.tv_nsec - before.tv_nsec);
+    if (elapsed < 40000000)   { ret 1; }
+    if (elapsed > 5000000000) { ret 1; }
+    ret 0;
+}
+
+# the monotonic clock never runs backwards across repeated reads
+test "std.system.os.darwin.libsystem:monotonic_never_decreases" {
+    var prev: timespec;
+    if (clock_gettime(CLOCK_MONOTONIC, ?prev) != 0) { ret 1; }
+
+    var i: usize = 0;
+    for (i < 200) {
+        var cur: timespec;
+        if (clock_gettime(CLOCK_MONOTONIC, ?cur) != 0) { ret 1; }
+        if (cur.tv_sec < prev.tv_sec) { ret 1; }
+        if (cur.tv_sec == prev.tv_sec && cur.tv_nsec < prev.tv_nsec) { ret 1; }
+        prev = cur;
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# an unknown clock id is refused with EINVAL, not answered with a wrong number
+#
+# the error path, provoked rather than assumed. this also confirms the wrapper
+# reads errno at all: the old trap-based version reported failure through a
+# different channel entirely.
+test "std.system.os.darwin.libsystem:unknown_clock_id_is_einval" {
+    var ts: timespec;
+    if (clock_gettime(9999, ?ts) != EINVAL) { ret 1; }
+    ret 0;
 }
 
 # errno

--- a/test/darwin/known-failures.txt
+++ b/test/darwin/known-failures.txt
@@ -9,10 +9,6 @@
 # every one of them is in a subsystem still issuing raw BSD traps, which is the
 # thesis of #415 stated as a test result:
 #
-#   chrono.time    -- clock_gettime through syscall 427. `now()` comes back
-#                     below the epoch, so the number the trap returns is not a
-#                     time. macOS has exported clock_gettime(3) from libSystem
-#                     since 10.12.
 #   process.exec   -- fork / execve / wait4 through raw traps.
 #
 # the verify script fails the build on any failure NOT listed here, and equally
@@ -25,10 +21,12 @@
 # sync.thread (3) -- bsdthread_create + bsdthread_register, the private
 #   kernel<->libpthread handshake #415 named as the most fragile thing on the
 #   least stable surface. migrated to pthread_create; all three now pass.
+#
+# chrono.time (3) -- darwin has no clock_gettime trap at all, so syscall 427
+#   was never going to be one; the backend read whatever it returned as a time
+#   and produced a value below the unix epoch. migrated to clock_gettime(3),
+#   which macOS has exported since 10.12. all three now pass.
 
-time: now returns non-zero
-time: since returns positive for past time
-time: monotonic returns non-zero
 std.process.exec.run:success_exits_zero
 std.process.exec.run:failure_exits_one
 std.process.exec.spawn:wait_matches_run


### PR DESCRIPTION
Refs #415. Third of several. Cheap in code, but the finding underneath is sharper than "port a call".

## darwin has no `clock_gettime` trap at all

Not "the number was wrong" — **there is no such BSD syscall on darwin.** `clock_gettime(3)` is implemented in userspace over `mach_absolute_time()` and the commpage, so hunting for a syscall number for it was never going to work. Syscall 427 is something else entirely; the backend called it and read the result as a time, which is how `now()` ended up returning a value *below the unix epoch*.

I have deliberately **not** claimed in the source what syscall 427 actually is. I could not verify that from here, and the fix does not depend on it. What is stated is what I observed and what is documented: darwin has no such trap, and the public call has shipped since macOS 10.12.

**This moves no deployment floor.** 10.12 is older than any macOS running on hardware these targets support — unlike `os_sync_wait_on_address` (14.4+), which is exactly why the thread layer in #464 went a different way. Worth contrasting the two decisions rather than treating "it's public API" as automatically fine.

The `CLOCK_REALTIME` / `CLOCK_MONOTONIC` constants needed **no change**: they were always written against darwin's own `<time.h>` values, even while the call underneath did not exist. So the bug was never in the constants.

## `sleep` came along, and it had to

`sleep` was `select` with a `timeval` timeout, carrying the note *"darwin has no nanosleep syscall"* — true of the trap table, false of libSystem, which exports `nanosleep(3)`.

I pulled it in for two reasons beyond it being the same domain. First, my unit assertions **measure a sleep**, so leaving `sleep` on an unverified raw syscall (93) would have made those tests untrustworthy. Second, it was silently lossy: `timeval` is microsecond-resolution, so every sub-microsecond sleep was being rounded. It now also handles `EINTR` by resuming with the *remaining* time rather than restarting, so an interrupted sleep ends near the requested moment instead of stretching towards double it.

## Tests: pinned to references, not return codes

A broken clock does not error — it returns a plausible-looking number, which is precisely what survives a return-code check. So none of the seven new tests looks at a return code as its assertion. Each pins the clock to something independent:

- **Epoch** — create a file, read its `mtime` back through `fstat`, require the wall clock to agree within 60s. Both numbers come from the same kernel clock by completely different routes, so an epoch error, a unit error, or a stuck clock all break it. **The old implementation fails this outright.**
- **Plausible span** — `tv_sec` inside 2023–2100, which guards the direction the filesystem comparison cannot (both being wrong the same way).
- **Unit** — sleep 50ms and require the monotonic clock to report an advance in the same ballpark. A clock counting microseconds reports ~50, one counting mach ticks something wildly larger, a stuck one zero. Bounds are wide enough not to flake on a loaded runner and tight enough that a wrong unit cannot pass.
- **Realtime moves too** — the same sleep measured on `CLOCK_REALTIME`, since a constant would satisfy the epoch checks forever.
- **`tv_nsec` range** — held to `[0, 1e9)` on both clocks; a tick count spilled into the field violates this immediately.
- **Monotonicity** — 200 consecutive reads, never decreasing.
- **Error path provoked** — an unknown clock id must be `EINVAL` specifically, which also confirms the wrapper reads errno at all (the trap version reported failure through an entirely different channel).

## Known-failures list: 8 → 5

The three `chrono.time` entries are removed. As before this was forced, not optional — the gate fails on a listed test that starts passing. Only the five `process.exec` entries remain, which is next.

## Deletions

`rec timeval`, and `SYS_SELECT` / `SYS_GETTIMEOFDAY` / `SYS_CLOCK_GETTIME`.

## Verified by execution

Both macOS runners, green:

- `std.chrono.time` **14 ok / 3 FAIL -> 17 ok** on both rows.
- `std.system.os.darwin.shared` 21 -> **28 ok** (7 new).
- Suite totals 799/8/807 -> **809 passed / 5 failed / 814**.
- Gate reports `no new darwin failures; 5 known pre-existing failures still outstanding`.
- linux, arm64-linux, riscv64: 788/0 - unchanged.

Everything asserted about darwin behaviour rests on that lane; I have no darwin machine. What I ran locally was the cross-build for both arches and the linux suite.
