### PR TITLE
chore(release): 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.26.0] - 2026-08-08
 
 ### Changed
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.25.1"
+version = "0.26.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 


### PR DESCRIPTION
Cuts 0.26.0. Minor rather than patch: this moves three darwin subsystems off the trap table and onto libSystem, which is behaviour change rather than repair alone.

## Why now

**mach's 4.17.0 release gate is blocked on this.** mach's darwin lane fails two new readout tests because every duration in the tree reads zero, and the cause is here: `SYS_CLOCK_GETTIME = 427` names a syscall XNU does not have at any number (427 is `fsgetpath`), so both clocks have returned zero since `f19a4ce` on 2026-03-11 — which replaced a working `gettimeofday` implementation with a nonexistent trap.

It went unseen for five months because nothing read a duration back and asserted on it. mach's #2826 added the first tests that do, and darwin only runs on an integration PR, so this is the first time the two met.

## What is in it

- **#465** — the clocks and `sleep` through libSystem. `clock_gettime(3)` is public, has shipped since macOS 10.12, and is implemented in userspace over `mach_absolute_time()` and the commpage, which is why hunting a trap number was never going to work. `sleep` moves to `nanosleep(3)` and now resumes with the *remaining* time on `EINTR` rather than stretching towards double the request.
- **#464** — threads created with `pthread_create` rather than `bsdthread`.
- **#462** — the filesystem layer through libSystem, which is what `libsystem.mach` was added for and what #465 depends on.
- **#460** — CI seeds from the latest published mach release.

All darwin lanes are green on both arches, verified on the PRs rather than inferred: `std.chrono.time` passes natively on darwin aarch64 and x86_64.

## The part worth keeping

From #465's entry, and it generalises past darwin: **a broken clock is not one that errors, it is one that returns a plausible-looking number.** None of the seven new tests checks a return code. Each pins the clock against something independent — the epoch against a timestamp the filesystem just wrote (same kernel clock, entirely different path), the unit against a measured 50 ms sleep (which is what catches microseconds, milliseconds, or raw mach ticks), monotonicity across 200 reads.

That is the same shape as the defect it fixes: the old code did not fail, it succeeded with a number below the unix epoch.