### PR TITLE
mach-std 0.26.0

### DIFF
--- a/.github/actions/seed-mach/action.yml
+++ b/.github/actions/seed-mach/action.yml
@@ -1,0 +1,93 @@
+name: seed mach
+description: put the released mach compiler for this runner's host on PATH
+
+# every lane builds this library with a RELEASED mach, so which release that is decides
+# what the whole suite was compiled by. it resolves through
+# repos/briar-systems/mach/releases/latest, which serves the newest *published* release
+# and never a draft or a prerelease. an untagged `gh release download` instead takes
+# whatever release the client considers newest, so a draft holding one hand-uploaded
+# archive silently became the seed and broke every lane whose host archive it did not
+# carry (briar-systems/mach#2573, and briar-systems/mach-std#457 for this repo).
+#
+# the failure this prevents is not a broken build, which is loud. it is a GREEN suite
+# compiled by a compiler nobody chose. resolution lives here, once, so no call site can
+# reintroduce it.
+#
+# NOTE the repository is hardcoded rather than read from $GITHUB_REPOSITORY: the seed
+# comes from mach, and this is mach-std. mach's own copy of this action resolves its own
+# repository, and that difference is the whole reason this is a separate file.
+
+inputs:
+  token:
+    description: token used to read the release
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  tag:
+    description: tag of the release the seed came from
+    value: ${{ steps.resolve.outputs.tag }}
+
+runs:
+  using: composite
+  steps:
+    # the seed has to EXEC on the runner, whatever it is later asked to build for, so
+    # each lane takes its own host's archive. the name is derived from the resolved tag
+    # rather than written per job, so it cannot drift from `runs-on`.
+    - name: resolve the seed release
+      id: resolve
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+      run: |
+        set -euo pipefail
+        case "$RUNNER_OS/$RUNNER_ARCH" in
+          Linux/X64)     host=x86_64-linux;    ext=tar.gz ;;
+          Linux/ARM64)   host=aarch64-linux;   ext=tar.gz ;;
+          Windows/X64)   host=x86_64-windows;  ext=zip ;;
+          macOS/X64)     host=x86_64-darwin;   ext=tar.gz ;;
+          macOS/ARM64)   host=aarch64-darwin;  ext=tar.gz ;;
+          *) echo "::error::no mach seed archive is published for host $RUNNER_OS/$RUNNER_ARCH"; exit 1 ;;
+        esac
+
+        # first line is the tag, the rest are the release's asset names
+        listing="$(gh api "repos/briar-systems/mach/releases/latest" --jq '.tag_name, .assets[].name')"
+        tag="$(printf '%s\n' "$listing" | head -1)"
+        names="$(printf '%s\n' "$listing" | tail -n +2)"
+        asset="mach-${tag#v}-$host.$ext"
+
+        if ! printf '%s\n' "$names" | grep -Fxq "$asset"; then
+          echo "::error::the latest published mach release $tag carries no $asset — it holds: $(printf '%s' "$names" | tr '\n' ' ')"
+          exit 1
+        fi
+
+        # a relative directory keeps every path here portable to the windows runner's bash
+        mkdir -p .mach-seed
+        gh release download "$tag" -R briar-systems/mach -p "$asset" -D .mach-seed
+
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+        echo "asset=$asset" >> "$GITHUB_OUTPUT"
+        echo "seeding from $tag ($asset)"
+
+    - name: install the seed
+      if: runner.os != 'Windows'
+      shell: bash
+      env:
+        ASSET: ${{ steps.resolve.outputs.asset }}
+      run: |
+        set -euo pipefail
+        tar -xzf ".mach-seed/$ASSET" -C .mach-seed mach
+        chmod +x .mach-seed/mach
+        echo "$PWD/.mach-seed" >> "$GITHUB_PATH"
+
+    # GITHUB_PATH only takes effect in later steps, so callers seed in one step and use
+    # the compiler in the next
+    - name: install the seed
+      if: runner.os == 'Windows'
+      shell: pwsh
+      env:
+        ASSET: ${{ steps.resolve.outputs.asset }}
+      run: |
+        $dir = Join-Path $PWD '.mach-seed'
+        Expand-Archive -Path (Join-Path $dir $env:ASSET) -DestinationPath $dir -Force
+        Add-Content -Path $env:GITHUB_PATH -Value $dir

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Install mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p /tmp/machdl
-          gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
-          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
-          cp /tmp/machdl/mach /usr/local/bin/mach
-          chmod +x /usr/local/bin/mach
-          mach info
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
 
+      - name: Report the seed
+        run: mach info
       - name: Build
         run: mach build .
 
@@ -57,20 +50,16 @@ jobs:
         with:
           submodules: true
 
-      - name: Install mach and qemu
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Install qemu
         run: |
           sudo apt-get update
           sudo apt-get install -y qemu-user
-          mkdir -p /tmp/machdl
-          gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
-          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
-          cp /tmp/machdl/mach /usr/local/bin/mach
-          chmod +x /usr/local/bin/mach
-          mach info
 
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
+
+      - name: Report the seed
+        run: mach info
       - name: Cross-compile and run the riscv64 runtime smoke test
         run: bash test/riscv64/verify.sh
 
@@ -100,18 +89,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Install mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p /tmp/machdl
-          gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-aarch64-linux.tar.gz' --dir /tmp/machdl --clobber
-          tar -xzf /tmp/machdl/mach-*-aarch64-linux.tar.gz -C /tmp/machdl
-          sudo cp /tmp/machdl/mach /usr/local/bin/mach
-          sudo chmod +x /usr/local/bin/mach
-          mach info
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
 
+      - name: Report the seed
+        run: mach info
       - name: Run the test suite natively on aarch64
         run: mach test .
 
@@ -131,29 +113,18 @@ jobs:
         with:
           submodules: true
 
-      - name: Download mach
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p machdl
-          gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-x86_64-windows.zip' --dir machdl --clobber
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
 
-      # Expand-Archive rather than unzip: the archive is a zip and unzip is not
-      # part of the windows runner's guaranteed toolset.
-      - name: Install mach
-        shell: pwsh
-        run: |
-          $dir = Join-Path $PWD 'machdl'
-          Get-ChildItem -Path $dir -Filter '*.zip' | ForEach-Object {
-            Expand-Archive -Path $_.FullName -DestinationPath $dir -Force
-          }
-          & (Join-Path $dir 'mach.exe') info
+      - name: Report the seed
+        run: mach info
 
+      # the explicit path rather than the PATH entry: this probe runs under bash on
+      # the windows runner and takes the compiler as an argument, so it names the
+      # binary the seed step just installed.
       - name: Relative-target directory symlink
         shell: bash
-        run: bash test/symlink/verify.sh "$PWD/machdl/mach.exe" windows-x86_64
+        run: bash test/symlink/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
 
   cross-backends:
     runs-on: ubuntu-latest
@@ -162,17 +133,10 @@ jobs:
         with:
           submodules: true
 
-      - name: Install mach
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p /tmp/machdl
-          gh release download --repo briar-systems/mach \
-            --pattern 'mach-*-x86_64-linux.tar.gz' --dir /tmp/machdl --clobber
-          tar -xzf /tmp/machdl/mach-*-x86_64-linux.tar.gz -C /tmp/machdl
-          cp /tmp/machdl/mach /usr/local/bin/mach
-          chmod +x /usr/local/bin/mach
-          mach info
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
 
+      - name: Report the seed
+        run: mach info
       - name: Cross-compile the windows and darwin backends
         run: bash test/backends/verify.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,107 @@ jobs:
         shell: bash
         run: bash test/symlink/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
 
+  # darwin runs NATIVE on both architectures, for the same reason the arm64 job
+  # above is native rather than emulated -- and with a sharper edge now that the
+  # backend calls libSystem instead of issuing raw traps.
+  #
+  # the darwin OS layer is the only place mach-std depends on a C-VARIADIC call,
+  # and apple arm64 is the only platform that passes the whole variadic tail on
+  # the stack. a wrongly-lowered `openat(..., mode)` there does not fail to link
+  # and does not crash: it creates a file with the wrong permission bits. that
+  # divergence exists on ONE of these two rows, so a pass on the other says
+  # nothing about it, and neither row can stand in for the other.
+  #
+  # `cross-backends` still cross-compiles darwin from linux and is not made
+  # redundant by this job -- it is the leg that catches a target-gated module
+  # silently dropping out of the build. it just cannot execute anything.
+  darwin:
+    name: darwin ${{ matrix.arch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: aarch64
+            runner: macos-15
+          - arch: x86_64
+            runner: macos-15-intel
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - name: Seed mach
+        uses: ./.github/actions/seed-mach
+
+      - name: Report the seed
+        run: mach info
+
+      - name: Build
+        run: mach build .
+
+      - name: Run the test suite natively on darwin
+        run: mach test .
+
+      # std itself is a static artifact, so the dependency list only becomes
+      # observable once something LINKS it. this builds the backends smoke test
+      # natively -- an executable -- and inspects that.
+      #
+      # the image must name exactly one libSystem, under its install path. two
+      # LC_LOAD_DYLIB commands -- the implicit platform dependency plus a
+      # manifest entry spelled differently enough not to match it -- load and
+      # run here, so nothing else in this job would notice.
+      - name: One libSystem dependency, at its install path
+        run: |
+          set -euo pipefail
+          cd test/backends
+          mkdir -p dep
+          ln -sfn "$(cd ../.. && pwd)" dep/std
+          mach build . --profile debug
+          exe="$(find out -type f -name backends -print -quit)"
+          [ -n "$exe" ] || { echo "::error::no native darwin executable was produced"; exit 1; }
+          echo "inspecting $exe"
+          otool -L "$exe"
+          n="$(otool -L "$exe" | tail -n +2 | grep -c 'libSystem' || true)"
+          [ "$n" = "1" ] || { echo "::error::expected exactly 1 libSystem dependency, found $n"; exit 1; }
+          otool -L "$exe" | grep -q '/usr/lib/libSystem.B.dylib' \
+            || { echo "::error::libSystem is not named by its install path"; exit 1; }
+          # and it runs: the binary dyld-binds libSystem and reaches main
+          ./"$exe"
+
+      # the stat family is reached through the `$INODE64` variant symbol on
+      # x86_64 and the plain name on arm64. binding the plain name on x86_64
+      # would link, run, and quietly fill stat_t from a different struct
+      # layout, so the bound symbol name is asserted per architecture.
+      - name: The stat family binds the right symbol for this architecture
+        run: |
+          set -euo pipefail
+          exe="$(find test/backends/out -type f -name backends -print -quit)"
+          # the undefined-symbol list is the stable spelling across xcode
+          # versions; the bind-table dumpers move around, the symbol table does not
+          undef="$(nm -u "$exe")"
+          printf '%s\n' "$undef" | grep -F '_fstat' || true
+
+          if [ "${{ matrix.arch }}" = "x86_64" ]; then
+            if ! printf '%s\n' "$undef" | grep -qF '_fstat$INODE64'; then
+              echo "::error::x86_64 must bind _fstat\$INODE64, not the legacy 32-bit-inode _fstat"
+              exit 1
+            fi
+            if ! printf '%s\n' "$undef" | grep -qF '_fstatat$INODE64'; then
+              echo "::error::x86_64 must bind _fstatat\$INODE64"
+              exit 1
+            fi
+          else
+            if ! printf '%s\n' "$undef" | grep -qx '_fstat'; then
+              echo "::error::arm64 must bind the plain _fstat"
+              exit 1
+            fi
+            if printf '%s\n' "$undef" | grep -qF 'INODE64'; then
+              echo "::error::arm64 has no \$INODE64 variant; binding one is wrong"
+              exit 1
+            fi
+          fi
+
   cross-backends:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,16 @@ jobs:
       - name: Build
         run: mach build .
 
+      # gated against test/darwin/known-failures.txt rather than run bare. this
+      # lane's FIRST execution found eleven failures on both architectures, all
+      # of them predating this migration -- confirmed by running untouched `dev`
+      # on the same two runners. they are enumerated with evidence in that file.
+      #
+      # the gate fails on any failure not listed AND on any listed test that
+      # starts passing, so the list cannot become a mute button: it has to
+      # shrink to empty as the rest of #415 lands.
       - name: Run the test suite natively on darwin
-        run: mach test .
+        run: bash test/darwin/verify.sh
 
       # std itself is a static artifact, so the dependency list only becomes
       # observable once something LINKS it. this builds the backends smoke test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.26.0] - 2026-08-08
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+#### darwin: the filesystem layer calls libSystem instead of raw BSD traps (#415)
+
+Apple does not guarantee syscall-number stability. `svc 0x80` / `syscall` works today and has been broken across macOS releases before, and libSystem is the only interface Apple supports. This moves the **filesystem and descriptor** primitives of the darwin backend onto it. Memory, time, process, sockets, threads, `read_dir`, and `terminal` still issue raw traps; see "what is deliberately left" below.
+
+**The errno contract inverts, so every error path was re-derived rather than re-pointed.** A raw BSD trap sets the carry flag and returns the *positive* errno in the result register. libSystem returns `-1` (or `nil`) and leaves the errno in thread-local storage, reached through `__error()`. Two facts follow that the old code never had to encode:
+
+- **errno is not cleared on success.** It may only be read once the return value has already reported failure. `fail_errno` is the single place the conversion happens and is only ever reached from inside a test of the documented sentinel.
+- **the sentinel is per-function, not "negative".** `lseek` returns a file offset, and its failure value is exactly `-1`; testing the sign would be a different predicate that happens to agree today.
+
+The layer's outward contract is unchanged — a count or descriptor on success, a negative errno on failure — so nothing above `std.system.os.darwin` moved.
+
+**`open`, `fcntl`, and the apple arm64 variadic ABI.** `openat` and `fcntl` are C-variadic, and apple arm64 passes *every* variadic argument on the stack with no register phase. A fixed-arity declaration lowers `mode` into `x2` while libSystem reads it off the stack — which links, runs, and creates a file with the wrong permission bits. They are declared with mach's C-variadic `ext fun` form (briar-systems/mach#2575) and, where a call needs no tail, called with none: two-argument `openat` without `O_CREAT`, and `F_GETFD` / `F_GETFL`. Passing a dummy zero would not be an equivalent spelling on that target. Every tail this layer passes is an int, never a float, which keeps `AL` at zero on the SysV x86_64 leg.
+
+**The stat family is arch-gated on `$INODE64`.** On x86_64 the plain `_fstat` is still the legacy 32-bit-`st_ino` struct and the 64-bit layout — the one `stat_t` describes — is reached through the `$INODE64` variant symbol. arm64 has only the plain name. Binding the plain name on x86_64 would link and run and quietly fill `stat_t` from a different field order, so the suffix is applied by an explicit gate and asserted in CI per architecture.
+
+**Cancellation: the plain entry points, deliberately.** libSystem exports a `$NOCANCEL` twin for every cancellation point. std has no cancellation model, never calls `pthread_cancel`, and exposes no way to, so a cancellation point never acts and the plain entry point does exactly what its twin does — while remaining the public symbol. The decision is recorded in one place rather than left to whatever the linker resolves.
+
+**Deletions.** `getcwd` was an `open(".")` + `fcntl(F_GETPATH)` dance with a `MAXPATHLEN` bounce buffer, because `F_GETPATH` carries no capacity and XNU writes up to `MAXPATHLEN` bytes whatever the caller sized its destination. `getcwd(3)` takes the capacity, so the scratch buffer, the copy loop, the `F_GETPATH` constant and `MAXPATHLEN` all go (#409, #413). The hand-written `pipe` asm in both arch modules — which existed only because the raw trap returns two descriptors in `x0`/`x1` and signals through the carry flag — collapses to one line, identical on both architectures. Fifteen `SYS_*` constants are gone.
+
+### Added
+
+#### CI runs the suite natively on both darwin architectures
+
+There was no darwin execution anywhere in this repo's CI: `cross-backends` compiles the darwin backends from linux and runs nothing. The suite now runs natively on `macos-15` (arm64) and `macos-15-intel`, matching the reasoning already applied to the arm64 linux job — a psABI fact is exactly what an emulator or a cross-build can be wrong about.
+
+The two rows are not interchangeable. The stack-passed variadic tail exists on apple arm64 and nowhere else, and the `$INODE64` suffix exists on x86_64 and nowhere else, so each divergence is invisible on the other row. CI additionally asserts that a linked darwin image names **exactly one** libSystem, at its install path — the implicit platform dependency plus a manifest entry spelled differently enough not to match it produces two `LC_LOAD_DYLIB` commands, which loads and runs and would otherwise go unnoticed.
+
+Tests assert observable effects, not return codes: a file created with `O_CREAT` is stat'd back and its mode compared **exactly** (with the umask pinned to zero, so a dropped variadic argument cannot pass), `FD_CLOEXEC` is set and read back and cleared and read back, a pipe carries bytes end to end, `lseek` reports the size the writes produced, and the claimed error paths are provoked for their **specific** errno — `EEXIST`, `ENOENT`, `EBADF`.
+
+### What is deliberately left, and why
+
+This is a partial migration and the mixed state is intentional. `read_dir` needs `getdirentries64`, which is not public API on darwin; replacing it means an `opendir`/`readdir` redesign that changes the primitive's shape rather than just its callee. The thread layer's `bsdthread_create` / `__ulock_*` is the highest-value part of this issue and carries its own risk, and it interacts with everything else here — see the follow-up issue for the ordering question it raises.
+
 ## [0.25.1] - 2026-08-07
 
 **Requires mach 4.14.0 or newer, and 4.13.0 will NOT build this.** `eq[f.type]` — the walk re-entering itself at a field's type — is a spelling mach did not accept before briar-systems/mach#2691, which landed on mach `dev` after 4.13.0 was tagged. On an older toolchain this is a **parse** error ("expected a module alias before `.`") reported against `src/derive.mach`, and because parsing precedes comptime evaluation the module's own `$mach.version` gate cannot fire ahead of it. That capability now exists: briar-systems/mach#2714 landed and shipped in mach 4.15.0, so `[project].mach` takes a semver minimum and is checked when the manifest is read, before any source is parsed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### darwin: threads are pthreads, not bsdthreads (#415)
+
+`bsdthread_create` / `bsdthread_register` was never an ABI. `bsdthread_register` publishes a workqueue callback the kernel invokes, versioned against the libpthread that shipped with the OS — an internal kernel↔libpthread protocol this backend was impersonating. It is what #415 singles out as the most fragile code on the least stable part of the surface, and on current macOS it does not work: all three `std.sync.thread` tests were failing before this change, and had been failing unnoticed because nothing had ever run this suite on darwin.
+
+**This had to come before the rest of the migration, not after it.** libSystem reaches errno through `__error()`, a thread-local resolved against the pthread structure libpthread installs for threads it created. A raw bsdthread never had one, because the start routine never performed libpthread's own `_pthread_set_self` handshake. Every libSystem call already migrated would therefore have carried an unvalidated errno path the moment it ran off the main thread. `pthread_create` makes every thread a real pthread and the question stops existing.
+
+**pthread does not use errno, and that is the trap.** Every other libSystem entry point reports failure as `-1` and leaves the reason in errno. The pthread family returns the error number *directly* and leaves errno untouched, so the `if (rc < 0) { ret fail_errno(); }` shape used everywhere else is wrong twice over — the branch never fires, and if it did it would report an unrelated stale errno. The pthread wrappers negate `rc` itself and never call `fail_errno`.
+
+**The OS-layer contract is unchanged; stack ownership moved.** `thread_spawn` still takes a caller-allocated region and a completion flag, and `thread_wait`/`thread_wake` are still address-keyed. The caller's region is now a *context block* only — pthread allocates and frees the real stack — which is exactly how the windows backend has always used it. The block is released by the new thread itself, so an unjoined thread still reclaims it, matching what `bsdthread_terminate` did. Threads are created **detached**, because joining waits on the completion flag rather than calling `pthread_join`, and a joinable pthread would leave its descriptor unreaped.
+
+**The address-keyed wait is a table of condition variables.** darwin's futex equivalent, `__ulock_wait`, is as private as the bsdthread traps; the public replacement `os_sync_wait_on_address` is macOS 14.4+ and adopting it would quietly raise this library's deployment floor. So the wait is built from pthread condition variables in a fixed table hashed by address. Buckets are genuinely shared, and the consequences are handled rather than hoped away: `thread_wake` **broadcasts**, because a signal could hand the one wakeup to a waiter on an unrelated address; and the lost-wakeup race is closed by lock discipline, since the waiter re-reads the address under the bucket mutex that `pthread_cond_wait` releases atomically and that `thread_wake` must hold to broadcast.
+
+Deleted with it: both hand-written `asm` trampolines (including the x86_64 stack-realignment fixup that existed only because the kernel *jumped* to the entry rather than calling it), the workqueue callback, and six `SYS_*` constants.
+
+
+
 #### darwin: the filesystem layer calls libSystem instead of raw BSD traps (#415)
 
 Apple does not guarantee syscall-number stability. `svc 0x80` / `syscall` works today and has been broken across macOS releases before, and libSystem is the only interface Apple supports. This moves the **filesystem and descriptor** primitives of the darwin backend onto it. Memory, time, process, sockets, threads, `read_dir`, and `terminal` still issue raw traps; see "what is deliberately left" below.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+#### darwin: the clocks and `sleep` go through libSystem (#415)
+
+**darwin has no `clock_gettime` trap at all.** The backend called syscall 427 and read the result as a time; whatever that number is on current macOS, it is not one — `now()` came back *below the unix epoch*. The three `std.chrono.time` tests had been failing for as long as nothing was running them. `clock_gettime(3)` is public, has shipped since macOS 10.12, and is implemented in userspace over `mach_absolute_time()` and the commpage rather than as a trap, which is why hunting for a syscall number was never going to work. 10.12 is older than any macOS running on hardware these targets support, so this moves no deployment floor — unlike `os_sync_wait_on_address`, which is why the thread layer went a different way.
+
+The `CLOCK_REALTIME` / `CLOCK_MONOTONIC` constants needed no change: they were always written against darwin's own `<time.h>` values, even while the call underneath did not exist.
+
+**`sleep` moves to `nanosleep(3)`.** The note it carried — "darwin has no nanosleep syscall" — was true of the trap table and false of libSystem, so it went through `select` with a `timeval` timeout and lost sub-microsecond resolution on the way. It now also handles `EINTR` by resuming with the *remaining* time, so an interrupted sleep ends at about the requested moment instead of stretching towards double it. `rec timeval` and three more `SYS_*` constants go with it.
+
+**A broken clock is not a clock that errors — it is one that returns a plausible-looking number**, so none of the seven new tests checks a return code. Each pins the clock against something independent: the epoch against a timestamp the *filesystem* just wrote (same kernel clock, completely different path), the unit against a measured 50ms sleep (which is what catches microseconds, milliseconds, or raw mach ticks), and `tv_nsec` against its documented range. Monotonicity is checked across 200 reads, and an unknown clock id is provoked for `EINVAL`.
+
+
+
 #### darwin: threads are pthreads, not bsdthreads (#415)
 
 `bsdthread_create` / `bsdthread_register` was never an ABI. `bsdthread_register` publishes a workqueue callback the kernel invokes, versioned against the libpthread that shipped with the OS — an internal kernel↔libpthread protocol this backend was impersonating. It is what #415 singles out as the most fragile code on the least stable part of the surface, and on current macOS it does not work: all three `std.sync.thread` tests were failing before this change, and had been failing unnoticed because nothing had ever run this suite on darwin.

--- a/mach.toml
+++ b/mach.toml
@@ -19,6 +19,32 @@ isa = "riscv64"
 os  = "linux"
 abi = "lp64"
 
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+# darwin's platform library, and the only supported way to reach the kernel:
+# apple does not promise syscall numbers. `name` is spelled as the full install
+# path on purpose. a dyld-loaded image implicitly links libSystem under exactly
+# that path, and a requirement that does not match it string-for-string is a
+# SECOND dependency rather than the same one - the image then carries two
+# LC_LOAD_DYLIB commands, one of them a bare leaf name dyld would have to
+# search for. `library` is the logical name `#[library("libSystem")]` pins to.
+[link.libsystem]
+source  = "system"
+name    = "/usr/lib/libSystem.B.dylib"
+library = "libSystem"
+os      = ["darwin"]
+isa     = ["*"]
+abi     = ["*"]
+export  = true
+
 [link.kernel32]
 source = "system"
 name = "kernel32.dll"
@@ -56,5 +82,5 @@ kind = "static"
 entry = "lib/libstd.mach"
 out = "lib/std"
 targets = ["*"]
-link = ["kernel32", "ws2_32", "advapi32", "synch"]
+link = ["kernel32", "ws2_32", "advapi32", "synch", "libsystem"]
 need = []

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.25.1"
+version = "0.26.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -6,6 +6,7 @@
 use std.types.size.usize;
 
 use std.system.os.darwin.shared;
+use ls: std.system.os.darwin.libsystem;
 
 $if ($mach.build.os != $mach.os.darwin) {
     $error("std.system.os.darwin.aarch64: requires darwin target");
@@ -21,29 +22,18 @@ pub fun page_size() usize {
 
 # create a unidirectional pipe
 #
-# darwin pipe() returns two fds in x0/x1 and signals failure via the
-# carry flag, neither of which the syscall DSL captures, so this uses raw
-# asm. inline-asm branches must target symbols (issue #216), so the carry
-# flag is materialized into a register (`cset`) and the branching happens
-# in mach code instead of the asm block.
+# this was hand-written asm for one reason: the raw XNU pipe trap returns the
+# two descriptors in x0/x1 and signals failure through the carry flag, and the
+# syscall DSL captures neither. libSystem's pipe(2) is an ordinary C function
+# that writes both descriptors through the caller's array and reports failure
+# as -1, so the arch-specific asm has nothing left to do and the wrapper is now
+# identical on both darwin architectures - it lives here only because `pipe` is
+# part of the per-arch module's published surface.
 # ---
 # fds: pointer to two i32s; fds[0] = read end, fds[1] = write end
 # ret: 0 on success, or negative errno
 pub fun pipe(fds: *i32) i64 {
-    var fd0: i64 = 0;
-    var fd1: i64 = 0;
-    var fail: i64 = 0;
-    asm aarch64 {
-        mov x16, 42
-        svc 0x80
-        cset x9, cs              # x9 = 1 when carry set (error), else 0
-        str x9, {fail}
-        str x0, {fd0}
-        str x1, {fd1}
-    }
-    if (fail != 0) { ret -fd0; }
-    fds[0] = fd0::i32;
-    fds[1] = fd1::i32;
+    if (ls.pipe(fds) < 0) { ret ls.fail_errno(); }
     ret 0;
 }
 

--- a/src/system/os/darwin/libsystem.mach
+++ b/src/system/os/darwin/libsystem.mach
@@ -177,6 +177,40 @@ pub ext fun getcwd(buf: *u8, size: usize) *u8;
 #[library("libSystem")]
 pub ext fun pipe(fds: *i32) i32;
 
+# time
+#
+# darwin has no `clock_gettime` BSD trap at all. the backend used to call
+# syscall 427 and read the result as a time; whatever that number is on current
+# macOS, it is not one - `now()` came back BELOW the unix epoch, and the three
+# `std.chrono.time` tests had been failing on darwin for as long as nothing was
+# running them.
+#
+# `clock_gettime(3)` is real, public, and has shipped since macOS 10.12; it is
+# implemented in userspace over `mach_absolute_time()` and the commpage rather
+# than as a trap, which is exactly why looking for a syscall number for it was
+# never going to work. 10.12 is older than any macOS that runs on hardware
+# these targets support, so binding it moves no floor - unlike
+# `os_sync_wait_on_address`, which is why the thread layer went a different way.
+#
+# `timespec` here is the same layout `shared.mach` declares; it is taken as
+# `*u8` only to keep this module free of a dependency back on that one.
+#[library("libSystem")]
+pub ext fun clock_gettime(clock_id: i32, ts: *u8) i32;
+
+# suspend the calling thread for the requested interval
+#
+# the old backend said "darwin has no nanosleep syscall" and reached for
+# `select` with a timeout instead. that is true of the TRAP table and false of
+# libSystem, which exports nanosleep(3). taking it also gets the remaining-time
+# argument, so an interrupted sleep can resume for what is left rather than
+# returning early or restarting the full interval.
+# ---
+# req: requested interval
+# rem: filled with the unslept remainder when interrupted; may be nil
+# ret: 0, or -1 with errno set (EINTR when a signal cut the sleep short)
+#[library("libSystem")]
+pub ext fun nanosleep(req: *u8, rem: *u8) i32;
+
 # threads
 #
 # ## pthread does NOT use errno, and that is the trap in this section

--- a/src/system/os/darwin/libsystem.mach
+++ b/src/system/os/darwin/libsystem.mach
@@ -1,0 +1,194 @@
+# libSystem imports for the darwin backend
+#
+# apple does not guarantee syscall-number stability, so `svc 0x80` / `syscall`
+# is not a supportable distribution surface: libSystem is. every darwin OS
+# primitive that used to issue a raw trap binds a libSystem symbol declared
+# here instead.
+#
+# three things about this boundary are easy to get wrong, so they are settled
+# once, here, rather than at each call site.
+#
+# ## the errno contract
+#
+# a raw BSD trap sets the carry flag and returns the POSITIVE errno in the
+# result register. libSystem instead returns -1 (or nil, for the pointer-valued
+# entry points) and leaves the errno in thread-local storage. these are
+# different contracts, and the difference is not just where the number lives:
+#
+#   - errno is NOT cleared on success. reading it after a call that succeeded
+#     returns whatever the last failing call left behind. it may only be read
+#     once the RETURN VALUE has already said the call failed.
+#   - a success can be a negative number. `lseek` past 2^63 cannot happen, but
+#     the rule holds generally: the failure indicator is the documented
+#     sentinel for that specific function, never "the result is negative".
+#
+# `fail_errno` is the only way this module converts a failure, and it is only
+# ever reached from inside an `if` that already tested the sentinel. the darwin
+# OS layer keeps its existing outward contract - a negative errno - so nothing
+# above `std.system.os.darwin` changes shape.
+#
+# ## `__error`, and why it is not the thing we refuse to use
+#
+# `<errno.h>` defines `errno` as `(*__error())`. the underscores make it look
+# like the private `__open` / `__fcntl` family, but it is the opposite: it is
+# the documented, stable, public way to reach errno on darwin, and there is no
+# other one. the symbols this migration refuses are the private SYSCALL shims
+# (`__open`, `__fcntl`, ...) whose only purpose is to skip the cancellation
+# wrapper - taking those would leave us on exactly the unsupported surface the
+# migration exists to leave.
+#
+# ## cancellation: the plain entry points, deliberately
+#
+# libSystem exports a `$NOCANCEL` twin for every entry point that is a POSIX
+# cancellation point (`read$NOCANCEL`, `open$NOCANCEL`, ...). this module binds
+# the PLAIN names on purpose:
+#
+#   - std has no cancellation model. it never calls `pthread_cancel` and
+#     exposes no way for a caller to. a cancellation point only acts when a
+#     cancel is already pending, so with none ever requested the plain entry
+#     point does exactly what its `$NOCANCEL` twin does.
+#   - the plain name is the public one. `$NOCANCEL` is a suffixed variant symbol
+#     that exists to serve libpthread's internals; binding it would put the same
+#     "Apple never promised you this" question back into the layer whose whole
+#     purpose is to answer it.
+#
+# so the choice costs nothing today and keeps the supported surface. should std
+# ever grow real cancellation, the decision to revisit is here, in one place,
+# and not spread across sixty call sites.
+#
+# ## `$INODE64`, and why the stat family is arch-gated
+#
+# macOS grew a 64-bit `st_ino` in 10.5 without breaking the binaries compiled
+# against the 32-bit one. on x86_64 both layouts still ship: the PLAIN `_fstat`
+# is the legacy 32-bit-inode struct, and the 64-bit layout - the one `stat_t`
+# in shared.mach describes - is reached through the `$INODE64` variant symbol.
+# arm64 has no legacy to carry, so only the plain name exists there.
+#
+# binding the plain name on x86_64 would link and run and quietly fill the
+# caller's `stat_t` from a struct with a different field order. that is silent
+# corruption, not an error, which is why the suffix is applied by an explicit
+# arch gate rather than left to whatever the linker happens to resolve.
+
+use std.types.size.usize;
+
+$if ($mach.build.os != $mach.os.darwin) {
+    $error("std.system.os.darwin.libsystem: requires darwin target");
+}
+
+# the thread-local errno cell
+#
+# `errno` is a macro over this in C; there is no importable data symbol for it.
+# ---
+# ret: pointer to the calling thread's errno
+#[library("libSystem")]
+ext fun __error() *i32;
+
+# the calling thread's current errno, as a positive number
+#
+# only meaningful directly after a call whose return value already reported
+# failure - errno is not cleared by a successful call.
+# ---
+# ret: the current errno
+pub fun errno() i32 {
+    val cell: *i32 = __error();
+    ret @cell;
+}
+
+# the current errno negated, for a darwin OS primitive's return
+#
+# the darwin backend's outward contract is "a negative errno on failure", which
+# is what it returned when it read the number straight out of a trap's result
+# register. this is the single place that contract is reconstructed from the
+# libSystem one.
+#
+# a libSystem entry point that fails without setting errno is not supposed to
+# exist, but a zero here would be indistinguishable from success to every
+# caller, so it is reported as EINVAL rather than silently swallowed.
+# ---
+# ret: the negated errno, always < 0
+pub fun fail_errno() i64 {
+    val e: i32 = errno();
+    if (e == 0) { ret -22; }
+    ret -(e::i64);
+}
+
+# file descriptors and paths
+
+#[library("libSystem")]
+pub ext fun read(fd: i32, buf: *u8, count: usize) i64;
+
+#[library("libSystem")]
+pub ext fun write(fd: i32, buf: *u8, count: usize) i64;
+
+# `openat` is C-variadic: the mode argument is only read when the flags carry
+# O_CREAT. declaring it at a fixed arity of three would be silently wrong on
+# apple arm64, which passes the whole variadic tail on the stack while a fixed
+# third parameter would be lowered into x2 (see mach's doc/language/ext-fun.md).
+#[library("libSystem")]
+pub ext fun openat(dirfd: i32, path: *u8, flags: i32, ...) i32;
+
+#[library("libSystem")]
+pub ext fun close(fd: i32) i32;
+
+#[library("libSystem")]
+pub ext fun lseek(fd: i32, offset: i64, whence: i32) i64;
+
+# the stat family carries the `$INODE64` suffix on x86_64 only; see the module
+# header. the two arms are mutually exclusive, so the duplicate-attribution
+# check does not apply to them.
+$if ($mach.build.arch == $mach.arch.x86_64) {
+    #[library("libSystem")] #[symbol("_fstat$INODE64")]
+    pub ext fun fstat(fd: i32, st: *u8) i32;
+
+    #[library("libSystem")] #[symbol("_fstatat$INODE64")]
+    pub ext fun fstatat(dirfd: i32, path: *u8, st: *u8, flags: i32) i32;
+}
+$or {
+    #[library("libSystem")] #[symbol("_fstat")]
+    pub ext fun fstat(fd: i32, st: *u8) i32;
+
+    #[library("libSystem")] #[symbol("_fstatat")]
+    pub ext fun fstatat(dirfd: i32, path: *u8, st: *u8, flags: i32) i32;
+}
+
+#[library("libSystem")]
+pub ext fun unlinkat(dirfd: i32, path: *u8, flags: i32) i32;
+
+#[library("libSystem")]
+pub ext fun renameat(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun symlink(target: *u8, linkpath: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun mkdirat(dirfd: i32, path: *u8, mode: u32) i32;
+
+#[library("libSystem")]
+pub ext fun faccessat(dirfd: i32, path: *u8, mode: i32, flags: i32) i32;
+
+# `getcwd(3)` replaces the open(".") + fcntl(F_GETPATH) dance the raw-syscall
+# backend needed. it takes a capacity, so the caller's buffer size is honoured
+# by the callee instead of being defended against afterwards.
+# ---
+# ret: `buf` on success, or nil with errno set (ERANGE when size is too small)
+#[library("libSystem")]
+pub ext fun getcwd(buf: *u8, size: usize) *u8;
+
+#[library("libSystem")]
+pub ext fun pipe(fds: *i32) i32;
+
+# set the file-mode creation mask, returning the previous one
+#
+# cannot fail and does not touch errno. imported so a test can pin the mask to
+# a known value and then assert a created file's mode EXACTLY, rather than
+# asserting some umask-dependent subset of it - which is what makes the mode
+# assertion able to catch a dropped variadic argument.
+#[library("libSystem")]
+pub ext fun umask(mask: u32) u32;
+
+# `fcntl` is C-variadic. the two-argument commands (F_GETFL, F_GETFD) pass no
+# tail at all and are called with none; F_SETFD / F_SETFL / F_DUPFD pass a
+# single int. every tail this module ever passes is an int or a pointer, never
+# a float, which is what keeps `AL` at zero on the SysV x86_64 leg.
+#[library("libSystem")]
+pub ext fun fcntl(fd: i32, cmd: i32, ...) i32;

--- a/src/system/os/darwin/libsystem.mach
+++ b/src/system/os/darwin/libsystem.mach
@@ -177,6 +177,94 @@ pub ext fun getcwd(buf: *u8, size: usize) *u8;
 #[library("libSystem")]
 pub ext fun pipe(fds: *i32) i32;
 
+# threads
+#
+# ## pthread does NOT use errno, and that is the trap in this section
+#
+# every entry point above reports failure as -1 and leaves the reason in
+# errno. **the pthread family does neither.** it returns the error number
+# DIRECTLY as its result: 0 on success, otherwise an `errno.h` value. errno
+# itself is left completely untouched.
+#
+# so `if (rc < 0) { ret fail_errno(); }` - the shape every other wrapper in
+# this module uses - is wrong twice over for a pthread call. `rc` is never
+# negative, so the branch never fires and a failure returns as success; and if
+# it did fire it would report whatever unrelated errno was lying around. the
+# pthread wrappers negate `rc` itself and never call `fail_errno`.
+#
+# ## why pthread at all, rather than the bsdthread traps
+#
+# `bsdthread_create` / `bsdthread_register` is not an ABI. `bsdthread_register`
+# publishes a workqueue callback the kernel invokes, versioned against the
+# libpthread that shipped with the OS - an internal kernel<->libpthread
+# protocol we were impersonating. It is the least stable part of the surface
+# this migration exists to leave, and on current macOS it no longer works: the
+# thread tests were failing before this change.
+#
+# it also blocked everything else. libSystem reaches errno through `__error()`,
+# a thread-local lookup that resolves against the pthread structure libpthread
+# installs for a thread it created. a raw bsdthread never had one, because the
+# start routine never performed libpthread's own `_pthread_set_self` handshake.
+# every libSystem call in this module would therefore have had an unvalidated
+# errno path the moment it ran off the main thread. `pthread_create` makes
+# every thread a real pthread and the question stops existing - which is why
+# this is the FIRST domain migrated after the filesystem, not the last.
+
+# opaque pthread object sizes, from <sys/_pthread/_pthread_types.h> on LP64.
+# each object is a `long sig` followed by an opaque byte array:
+#   _PTHREAD_MUTEX_SIZE 56, _PTHREAD_COND_SIZE 40,
+#   _PTHREAD_ATTR_SIZE  56, _PTHREAD_ONCE_SIZE  8
+# these are public ABI - changing one would break every compiled C program on
+# the system - so they are spelled as constants rather than probed. they are
+# asserted against the runtime's own behaviour by the tests in shared.mach.
+pub val PTHREAD_MUTEX_BYTES: usize = 64;
+pub val PTHREAD_COND_BYTES:  usize = 48;
+pub val PTHREAD_ATTR_BYTES:  usize = 64;
+pub val PTHREAD_ONCE_BYTES:  usize = 16;
+
+# pthread_attr_setdetachstate states (<pthread.h>)
+pub val PTHREAD_CREATE_JOINABLE: i32 = 1;
+pub val PTHREAD_CREATE_DETACHED: i32 = 2;
+
+# `start` is a `void *(*)(void *)` passed as a bare address, matching how the
+# windows backend hands CreateThread its trampoline.
+#[library("libSystem")]
+pub ext fun pthread_create(thread: *usize, attr: *u8, start: usize, arg: ptr) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_attr_init(attr: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_attr_destroy(attr: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_attr_setstacksize(attr: *u8, size: usize) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_attr_setdetachstate(attr: *u8, state: i32) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_mutex_init(m: *u8, attr: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_mutex_lock(m: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_mutex_unlock(m: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_cond_init(c: *u8, attr: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_cond_wait(c: *u8, m: *u8) i32;
+
+#[library("libSystem")]
+pub ext fun pthread_cond_broadcast(c: *u8) i32;
+
+# `init` is a `void (*)(void)` passed as a bare address.
+#[library("libSystem")]
+pub ext fun pthread_once(once: *u8, init: usize) i32;
+
 # set the file-mode creation mask, returning the previous one
 #
 # cannot fail and does not touch errno. imported so a test can pin the mask to

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -37,9 +37,6 @@ val SYS_MUNLOCK:          usize = 204;
 val SYS_EXECVE:           usize = 59;
 val SYS_VFORK:            usize = 66;
 val SYS_GETDIRENTRIES64:  usize = 344;
-val SYS_SELECT:           usize = 93;
-val SYS_GETTIMEOFDAY:     usize = 116;
-val SYS_CLOCK_GETTIME:    usize = 427;
 val SYS_GETPID:           usize = 20;
 val SYS_KILL:             usize = 37;
 val SYS___SYSCTL:         usize = 202;
@@ -119,13 +116,6 @@ pub rec stat_t {
     _reserved0:        i32;
     _reserved1:        i64;
     _reserved2:        i64;
-}
-
-# gettimeofday result
-rec timeval {
-    tv_sec:  i64;
-    tv_usec: i32;
-    _pad:    i32;
 }
 
 # time specification with seconds and nanoseconds
@@ -1070,21 +1060,34 @@ pub fun getpid() i64 {
 
 # suspend execution for the given number of nanoseconds
 #
-# darwin has no nanosleep syscall; uses select with a timeval timeout.
+# uses nanosleep(3). the previous note here - "darwin has no nanosleep
+# syscall" - was true of the trap table and false of libSystem, so this went
+# through `select` with a timeout and lost the sub-microsecond resolution to
+# `timeval` on the way.
+#
+# a signal that cuts the sleep short leaves the unslept remainder in `rem`, and
+# the retry resumes with THAT rather than restarting the full interval, so an
+# interrupted sleep still ends at about the requested time instead of
+# stretching towards double it.
 # ---
 # nsec: nanoseconds to sleep
 pub fun sleep(nsec: i64) {
     if (nsec <= 0) { ret; }
-    var sec: i64 = nsec / 1000000000;
-    var usec: i64 = (nsec % 1000000000 + 999) / 1000;
-    if (usec >= 1000000) {
-        sec = sec + 1;
-        usec = usec - 1000000;
+    var req: timespec;
+    req.tv_sec  = nsec / 1000000000;
+    req.tv_nsec = nsec % 1000000000;
+
+    var rem: timespec;
+    rem.tv_sec  = 0;
+    rem.tv_nsec = 0;
+
+    var retries: usize = 0;
+    for (retries < EINTR_MAX_RETRIES) {
+        if (ls.nanosleep((?req)::usize::*u8, (?rem)::usize::*u8) == 0) { ret; }
+        if (ls.fail_errno() != EINTR) { ret; }
+        req = rem;
+        retries = retries + 1;
     }
-    var tv: timeval;
-    tv.tv_sec = sec;
-    tv.tv_usec = usec::i32;
-    syscall5(SYS_SELECT, 0, 0, 0, 0, (?tv)::usize);
 }
 
 # the number of CPUs available to this process
@@ -2103,14 +2106,169 @@ pub fun random_fill(buf: *u8, len: usize) i64 {
 # time
 
 # read a clock into a timespec
-# uses the kernel clock_gettime syscall (available since macOS 10.12).
-# CLOCK_MONOTONIC returns true monotonic time via the kernel's nanouptime.
+#
+# CLOCK_REALTIME (0) and CLOCK_MONOTONIC (6) are darwin's own `clockid_t`
+# values from <time.h>, not linux's - they happen to have been correct already,
+# because the constants were always written against darwin's header even while
+# the call underneath was a trap that does not exist.
 # ---
 # clock_id: CLOCK_REALTIME or CLOCK_MONOTONIC
 # ts:       output timespec
 # ret:      0 on success, or negative errno
 pub fun clock_gettime(clock_id: i32, ts: *timespec) i64 {
-    ret syscall2(SYS_CLOCK_GETTIME, clock_id::u32::usize, ts::usize);
+    if (ls.clock_gettime(clock_id, ts::usize::*u8) < 0) { ret ls.fail_errno(); }
+    ret 0;
+}
+
+# clock migration tests
+#
+# a broken clock is not a clock that errors - it is a clock that returns a
+# plausible-looking number. the old backend's `clock_gettime` returned 0
+# happily and produced a time below the unix epoch. so none of these check a
+# return code: each one pins the clock against something independent.
+#
+#   epoch  -- compared against a timestamp the FILESYSTEM wrote, which comes
+#             from the same kernel wall clock by a completely different path
+#   unit   -- compared against a measured sleep, which is what catches a clock
+#             reporting microseconds, milliseconds, or raw mach ticks
+#   field  -- tv_nsec held to its documented range, which a tick count spilled
+#             into the struct would violate
+
+# both clocks report nanoseconds in tv_nsec, not some other unit
+#
+# a tick count or a microsecond value dropped into this field lands outside
+# [0, 1e9) almost immediately, so this is a cheap unit check independent of
+# how long anything takes.
+test "std.system.os.darwin.libsystem:clock_tv_nsec_is_within_one_second" {
+    var rt: timespec;
+    if (clock_gettime(CLOCK_REALTIME, ?rt) != 0) { ret 1; }
+    if (rt.tv_nsec < 0 || rt.tv_nsec >= 1000000000) { ret 1; }
+
+    var mt: timespec;
+    if (clock_gettime(CLOCK_MONOTONIC, ?mt) != 0) { ret 1; }
+    if (mt.tv_nsec < 0 || mt.tv_nsec >= 1000000000) { ret 1; }
+    ret 0;
+}
+
+# CLOCK_REALTIME agrees with the timestamp the filesystem just wrote
+#
+# the strongest reference available without a network: create a file, read its
+# mtime back through fstat, and require the wall clock to agree. both numbers
+# come from the same kernel clock by entirely different routes, so an epoch
+# error, a unit error, or a stuck clock all break the comparison. the old
+# implementation - which returned a time below 1970 - fails this outright.
+test "std.system.os.darwin.libsystem:realtime_agrees_with_a_filesystem_timestamp" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'k'::u8);
+    unlink(AT_FDCWD, ?path[0], 0);
+
+    val fd: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_RDWR, 0o600);
+    if (fd < 0) { ret 1; }
+
+    var st: stat_t;
+    val sr: i64 = stat(fd::i32, ?st);
+    close(fd::i32);
+    unlink(AT_FDCWD, ?path[0], 0);
+    if (sr != 0) { ret 1; }
+
+    var now: timespec;
+    if (clock_gettime(CLOCK_REALTIME, ?now) != 0) { ret 1; }
+
+    var delta: i64 = now.tv_sec - st.st_mtime;
+    if (delta < 0) { delta = -delta; }
+    # generous enough never to flake on a loaded runner, tight enough that a
+    # wrong epoch or unit cannot slip through
+    if (delta > 60) { ret 1; }
+    ret 0;
+}
+
+# the wall clock sits in a plausible span of years
+#
+# guards the direction the filesystem comparison cannot: if BOTH the clock and
+# the filesystem were wrong in the same way the check above would still pass.
+# the lower bound is a date already in the past when this was written.
+test "std.system.os.darwin.libsystem:realtime_is_a_plausible_wall_clock" {
+    var ts: timespec;
+    if (clock_gettime(CLOCK_REALTIME, ?ts) != 0) { ret 1; }
+    # 2023-01-01 .. 2100-01-01
+    if (ts.tv_sec < 1672531200) { ret 1; }
+    if (ts.tv_sec > 4102444800) { ret 1; }
+    ret 0;
+}
+
+# the monotonic clock advances by about the interval we actually slept
+#
+# this is the unit check with teeth. sleep for 50ms and require the clock to
+# report an advance in the same ballpark: a clock counting microseconds would
+# report ~50, a clock counting mach ticks something wildly larger, and a stuck
+# clock zero. it also proves `sleep` itself works, which the old select-based
+# implementation could not be assumed to.
+test "std.system.os.darwin.libsystem:monotonic_advances_by_the_interval_slept" {
+    var before: timespec;
+    if (clock_gettime(CLOCK_MONOTONIC, ?before) != 0) { ret 1; }
+
+    sleep(50000000);
+
+    var after: timespec;
+    if (clock_gettime(CLOCK_MONOTONIC, ?after) != 0) { ret 1; }
+
+    val elapsed: i64 = (after.tv_sec - before.tv_sec) * 1000000000
+                     + (after.tv_nsec - before.tv_nsec);
+
+    # at least the interval requested, and not so much more that the units
+    # could be wrong; a heavily loaded runner still lands far inside 5s
+    if (elapsed < 40000000)   { ret 1; }
+    if (elapsed > 5000000000) { ret 1; }
+    ret 0;
+}
+
+# the wall clock advances across a sleep too, at the same rate
+#
+# a realtime clock that is merely a constant would satisfy the epoch checks
+# above forever. this requires it to actually move, and to move by roughly what
+# the monotonic clock says elapsed.
+test "std.system.os.darwin.libsystem:realtime_advances_across_a_sleep" {
+    var before: timespec;
+    if (clock_gettime(CLOCK_REALTIME, ?before) != 0) { ret 1; }
+
+    sleep(50000000);
+
+    var after: timespec;
+    if (clock_gettime(CLOCK_REALTIME, ?after) != 0) { ret 1; }
+
+    val elapsed: i64 = (after.tv_sec - before.tv_sec) * 1000000000
+                     + (after.tv_nsec - before.tv_nsec);
+    if (elapsed < 40000000)   { ret 1; }
+    if (elapsed > 5000000000) { ret 1; }
+    ret 0;
+}
+
+# the monotonic clock never runs backwards across repeated reads
+test "std.system.os.darwin.libsystem:monotonic_never_decreases" {
+    var prev: timespec;
+    if (clock_gettime(CLOCK_MONOTONIC, ?prev) != 0) { ret 1; }
+
+    var i: usize = 0;
+    for (i < 200) {
+        var cur: timespec;
+        if (clock_gettime(CLOCK_MONOTONIC, ?cur) != 0) { ret 1; }
+        if (cur.tv_sec < prev.tv_sec) { ret 1; }
+        if (cur.tv_sec == prev.tv_sec && cur.tv_nsec < prev.tv_nsec) { ret 1; }
+        prev = cur;
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# an unknown clock id is refused with EINVAL, not answered with a wrong number
+#
+# the error path, provoked rather than assumed. this also confirms the wrapper
+# reads errno at all: the old trap-based version reported failure through a
+# different channel entirely.
+test "std.system.os.darwin.libsystem:unknown_clock_id_is_einval" {
+    var ts: timespec;
+    if (clock_gettime(9999, ?ts) != EINVAL) { ret 1; }
+    ret 0;
 }
 
 # errno

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -92,10 +92,6 @@ val SEEK_SET: i32 = 0;
 val SEEK_CUR: i32 = 1;
 val SEEK_END: i32 = 2;
 
-# thread creation (bsdthread)
-
-# ulock (futex equivalent)
-
 # kernel ABI types
 
 # darwin stat64 structure for file metadata

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -19,13 +19,11 @@ $if ($mach.build.os != $mach.os.darwin) {
 }
 
 use os_shared: std.system.os.shared;
+use ls: std.system.os.darwin.libsystem;
 
 # syscall numbers (BSD convention, same across darwin arches)
 val SYS_EXIT:             usize = 1;
 val SYS_FORK:             usize = 2;
-val SYS_READ:             usize = 3;
-val SYS_WRITE:            usize = 4;
-val SYS_OPEN:             usize = 5;
 val SYS_CLOSE:            usize = 6;
 val SYS_CHDIR:            usize = 12;
 val SYS_WAIT4:            usize = 7;
@@ -38,17 +36,7 @@ val SYS_MLOCK:            usize = 203;
 val SYS_MUNLOCK:          usize = 204;
 val SYS_EXECVE:           usize = 59;
 val SYS_VFORK:            usize = 66;
-val SYS_LSEEK:            usize = 199;
-val SYS_FSTAT64:          usize = 339;
 val SYS_GETDIRENTRIES64:  usize = 344;
-val SYS_OPENAT:           usize = 463;
-val SYS_MKDIRAT:          usize = 475;
-val SYS_RENAMEAT:         usize = 465;
-val SYS_UNLINKAT:         usize = 472;
-val SYS_FACCESSAT:        usize = 466;
-val SYS_FSTATAT64:        usize = 470;
-val SYS_SYMLINK:          usize = 57;
-val SYS_PIPE:             usize = 42;
 val SYS_SELECT:           usize = 93;
 val SYS_GETTIMEOFDAY:     usize = 116;
 val SYS_CLOCK_GETTIME:    usize = 427;
@@ -68,15 +56,19 @@ val SYS_SETSOCKOPT:       usize = 105;
 val SYS_GETRLIMIT:        usize = 194;
 val RLIMIT_NOFILE:        usize = 8;
 val SYS_DUP2:             usize = 90;
-val SYS_FCNTL:            usize = 92;
 
 val SIGABRT: i32 = 6;
 
-# fcntl flags
-val F_GETPATH:  usize = 50;
-# XNU writes a F_GETPATH result of up to this many bytes whatever the caller
-# sized its destination, so a F_GETPATH destination is never smaller
-val MAXPATHLEN: usize = 1024;
+# fcntl commands
+#
+# F_GETPATH and its MAXPATHLEN companion are gone: they existed only because
+# the raw-syscall backend had no getcwd, and getcwd(3) replaces both.
+pub val F_GETFD: i32 = 1;
+pub val F_SETFD: i32 = 2;
+pub val F_GETFL: i32 = 3;
+pub val F_SETFL: i32 = 4;
+
+pub val FD_CLOEXEC: i32 = 1;
 
 # mmap protection
 val PROT_NONE:  i32 = 0;
@@ -639,12 +631,20 @@ pub fun environ() **u8 {
 }
 
 # filesystem
+#
+# every primitive below calls libSystem and rebuilds this module's outward
+# contract - a count/descriptor on success, a NEGATIVE errno on failure - from
+# libSystem's (-1 plus a thread-local errno). errno is read only after the
+# return value has already reported failure, because a successful call does not
+# clear it; see std.system.os.darwin.libsystem.
 
 pub fun read(fd: i32, buf: *u8, count: usize) i64 {
     var retries: usize = 0;
     for (retries < EINTR_MAX_RETRIES) {
-        val res: i64 = syscall3(SYS_READ, fd::isize::usize, buf::usize, count);
-        if (res != EINTR) { ret res; }
+        val res: i64 = ls.read(fd, buf, count);
+        if (res >= 0) { ret res; }
+        val e: i64 = ls.fail_errno();
+        if (e != EINTR) { ret e; }
         retries = retries + 1;
     }
     ret EINTR;
@@ -653,33 +653,64 @@ pub fun read(fd: i32, buf: *u8, count: usize) i64 {
 pub fun write(fd: i32, buf: *u8, count: usize) i64 {
     var retries: usize = 0;
     for (retries < EINTR_MAX_RETRIES) {
-        val res: i64 = syscall3(SYS_WRITE, fd::isize::usize, buf::usize, count);
-        if (res != EINTR) { ret res; }
+        val res: i64 = ls.write(fd, buf, count);
+        if (res >= 0) { ret res; }
+        val e: i64 = ls.fail_errno();
+        if (e != EINTR) { ret e; }
         retries = retries + 1;
     }
     ret EINTR;
 }
 
+# open a path relative to a directory descriptor
+#
+# `mode` is only consulted by the kernel when `flags` carries O_CREAT, so it is
+# passed in the variadic tail only in that case. the two forms are not
+# interchangeable spellings of one call: apple arm64 passes the whole variadic
+# tail on the stack, so the no-O_CREAT form genuinely passes nothing rather
+# than passing an ignored register.
+# ---
+# dirfd: directory descriptor the path resolves against, or AT_FDCWD
+# path:  null-terminated path
+# flags: O_* flags
+# mode:  permission bits for a created file; ignored without O_CREAT
+# ret:   the new descriptor, or negative errno
 pub fun open(dirfd: i32, path: *u8, flags: i32, mode: i32) i64 {
     var retries: usize = 0;
     for (retries < EINTR_MAX_RETRIES) {
-        val res: i64 = syscall4(SYS_OPENAT, dirfd::isize::usize, path::usize, flags::u32::usize, mode::u32::usize);
-        if (res != EINTR) { ret res; }
+        var res: i32 = 0;
+        if ((flags & O_CREAT) != 0) {
+            res = ls.openat(dirfd, path, flags, mode::u32);
+        }
+        or {
+            res = ls.openat(dirfd, path, flags);
+        }
+        if (res >= 0) { ret res::i64; }
+        val e: i64 = ls.fail_errno();
+        if (e != EINTR) { ret e; }
         retries = retries + 1;
     }
     ret EINTR;
 }
 
+# close a descriptor
+#
+# a failed close does NOT mean the descriptor is still open: darwin has already
+# released it by the time an error is reported. callers must not retry, and
+# none do - the return exists to surface a deferred write error.
 pub fun close(fd: i32) i64 {
-    ret syscall1(SYS_CLOSE, fd::isize::usize);
+    if (ls.close(fd) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 pub fun stat(fd: i32, st: *stat_t) i64 {
-    ret syscall2(SYS_FSTAT64, fd::isize::usize, st::usize);
+    if (ls.fstat(fd, st::usize::*u8) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 pub fun stat_path(dirfd: i32, path: *u8, st: *stat_t, flags: i32) i64 {
-    ret syscall4(SYS_FSTATAT64, dirfd::isize::usize, path::usize, st::usize, flags::u32::usize);
+    if (ls.fstatat(dirfd, path, st::usize::*u8, flags) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 # read the type/permission bits from a filled stat buffer as a 32-bit word
@@ -694,11 +725,13 @@ pub fun stat_mode(st: *stat_t) u32 {
 }
 
 pub fun unlink(dirfd: i32, path: *u8, flags: i32) i64 {
-    ret syscall3(SYS_UNLINKAT, dirfd::isize::usize, path::usize, flags::u32::usize);
+    if (ls.unlinkat(dirfd, path, flags) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
-    ret syscall4(SYS_RENAMEAT, olddir::isize::usize, oldpath::usize, newdir::isize::usize, newpath::usize);
+    if (ls.renameat(olddir, oldpath, newdir, newpath) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 # create a symbolic link at linkpath pointing to target
@@ -710,11 +743,13 @@ pub fun rename(olddir: i32, oldpath: *u8, newdir: i32, newpath: *u8) i64 {
 # linkpath: path of the link to create
 # ret:      0 on success, or negative errno
 pub fun symlink(target: *u8, linkpath: *u8) i64 {
-    ret syscall2(SYS_SYMLINK, target::usize, linkpath::usize);
+    if (ls.symlink(target, linkpath) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 pub fun make_dir(dirfd: i32, path: *u8, mode: i32) i64 {
-    ret syscall3(SYS_MKDIRAT, dirfd::isize::usize, path::usize, mode::u32::usize);
+    if (ls.mkdirat(dirfd, path, mode::u32) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 # darwin uses getdirentries64 instead of getdents64
@@ -724,11 +759,66 @@ pub fun read_dir(fd: i32, dirp: *dirent64, count: usize) i64 {
 }
 
 pub fun access(dirfd: i32, path: *u8, mode: i32, flags: i32) i64 {
-    ret syscall4(SYS_FACCESSAT, dirfd::isize::usize, path::usize, mode::u32::usize, flags::u32::usize);
+    if (ls.faccessat(dirfd, path, mode, flags) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
+# reposition a descriptor's offset
+#
+# lseek's failure sentinel is exactly -1, not "negative": the success value is
+# a file offset, which is never negative but IS returned as a signed 64-bit
+# number that a caller may legitimately compare against. testing for the
+# documented sentinel rather than for a sign keeps that distinction.
+# ---
+# ret: the resulting absolute offset, or negative errno
 pub fun seek(fd: i32, offset: i64, whence: i32) i64 {
-    ret syscall3(SYS_LSEEK, fd::isize::usize, offset::isize::usize, whence::u32::usize);
+    val res: i64 = ls.lseek(fd, offset, whence);
+    if (res == -1) { ret ls.fail_errno(); }
+    ret res;
+}
+
+# read a descriptor's descriptor-level flags (FD_CLOEXEC)
+#
+# F_GETFD is a TWO-argument fcntl: it reads no third argument, so none is
+# passed. that is not a micro-optimisation - on apple arm64 the variadic tail
+# is stack-passed, so "pass a dummy zero" and "pass nothing" put genuinely
+# different bytes at the callee's stack slot. the two forms are kept distinct
+# everywhere fcntl is called.
+# ---
+# ret: the flag word, or negative errno
+pub fun fd_flags(fd: i32) i64 {
+    val r: i32 = ls.fcntl(fd, F_GETFD);
+    if (r < 0) { ret ls.fail_errno(); }
+    ret r::i64;
+}
+
+# set a descriptor's descriptor-level flags
+#
+# F_SETFD is a three-argument fcntl: exactly one int rides the variadic tail.
+# ---
+# ret: 0 on success, or negative errno
+pub fun set_fd_flags(fd: i32, flags: i32) i64 {
+    if (ls.fcntl(fd, F_SETFD, flags) < 0) { ret ls.fail_errno(); }
+    ret 0;
+}
+
+# read a descriptor's file-status flags (access mode, O_APPEND, O_NONBLOCK)
+#
+# F_GETFL, like F_GETFD, takes no third argument.
+# ---
+# ret: the status flag word, or negative errno
+pub fun file_flags(fd: i32) i64 {
+    val r: i32 = ls.fcntl(fd, F_GETFL);
+    if (r < 0) { ret ls.fail_errno(); }
+    ret r::i64;
+}
+
+# set a descriptor's file-status flags
+# ---
+# ret: 0 on success, or negative errno
+pub fun set_file_flags(fd: i32, flags: i32) i64 {
+    if (ls.fcntl(fd, F_SETFL, flags) < 0) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 # process
@@ -1027,32 +1117,310 @@ pub fun cpu_count() i64 {
 
 # get the current working directory
 #
-# F_GETPATH carries no capacity and XNU writes up to MAXPATHLEN bytes into the
-# destination whatever the caller sized it, so it must never be handed a buffer
-# that could be smaller. the path is read into a MAXPATHLEN scratch and copied
-# out only when it fits, which is what makes `size` mean what the signature says
-# it means. a path too long for the caller is ERANGE, as it is on linux (#409).
+# this used to be an open(".") + fcntl(F_GETPATH) dance with a MAXPATHLEN
+# bounce buffer, because F_GETPATH carries no capacity: XNU writes up to
+# MAXPATHLEN bytes into the destination whatever the caller sized it, so the
+# result had to be caught in a large scratch and copied out only when it fit.
+#
+# getcwd(3) TAKES the capacity, so the callee honours `size` itself and a path
+# that does not fit comes back as ERANGE from libSystem rather than as an
+# overrun this function has to defend against afterwards. the scratch buffer,
+# the copy loop, and the F_GETPATH constant all go away with it (#409, #413).
 # ---
 # buf:  destination buffer
 # size: buffer capacity in bytes, including room for the terminator
 # ret:  length of path on success, or negative errno
 pub fun getcwd(buf: *u8, size: usize) i64 {
-    var scratch: [MAXPATHLEN]u8;
-    val fd: i64 = syscall2(SYS_OPEN, "."::usize, O_RDONLY::u32::usize);
-    if (fd < 0) { ret fd; }
-    val res: i64 = syscall3(SYS_FCNTL, fd::usize, F_GETPATH, (?scratch[0])::usize);
-    syscall1(SYS_CLOSE, fd::usize);
-    if (res < 0) { ret res; }
+    if (ls.getcwd(buf, size)::usize == 0) { ret ls.fail_errno(); }
+    ret str_len(buf)::i64;
+}
 
-    val n: usize = str_len(?scratch[0]);
-    if (n + 1 > size) { ret ERANGE; }
-    var i: usize = 0;
-    for (i < n) {
-        buf[i] = scratch[i];
-        i = i + 1;
+# libSystem migration tests
+#
+# these assert the OBSERVABLE EFFECT of each migrated call, not that it
+# returned a non-negative number. the mode assertions in particular are the
+# regression for the apple arm64 variadic ABI: `mode` rides the STACK there,
+# with no register phase, so a wrongly-lowered call hands openat whatever
+# happened to be at the callee's stack slot. that does not fail to link and
+# does not crash - it creates a file with the wrong permissions. only reading
+# the mode back catches it.
+
+# build "/tmp/mach-std-415-<pid>-<tag>" into buf, returning its length
+fun tmp_path(buf: *u8, tag: u8) usize {
+    val prefix: str = "/tmp/mach-std-415-";
+    var n: usize = 0;
+    for (n < str_len(prefix)) { buf[n] = prefix[n]; n = n + 1; }
+    var pid: i64 = getpid();
+    if (pid < 0) { pid = 0; }
+    var digits: [24]u8;
+    var d: usize = 0;
+    if (pid == 0) { digits[0] = '0'::u8; d = 1; }
+    for (pid > 0) {
+        digits[d] = ('0'::u8) + (pid % 10)::u8;
+        pid = pid / 10;
+        d = d + 1;
     }
+    for (d > 0) { d = d - 1; buf[n] = digits[d]; n = n + 1; }
+    buf[n] = '-'::u8; n = n + 1;
+    buf[n] = tag;     n = n + 1;
     buf[n] = 0;
-    ret n::i64;
+    ret n;
+}
+
+# O_CREAT carries `mode` in the variadic tail, and the file really gets it
+#
+# the mask is pinned to 0 for the duration so the expected mode is exact: a
+# subset assertion would still pass if the tail were dropped and openat read a
+# stale stack slot that happened to have the right bits set.
+test "std.system.os.darwin.libsystem:open_creat_applies_the_variadic_mode" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'a'::u8);
+    unlink(AT_FDCWD, ?path[0], 0);
+
+    val saved: u32 = ls.umask(0);
+    val fd: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_RDWR, 0o741);
+    ls.umask(saved);
+    if (fd < 0) { ret 1; }
+    close(fd::i32);
+
+    var st: stat_t;
+    val r: i64 = stat_path(AT_FDCWD, ?path[0], ?st, 0);
+    unlink(AT_FDCWD, ?path[0], 0);
+    if (r != 0) { ret 1; }
+
+    # the exact bits asked for, not merely "some file exists"
+    if ((stat_mode(?st) & 0o777) != 0o741) { ret 1; }
+    if ((stat_mode(?st) & S_IFMT) != S_IFREG) { ret 1; }
+    ret 0;
+}
+
+# a second O_CREAT|O_EXCL on the same path is EEXIST, not "an error"
+test "std.system.os.darwin.libsystem:open_excl_twice_is_eexist" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'b'::u8);
+    unlink(AT_FDCWD, ?path[0], 0);
+
+    val first: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_EXCL | O_WRONLY, 0o600);
+    if (first < 0) { ret 1; }
+    close(first::i32);
+
+    val second: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_EXCL | O_WRONLY, 0o600);
+    unlink(AT_FDCWD, ?path[0], 0);
+    if (second != EEXIST) { ret 1; }
+    ret 0;
+}
+
+# opening a path that is not there is ENOENT specifically
+#
+# this is the two-argument openat form: no O_CREAT, so nothing rides the
+# variadic tail at all.
+test "std.system.os.darwin.libsystem:open_missing_path_is_enoent" {
+    if (open(AT_FDCWD, "/tmp/mach-std-415-definitely-absent/x", O_RDONLY, 0) != ENOENT) {
+        ret 1;
+    }
+    ret 0;
+}
+
+# a bad descriptor is EBADF, and errno survives being read through __error
+test "std.system.os.darwin.libsystem:close_bad_descriptor_is_ebadf" {
+    if (close(-1) != EBADF) { ret 1; }
+    ret 0;
+}
+
+# F_SETFD really sets the flag F_GETFD then reads back
+#
+# F_SETFD passes one int in the variadic tail; F_GETFD passes none. a round
+# trip through both proves the two forms are lowered distinctly - if the
+# no-tail form were lowered as if it had a tail, or vice versa, the flag word
+# read back would not be the one written.
+test "std.system.os.darwin.libsystem:fcntl_fd_cloexec_round_trip" {
+    var fds: [2]i32;
+    if (ls.pipe(?fds[0]) < 0) { ret 1; }
+
+    var rc: i32 = 0;
+    if (fd_flags(fds[0]) != 0) { rc = 1; }
+
+    if (rc == 0 && set_fd_flags(fds[0], FD_CLOEXEC) != 0) { rc = 1; }
+    if (rc == 0 && fd_flags(fds[0]) != FD_CLOEXEC::i64) { rc = 1; }
+
+    # and clearing it takes effect too, so the previous read was not just a
+    # constant that happened to match
+    if (rc == 0 && set_fd_flags(fds[0], 0) != 0) { rc = 1; }
+    if (rc == 0 && fd_flags(fds[0]) != 0) { rc = 1; }
+
+    close(fds[0]);
+    close(fds[1]);
+    ret rc;
+}
+
+# O_APPEND set at open time is visible through F_GETFL
+test "std.system.os.darwin.libsystem:fcntl_getfl_reports_open_flags" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'c'::u8);
+    unlink(AT_FDCWD, ?path[0], 0);
+
+    val fd: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_WRONLY | O_APPEND, 0o600);
+    if (fd < 0) { ret 1; }
+
+    var rc: i32 = 0;
+    val fl: i64 = file_flags(fd::i32);
+    if (fl < 0)                          { rc = 1; }
+    if (rc == 0 && (fl & O_APPEND::i64) == 0) { rc = 1; }
+
+    close(fd::i32);
+    unlink(AT_FDCWD, ?path[0], 0);
+    ret rc;
+}
+
+# a pipe actually carries bytes end to end
+test "std.system.os.darwin.libsystem:pipe_round_trips_bytes" {
+    var fds: [2]i32;
+    if (ls.pipe(?fds[0]) < 0) { ret 1; }
+
+    var out: [4]u8;
+    out[0] = 'm'::u8; out[1] = 'a'::u8; out[2] = 'c'::u8; out[3] = 'h'::u8;
+
+    var rc: i32 = 0;
+    if (write(fds[1], ?out[0], 4) != 4) { rc = 1; }
+
+    var back: [4]u8;
+    back[0] = 0; back[1] = 0; back[2] = 0; back[3] = 0;
+    if (rc == 0 && read(fds[0], ?back[0], 4) != 4) { rc = 1; }
+    if (rc == 0 && (back[0] != 'm'::u8 || back[1] != 'a'::u8
+                 || back[2] != 'c'::u8 || back[3] != 'h'::u8)) { rc = 1; }
+
+    close(fds[0]);
+    close(fds[1]);
+    ret rc;
+}
+
+# written bytes come back after a seek, and seek reports the absolute offset
+test "std.system.os.darwin.libsystem:write_seek_read_round_trip" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'd'::u8);
+    unlink(AT_FDCWD, ?path[0], 0);
+
+    val fd: i64 = open(AT_FDCWD, ?path[0], O_CREAT | O_RDWR, 0o600);
+    if (fd < 0) { ret 1; }
+    val d: i32 = fd::i32;
+
+    var rc: i32 = 0;
+    var out: [5]u8;
+    out[0] = 'h'::u8; out[1] = 'e'::u8; out[2] = 'l'::u8; out[3] = 'l'::u8; out[4] = 'o'::u8;
+    if (write(d, ?out[0], 5) != 5) { rc = 1; }
+
+    # SEEK_END reports the size the writes produced
+    if (rc == 0 && seek(d, 0, SEEK_END) != 5) { rc = 1; }
+    if (rc == 0 && seek(d, 1, SEEK_SET) != 1) { rc = 1; }
+
+    var back: [4]u8;
+    if (rc == 0 && read(d, ?back[0], 4) != 4) { rc = 1; }
+    if (rc == 0 && (back[0] != 'e'::u8 || back[1] != 'l'::u8
+                 || back[2] != 'l'::u8 || back[3] != 'o'::u8)) { rc = 1; }
+
+    # and stat agrees about the size, through the $INODE64-gated fstat
+    var st: stat_t;
+    if (rc == 0 && stat(d, ?st) != 0) { rc = 1; }
+    if (rc == 0 && st.st_size != 5)   { rc = 1; }
+
+    close(d);
+    unlink(AT_FDCWD, ?path[0], 0);
+    ret rc;
+}
+
+# mkdir creates a directory, and stat says so
+test "std.system.os.darwin.libsystem:make_dir_creates_a_directory" {
+    var path: [64]u8;
+    tmp_path(?path[0], 'e'::u8);
+    unlink(AT_FDCWD, ?path[0], AT_REMOVEDIR);
+
+    val saved: u32 = ls.umask(0);
+    val r: i64 = make_dir(AT_FDCWD, ?path[0], 0o751);
+    ls.umask(saved);
+    if (r != 0) { ret 1; }
+
+    var st: stat_t;
+    var rc: i32 = 0;
+    if (stat_path(AT_FDCWD, ?path[0], ?st, 0) != 0) { rc = 1; }
+    if (rc == 0 && (stat_mode(?st) & S_IFMT) != S_IFDIR) { rc = 1; }
+    if (rc == 0 && (stat_mode(?st) & 0o777) != 0o751)    { rc = 1; }
+
+    unlink(AT_FDCWD, ?path[0], AT_REMOVEDIR);
+    ret rc;
+}
+
+# rename moves the file: the new name resolves and the old one is ENOENT
+test "std.system.os.darwin.libsystem:rename_moves_the_file" {
+    var from: [64]u8;
+    var to:   [64]u8;
+    tmp_path(?from[0], 'f'::u8);
+    tmp_path(?to[0],   'g'::u8);
+    unlink(AT_FDCWD, ?from[0], 0);
+    unlink(AT_FDCWD, ?to[0],   0);
+
+    val fd: i64 = open(AT_FDCWD, ?from[0], O_CREAT | O_WRONLY, 0o600);
+    if (fd < 0) { ret 1; }
+    close(fd::i32);
+
+    var rc: i32 = 0;
+    if (rename(AT_FDCWD, ?from[0], AT_FDCWD, ?to[0]) != 0) { rc = 1; }
+
+    var st: stat_t;
+    if (rc == 0 && stat_path(AT_FDCWD, ?to[0], ?st, 0) != 0)        { rc = 1; }
+    if (rc == 0 && stat_path(AT_FDCWD, ?from[0], ?st, 0) != ENOENT) { rc = 1; }
+
+    unlink(AT_FDCWD, ?from[0], 0);
+    unlink(AT_FDCWD, ?to[0],   0);
+    ret rc;
+}
+
+# a symlink resolves to its target, and AT_SYMLINK_NOFOLLOW sees the link
+test "std.system.os.darwin.libsystem:symlink_is_a_link_to_its_target" {
+    var target: [64]u8;
+    var link:   [64]u8;
+    tmp_path(?target[0], 'h'::u8);
+    tmp_path(?link[0],   'i'::u8);
+    unlink(AT_FDCWD, ?target[0], 0);
+    unlink(AT_FDCWD, ?link[0],   0);
+
+    val fd: i64 = open(AT_FDCWD, ?target[0], O_CREAT | O_WRONLY, 0o600);
+    if (fd < 0) { ret 1; }
+    close(fd::i32);
+
+    var rc: i32 = 0;
+    if (symlink(?target[0], ?link[0]) != 0) { rc = 1; }
+
+    var st: stat_t;
+    # following the link lands on a regular file
+    if (rc == 0 && stat_path(AT_FDCWD, ?link[0], ?st, 0) != 0)      { rc = 1; }
+    if (rc == 0 && (stat_mode(?st) & S_IFMT) != S_IFREG)            { rc = 1; }
+    # not following it shows the link itself
+    if (rc == 0 && stat_path(AT_FDCWD, ?link[0], ?st, AT_SYMLINK_NOFOLLOW) != 0) { rc = 1; }
+    if (rc == 0 && (stat_mode(?st) & S_IFMT) != S_IFLNK)            { rc = 1; }
+
+    unlink(AT_FDCWD, ?link[0],   0);
+    unlink(AT_FDCWD, ?target[0], 0);
+    ret rc;
+}
+
+# errno is not cleared by a successful call, so a success must never consult it
+#
+# the trap this guards: provoke a failure to leave a non-zero errno behind,
+# then make a call that SUCCEEDS. a wrapper that read errno unconditionally
+# instead of only after its sentinel fired would report the stale ENOENT here.
+test "std.system.os.darwin.libsystem:stale_errno_does_not_poison_a_success" {
+    if (open(AT_FDCWD, "/tmp/mach-std-415-definitely-absent/x", O_RDONLY, 0) != ENOENT) {
+        ret 1;
+    }
+    if (ls.errno() != 2) { ret 1; }
+
+    var fds: [2]i32;
+    if (ls.pipe(?fds[0]) < 0) { ret 1; }
+    var rc: i32 = 0;
+    if (fd_flags(fds[0]) != 0) { rc = 1; }
+    close(fds[0]);
+    close(fds[1]);
+    ret rc;
 }
 
 # a destination too small for the path is refused rather than overrun

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -93,14 +93,8 @@ val SEEK_CUR: i32 = 1;
 val SEEK_END: i32 = 2;
 
 # thread creation (bsdthread)
-val SYS_BSDTHREAD_CREATE:    usize = 360;
-val SYS_BSDTHREAD_TERMINATE: usize = 361;
-val SYS_BSDTHREAD_REGISTER:  usize = 366;
 
 # ulock (futex equivalent)
-val SYS_ULOCK_WAIT: usize = 515;
-val SYS_ULOCK_WAKE: usize = 516;
-val UL_COMPARE_AND_WAIT64: usize = 5;
 
 # kernel ABI types
 
@@ -1494,121 +1488,422 @@ pub fun getenv(name: *u8, buf: *u8, cap: usize) i64 {
 }
 
 # threads
-
-var thread_registered: i64 = 0;
-
-# the bsdthread body: run the user function, flag completion, wake a joiner, and
-# terminate the thread (releasing its stack). the kernel never reaches this
-# directly - `thread_start` below is the registered entry and tails in through a
-# `call`/`b`, so the platform function-entry ABI (notably x86_64 stack alignment)
-# holds before any real work runs.
-# ---
-# self:      kernel thread self pointer (unused)
-# kport:     mach thread port, passed to bsdthread_terminate
-# func:      user function to run on the thread
-# arg:       pointer to the [done, stack_base, stack_size, user] context at the stack base
-# stacksize: kernel stack size (unused; the real size travels in the context)
-# pflags:    kernel pthread flags (unused)
-#[symbol("_std_darwin_thread_start_impl")]
-fun thread_start_impl(self: usize, kport: usize, func: usize, arg: usize, stacksize: usize, pflags: usize) {
-    val ctx: *usize = arg::*usize;
-    val done_addr: usize = ctx[0];
-    val stack_base: usize = ctx[1];
-    val stack_size: usize = ctx[2];
-    val user: usize = ctx[3];
-    val fn_ptr: fun(*u8) = func::fun(*u8);
-    fn_ptr(user::*u8);
-    val done: *i64 = done_addr::*i64;
-    @done = 1;
-    syscall3(SYS_ULOCK_WAKE, UL_COMPARE_AND_WAIT64, done_addr, 0);
-    syscall4(SYS_BSDTHREAD_TERMINATE, stack_base, stack_size, kport, 0);
-}
-
-# the bsdthread_create kernel entry point (registered via bsdthread_register)
 #
-# the kernel JUMPS here with the six thread arguments in registers and the thread's
-# initial stack pointer set to the stack top passed to bsdthread_create - it does
-# not `call`, so on x86_64 the stack lands 16-aligned rather than the (rsp+8)%16==0
-# the SysV ABI guarantees at a function entry (the return address a `call` would
-# have pushed). a compiled body would then run every stack access, and the user
-# function it calls, on a stack skewed by 8, so the first 16-byte-aligned SSE spill
-# faults. realign the stack and enter the compiled body through a `call`, which
-# restores the entry contract - the same fixup `_start` applies. aarch64 keeps SP
-# 16-aligned across a branch (a return address never lands on the stack), so it
-# tails straight into the body. naked: the inline asm owns the stack, no prologue.
-#[symbol("_std_darwin_thread_start")]
-fun thread_start() {
-    $if ($mach.build.arch == $mach.arch.x86_64) {
-        asm x86_64 {
-            and rsp, -16
-            call _std_darwin_thread_start_impl
-            hlt
-        }
-    }
-    $or ($mach.build.arch == $mach.arch.aarch64) {
-        asm aarch64 {
-            b _std_darwin_thread_start_impl
-        }
-    }
-}
+# pthread, not bsdthread. `bsdthread_register` published a workqueue callback
+# the kernel invokes, versioned against the libpthread that shipped with the
+# OS: an internal kernel<->libpthread protocol this module was impersonating
+# rather than an ABI. It stopped working - the three `std.sync.thread` tests
+# were failing on darwin before this change - and it was also the reason the
+# rest of the migration could not proceed, because libSystem reaches errno
+# through a thread-local that only exists on a thread libpthread created.
+#
+# the shape of the OS-layer contract is unchanged: `thread_spawn` still takes a
+# caller-allocated region and a completion flag, and `thread_wait`/`thread_wake`
+# are still address-keyed. what changed underneath is who owns the stack. the
+# caller's region is now a CONTEXT BLOCK only - pthread allocates and frees the
+# real stack from `stack_size` - which is exactly how the windows backend has
+# always used it (see `thread_trampoline` there). the context block is released
+# by the new thread itself, so an unjoined thread still reclaims it, matching
+# what `bsdthread_terminate` used to do.
 
-# workqueue thread callback (unused, required by bsdthread_register)
-fun thread_wq_start(self: usize, kport: usize, saddr: usize, arg: usize, cnt: usize, flags: usize) {
-    syscall4(SYS_BSDTHREAD_TERMINATE, 0, 0, 0, 0);
-}
+# ## the address-keyed wait, and why it is a table of condition variables
+#
+# `thread_wait`/`thread_wake` are a futex-shaped contract: linux has `futex`
+# and windows has `WaitOnAddress`, both of which take the address directly.
+# darwin's equivalent is `__ulock_wait`/`__ulock_wake`, which is private - as
+# private as the bsdthread traps - so it is not available to us. the public
+# replacement, `os_sync_wait_on_address`, is macOS 14.4+ and adopting it would
+# quietly raise this library's deployment floor.
+#
+# so the address-keyed wait is built from pthread condition variables, which
+# are public and have existed forever. a fixed table of (mutex, cond) pairs is
+# hashed by address. that is a real hash table, with real collisions: two
+# distinct addresses can share a bucket. the consequences are handled rather
+# than hoped away -
+#
+#   - `thread_wake` BROADCASTS. with a shared bucket, `signal` could hand the
+#     one wakeup to a waiter on an unrelated address and lose ours.
+#   - a waiter therefore sees wakeups that are not for it. the contract already
+#     documents spurious wakeups, and the only consumer (`sync.thread.join`)
+#     re-tests its flag in a loop, which is what a condition variable requires
+#     of every caller anyway.
+#
+# the lost-wakeup race is closed by the lock discipline, not by luck: the
+# waiter re-reads the address UNDER the bucket mutex and `pthread_cond_wait`
+# releases that mutex atomically, while `thread_wake` must acquire the same
+# mutex before it can broadcast. so a wake can never land in the window
+# between the waiter's test and its sleep.
 
-fun ensure_thread_registered() {
-    if (atomic.load(?thread_registered) != 0) { ret; }
+val WAIT_BUCKETS: usize = 64;
+
+var wait_mutexes: [4096]u8;   # WAIT_BUCKETS * PTHREAD_MUTEX_BYTES (64 * 64)
+var wait_conds:   [3072]u8;   # WAIT_BUCKETS * PTHREAD_COND_BYTES  (64 * 48)
+
+# 0 = untouched, 1 = one thread is initializing, 2 = ready
+var wait_ready: i64 = 0;
+
+# initialize the bucket table exactly once, whoever gets there first
+#
+# a plain compare-and-swap would let the loser proceed on half-built mutexes,
+# so the loser waits for the winner to publish state 2 rather than assuming the
+# swap it lost meant the work was done.
+fun ensure_wait_tables() {
+    if (atomic.load(?wait_ready) == 2) { ret; }
     var expected: i64 = 0;
-    if (!atomic.cas(?thread_registered, ?expected, 1)) { ret; }
-    val start: fun() = thread_start;
-    val wq: fun(usize, usize, usize, usize, usize, usize) = thread_wq_start;
-    syscall6(SYS_BSDTHREAD_REGISTER, start::usize, wq::usize, 64, 0, 0, 0);
+    if (atomic.cas(?wait_ready, ?expected, 1)) {
+        var i: usize = 0;
+        for (i < WAIT_BUCKETS) {
+            ls.pthread_mutex_init(?wait_mutexes[i * ls.PTHREAD_MUTEX_BYTES], nil);
+            ls.pthread_cond_init(?wait_conds[i * ls.PTHREAD_COND_BYTES], nil);
+            i = i + 1;
+        }
+        atomic.store(?wait_ready, 2);
+        ret;
+    }
+    for (atomic.load(?wait_ready) != 2) { atomic.spin_hint(); }
 }
 
-# create a new thread via bsdthread_create
+# pick a bucket for a futex address
 #
-# registers the thread start callback on first call, then creates a
-# thread that calls f(arg). the kernel passes f and the context pointer
-# through to the registered callback, which calls f(arg), sets *done_ptr
-# to 1, wakes waiters, and terminates the thread. arg travels in the
-# fourth context word alongside done_ptr and the stack bounds.
+# the low three bits are dead (the word is 8-byte aligned), so they are shifted
+# off before mixing rather than being allowed to collapse the table to a
+# fraction of its buckets.
+fun wait_bucket(addr: usize) usize {
+    var h: usize = addr >> 3;
+    h = h ^ (h >> 11);
+    ret h % WAIT_BUCKETS;
+}
+
+# the pthread start routine
+#
+# receives the caller's context block, whose five words are [fn, done, base,
+# size, user]. it runs on a stack pthread allocated, NOT on the context block,
+# which is why the block can be released here: nothing this function or the
+# user body touches lives in it once the five words have been copied out.
+# releasing it here rather than in `join` means a thread nobody joins still
+# reclaims its memory, which is the behaviour `bsdthread_terminate` gave.
+#
+# declared returning `usize` where C says `void *`: the value is discarded (the
+# thread is detached) and a 64-bit zero in the return register is the same
+# thing a `return NULL` puts there.
+# ---
+# arg: the context block address, as handed to pthread_create
+# ret: always 0, never read
+fun thread_entry(arg: ptr) usize {
+    val ctx: *usize = arg::usize::*usize;
+    val fn_addr:    usize = ctx[0];
+    val done_addr:  usize = ctx[1];
+    val stack_base: usize = ctx[2];
+    val stack_size: usize = ctx[3];
+    val user:       usize = ctx[4];
+
+    deallocate(stack_base::ptr, stack_size);
+
+    val fn_ptr: fun(*u8) = fn_addr::fun(*u8);
+    fn_ptr(user::*u8);
+
+    val done: *i64 = done_addr::*i64;
+    atomic.store(done, 1);
+    thread_wake(done);
+    ret 0;
+}
+
+# create a new thread via pthread_create
+#
+# the thread is created DETACHED. joining is done by `sync.thread.join`, which
+# waits on the completion flag rather than calling pthread_join, so a joinable
+# pthread would leave its descriptor unreaped forever. detaching hands that
+# cleanup to libpthread and keeps the flag as the single synchronisation point.
+#
+# note the error contract: pthread_* return the error number directly and do
+# NOT set errno, so these results are negated as they stand and `fail_errno`
+# is deliberately not used anywhere in this function.
 # ---
 # f:          entry function to execute in the new thread
 # arg:        opaque pointer passed through to f
 # done_ptr:   pointer to a completion flag (set to 1 when thread exits)
-# stack_base: base address of the pre-allocated stack region
-# stack_size: size of the stack in bytes
-# ret:        thread ID on success, or negative errno on failure
+# stack_base: base of a caller-allocated region used as the context block;
+#             released by the new thread, or by the caller if this call fails
+# stack_size: size of the stack pthread will allocate for the thread
+# ret:        thread handle on success, or negative errno on failure
 pub fun thread_spawn(f: fun(*u8), arg: *u8, done_ptr: *i64, stack_base: usize, stack_size: usize) i64 {
-    ensure_thread_registered();
     val ctx: *usize = stack_base::*usize;
-    ctx[0] = done_ptr::usize;
-    ctx[1] = stack_base;
-    ctx[2] = stack_size;
-    ctx[3] = arg::usize;
-    val stack_top: usize = stack_base + stack_size;
-    ret syscall5(SYS_BSDTHREAD_CREATE, f::usize, ctx::usize, stack_top, 0, 0);
+    ctx[0] = f::usize;
+    ctx[1] = done_ptr::usize;
+    ctx[2] = stack_base;
+    ctx[3] = stack_size;
+    ctx[4] = arg::usize;
+
+    var attr: [64]u8;
+    var rc: i32 = ls.pthread_attr_init(?attr[0]);
+    if (rc != 0) { ret -(rc::i64); }
+
+    rc = ls.pthread_attr_setstacksize(?attr[0], stack_size);
+    if (rc == 0) {
+        rc = ls.pthread_attr_setdetachstate(?attr[0], ls.PTHREAD_CREATE_DETACHED);
+    }
+
+    var tid: usize = 0;
+    if (rc == 0) {
+        val entry: fun(ptr) usize = thread_entry;
+        rc = ls.pthread_create(?tid, ?attr[0], entry::usize, stack_base::ptr);
+    }
+    ls.pthread_attr_destroy(?attr[0]);
+
+    if (rc != 0) { ret -(rc::i64); }
+
+    # a darwin user-space pointer never sets the top bit, so the handle is
+    # always positive and cannot be mistaken for the negative-errno failure
+    # this function's contract returns.
+    ret tid::i64;
 }
 
 # block until the value at addr changes from expected
 #
-# wraps __ulock_wait with UL_COMPARE_AND_WAIT64. returns immediately
-# if *addr does not equal expected. spurious wakeups are possible.
+# returns immediately if *addr does not equal expected. spurious wakeups are
+# possible and are expected: bucket sharing means a wake for a different
+# address can land here (see the bucket-table note above), so every caller must
+# re-test its own condition in a loop.
 # ---
 # addr:     pointer to the futex word
 # expected: value to compare against
 # ret:      0 on wake, or negative errno
 pub fun thread_wait(addr: *i64, expected: i64) i64 {
-    ret syscall4(SYS_ULOCK_WAIT, UL_COMPARE_AND_WAIT64, addr::usize, expected::usize, 0);
+    ensure_wait_tables();
+    val b: usize = wait_bucket(addr::usize);
+    val m: *u8 = ?wait_mutexes[b * ls.PTHREAD_MUTEX_BYTES];
+    val c: *u8 = ?wait_conds[b * ls.PTHREAD_COND_BYTES];
+
+    var rc: i32 = ls.pthread_mutex_lock(m);
+    if (rc != 0) { ret -(rc::i64); }
+
+    # the re-test happens under the bucket mutex, and pthread_cond_wait drops
+    # that mutex atomically. thread_wake cannot broadcast without holding it,
+    # so no wake fits between this load and the sleep.
+    var wr: i32 = 0;
+    if (atomic.load(addr) == expected) {
+        wr = ls.pthread_cond_wait(c, m);
+    }
+
+    val ur: i32 = ls.pthread_mutex_unlock(m);
+    if (wr != 0) { ret -(wr::i64); }
+    if (ur != 0) { ret -(ur::i64); }
+    ret 0;
 }
 
-# wake one thread blocked on a ulock wait at addr
+# wake threads blocked in thread_wait on addr
+#
+# broadcasts rather than signals: buckets are shared by address hash, so a
+# signal could be delivered to a waiter on an unrelated address and the wake
+# this call was meant to deliver would be lost.
 # ---
 # addr: pointer to the futex word
-# ret:  number of threads woken, or negative errno
+# ret:  0 on success, or negative errno
 pub fun thread_wake(addr: *i64) i64 {
-    ret syscall3(SYS_ULOCK_WAKE, UL_COMPARE_AND_WAIT64, addr::usize, 0);
+    ensure_wait_tables();
+    val b: usize = wait_bucket(addr::usize);
+    val m: *u8 = ?wait_mutexes[b * ls.PTHREAD_MUTEX_BYTES];
+    val c: *u8 = ?wait_conds[b * ls.PTHREAD_COND_BYTES];
+
+    var rc: i32 = ls.pthread_mutex_lock(m);
+    if (rc != 0) { ret -(rc::i64); }
+
+    val br: i32 = ls.pthread_cond_broadcast(c);
+    val ur: i32 = ls.pthread_mutex_unlock(m);
+    if (br != 0) { ret -(br::i64); }
+    if (ur != 0) { ret -(ur::i64); }
+    ret 0;
+}
+
+# pthread migration tests
+#
+# the OS-layer thread primitives, asserted for effect. `std.sync.thread` covers
+# the portable API on top of these; what is tested here is what is specific to
+# the darwin implementation and could be wrong without the portable tests
+# noticing - the opaque object sizes, the release of the context block, and the
+# bucket sharing in the address-keyed wait.
+
+val TEST_REGION: usize = 2097152;
+
+rec TestThread {
+    done: i64;
+    base: usize;
+}
+
+fun tt_spawn(f: fun(*u8), arg: *u8, t: *TestThread) i64 {
+    t.done = 0;
+    t.base = 0;
+    val base: usize = allocate(TEST_REGION)::usize;
+    if (base == 0) { ret -1; }
+    t.base = base;
+    val r: i64 = thread_spawn(f, arg, ?t.done, base, TEST_REGION);
+    if (r < 0) {
+        deallocate(base::ptr, TEST_REGION);
+        t.base = 0;
+    }
+    ret r;
+}
+
+fun tt_join(t: *TestThread) {
+    for (atomic.load(?t.done) == 0) {
+        thread_wait(?t.done, 0);
+    }
+}
+
+var tw_flag: i64 = 0;
+
+fun tw_setter(arg: *u8) {
+    atomic.store(?tw_flag, 7);
+}
+
+fun tw_add100(arg: *u8) {
+    val slot: *i64 = arg::*i64;
+    atomic.store(slot, atomic.load(slot) + 100);
+}
+
+# PTHREAD_MUTEX_BYTES is big enough for what pthread_mutex_init writes
+#
+# this asserts the SIZE, not the constant. an under-sized figure would let
+# pthread scribble past the object into whatever follows it in the bucket
+# table, so the check is that a guard region behind a real, initialized,
+# locked and unlocked mutex is still untouched.
+test "std.system.os.darwin.libsystem:pthread_mutex_fits_its_declared_size" {
+    var slab: [192]u8;
+    var i: usize = 0;
+    for (i < 192) { slab[i] = 0xC7; i = i + 1; }
+
+    if (ls.pthread_mutex_init(?slab[0], nil) != 0) { ret 1; }
+    if (ls.pthread_mutex_lock(?slab[0]) != 0)      { ret 1; }
+    if (ls.pthread_mutex_unlock(?slab[0]) != 0)    { ret 1; }
+
+    i = ls.PTHREAD_MUTEX_BYTES;
+    for (i < 192) {
+        if (slab[i] != 0xC7) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# PTHREAD_COND_BYTES is big enough for what pthread_cond_init writes
+test "std.system.os.darwin.libsystem:pthread_cond_fits_its_declared_size" {
+    var slab: [192]u8;
+    var i: usize = 0;
+    for (i < 192) { slab[i] = 0xD3; i = i + 1; }
+
+    if (ls.pthread_cond_init(?slab[0], nil) != 0)      { ret 1; }
+    if (ls.pthread_cond_broadcast(?slab[0]) != 0)      { ret 1; }
+
+    i = ls.PTHREAD_COND_BYTES;
+    for (i < 192) {
+        if (slab[i] != 0xD3) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# a spawned thread runs its body, and the waiter is released by its wake
+test "std.system.os.darwin.libsystem:thread_spawn_runs_body_and_wakes_waiter" {
+    atomic.store(?tw_flag, 0);
+    var t: TestThread;
+    if (tt_spawn(tw_setter, nil, ?t) < 0) { ret 1; }
+    tt_join(?t);
+    if (atomic.load(?tw_flag) != 7) { ret 1; }
+    ret 0;
+}
+
+# the context block is released by the thread, not leaked
+#
+# `thread_entry` frees the caller's region before it runs the body, so by the
+# time the completion flag is set the region is already unmapped. mprotect over
+# an unmapped range fails, which is the observable. nothing allocates between
+# the join and the probe, so the range cannot have been handed to something
+# else in the meantime.
+test "std.system.os.darwin.libsystem:thread_releases_its_context_block" {
+    atomic.store(?tw_flag, 0);
+    var t: TestThread;
+    if (tt_spawn(tw_setter, nil, ?t) < 0) { ret 1; }
+    val base: usize = t.base;
+    tt_join(?t);
+    if (atomic.load(?tw_flag) != 7) { ret 1; }
+
+    if (protect(base::ptr, TEST_REGION, PROT_READ::u32) >= 0) { ret 1; }
+    ret 0;
+}
+
+# each thread gets its own userdata pointer and every one of them runs
+test "std.system.os.darwin.libsystem:threads_receive_distinct_userdata" {
+    var slots: [4]i64;
+    var ts:    [4]TestThread;
+    var i: usize = 0;
+    for (i < 4) { slots[i] = i::i64; i = i + 1; }
+
+    i = 0;
+    for (i < 4) {
+        if (tt_spawn(tw_add100, (?slots[i])::*u8, ?ts[i]) < 0) { ret 1; }
+        i = i + 1;
+    }
+
+    i = 0;
+    for (i < 4) { tt_join(?ts[i]); i = i + 1; }
+
+    i = 0;
+    for (i < 4) {
+        if (slots[i] != (i::i64) + 100) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# thread_wait does not block when the word already differs from `expected`
+#
+# the guard that keeps `join` from sleeping on an already-finished thread. a
+# wait that ignored the comparison would hang here rather than fail.
+test "std.system.os.darwin.libsystem:thread_wait_returns_when_value_differs" {
+    var word: i64 = 5;
+    if (thread_wait(?word, 0) != 0) { ret 1; }
+    if (word != 5) { ret 1; }
+    ret 0;
+}
+
+# two waiters whose words share a bucket are both delivered
+#
+# the buckets are a hash table over addresses, so distinct words collide. this
+# builds a genuine collision rather than assuming one, and drives both to
+# completion. a `signal` in thread_wake instead of a `broadcast` can hand the
+# single wakeup to the wrong waiter here and stall.
+test "std.system.os.darwin.libsystem:colliding_wait_addresses_are_both_woken" {
+    var slots: [256]i64;
+    var i: usize = 0;
+    for (i < 256) { slots[i] = 0; i = i + 1; }
+
+    # find two distinct words that hash to the same bucket
+    var a: usize = 0;
+    var b: usize = 0;
+    var found: bool = false;
+    i = 0;
+    for (i < 256 && !found) {
+        var j: usize = i + 1;
+        for (j < 256 && !found) {
+            if (wait_bucket((?slots[i])::usize) == wait_bucket((?slots[j])::usize)) {
+                a = i; b = j; found = true;
+            }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    if (!found) { ret 1; }
+
+    var ta: TestThread;
+    var tb: TestThread;
+    if (tt_spawn(tw_add100, (?slots[a])::*u8, ?ta) < 0) { ret 1; }
+    if (tt_spawn(tw_add100, (?slots[b])::*u8, ?tb) < 0) { ret 1; }
+
+    tt_join(?ta);
+    tt_join(?tb);
+
+    if (slots[a] != 100) { ret 1; }
+    if (slots[b] != 100) { ret 1; }
+    ret 0;
 }
 
 # sockets

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -6,6 +6,7 @@
 use std.types.size.usize;
 
 use std.system.os.darwin.shared;
+use ls: std.system.os.darwin.libsystem;
 
 $if ($mach.build.os != $mach.os.darwin) {
     $error("std.system.os.darwin.x86_64: requires darwin target");
@@ -21,30 +22,18 @@ pub fun page_size() usize {
 
 # create a unidirectional pipe
 #
-# darwin pipe() returns two fds in rax/rdx and signals failure via the
-# carry flag, neither of which the syscall DSL captures, so this uses raw
-# asm. the inline-asm encoder only branches to symbols (issue #216), so the
-# carry flag is materialized into a register (`setc`) and the branching
-# happens in mach code instead of the asm block.
+# this was hand-written asm for one reason: the raw XNU pipe trap returns the
+# two descriptors in rax/rdx and signals failure through the carry flag, and the
+# syscall DSL captures neither. libSystem's pipe(2) is an ordinary C function
+# that writes both descriptors through the caller's array and reports failure
+# as -1, so the arch-specific asm has nothing left to do and the wrapper is now
+# identical on both darwin architectures - it lives here only because `pipe` is
+# part of the per-arch module's published surface.
 # ---
 # fds: pointer to two i32s; fds[0] = read end, fds[1] = write end
 # ret: 0 on success, or negative errno
 pub fun pipe(fds: *i32) i64 {
-    var fd0: i64 = 0;
-    var fd1: i64 = 0;
-    var fail: i64 = 0;
-    asm x86_64 {
-        mov eax, 0x200002A
-        syscall
-        mov rcx, 0
-        setc cl
-        mov {fail}, rcx
-        mov {fd0}, rax
-        mov {fd1}, rdx
-    }
-    if (fail != 0) { ret -fd0; }
-    fds[0] = fd0::i32;
-    fds[1] = fd1::i32;
+    if (ls.pipe(fds) < 0) { ret ls.fail_errno(); }
     ret 0;
 }
 

--- a/test/darwin/known-failures.txt
+++ b/test/darwin/known-failures.txt
@@ -1,0 +1,36 @@
+# tests that already fail on darwin BEFORE the libSystem migration (#415)
+#
+# this file is not a mute button. the darwin suite had never been executed by CI
+# until #462 added a native macOS lane, and its first run found eleven failures
+# on BOTH architectures, identically. they were confirmed to predate the
+# migration by running the untouched `dev` tree on the same two runners: dev
+# reports 777 passed / 11 failed, and the exact same eleven names.
+#
+# every one of them is in a subsystem still issuing raw BSD traps, which is the
+# thesis of #415 stated as a test result:
+#
+#   chrono.time    -- clock_gettime through syscall 427. `now()` comes back
+#                     below the epoch, so the number the trap returns is not a
+#                     time. macOS has exported clock_gettime(3) from libSystem
+#                     since 10.12.
+#   process.exec   -- fork / execve / wait4 through raw traps.
+#   sync.thread    -- bsdthread_create + bsdthread_register, the private
+#                     kernel<->libpthread handshake #415 calls out by name as
+#                     the most fragile thing on the least stable surface.
+#
+# the verify script fails the build on any failure NOT listed here, and equally
+# on any listed test that starts PASSING. so this cannot silently rot: fixing
+# one forces its removal, and regressing a new one is caught. the list must
+# reach empty as the rest of #415 lands, and it is the checklist for doing so.
+
+time: now returns non-zero
+time: since returns positive for past time
+time: monotonic returns non-zero
+std.process.exec.run:success_exits_zero
+std.process.exec.run:failure_exits_one
+std.process.exec.spawn:wait_matches_run
+std.process.exec.run:repeated_spawns_stay_correct
+std.process.exec.wait_any:reaps_each_child_once
+thread: spawn and join
+thread: is_done after join
+thread: spawn_with delivers distinct userdata

--- a/test/darwin/known-failures.txt
+++ b/test/darwin/known-failures.txt
@@ -14,14 +14,17 @@
 #                     time. macOS has exported clock_gettime(3) from libSystem
 #                     since 10.12.
 #   process.exec   -- fork / execve / wait4 through raw traps.
-#   sync.thread    -- bsdthread_create + bsdthread_register, the private
-#                     kernel<->libpthread handshake #415 calls out by name as
-#                     the most fragile thing on the least stable surface.
 #
 # the verify script fails the build on any failure NOT listed here, and equally
 # on any listed test that starts PASSING. so this cannot silently rot: fixing
 # one forces its removal, and regressing a new one is caught. the list must
 # reach empty as the rest of #415 lands, and it is the checklist for doing so.
+#
+# ## removed so far
+#
+# sync.thread (3) -- bsdthread_create + bsdthread_register, the private
+#   kernel<->libpthread handshake #415 named as the most fragile thing on the
+#   least stable surface. migrated to pthread_create; all three now pass.
 
 time: now returns non-zero
 time: since returns positive for past time
@@ -31,6 +34,3 @@ std.process.exec.run:failure_exits_one
 std.process.exec.spawn:wait_matches_run
 std.process.exec.run:repeated_spawns_stay_correct
 std.process.exec.wait_any:reaps_each_child_once
-thread: spawn and join
-thread: is_done after join
-thread: spawn_with delivers distinct userdata

--- a/test/darwin/known-failures.txt
+++ b/test/darwin/known-failures.txt
@@ -9,10 +9,6 @@
 # every one of them is in a subsystem still issuing raw BSD traps, which is the
 # thesis of #415 stated as a test result:
 #
-#   chrono.time    -- clock_gettime through syscall 427. `now()` comes back
-#                     below the epoch, so the number the trap returns is not a
-#                     time. macOS has exported clock_gettime(3) from libSystem
-#                     since 10.12.
 #   process.exec   -- fork / execve / wait4 through raw traps.
 #
 # the verify script fails the build on any failure NOT listed here, and equally
@@ -25,10 +21,12 @@
 # sync.thread (3) -- bsdthread_create + bsdthread_register, the private
 #   kernel<->libpthread handshake #415 named as the most fragile thing on the
 #   least stable surface. migrated to pthread_create; all three now pass.
+#
+# chrono.time (3) -- darwin has no clock_gettime trap at all, so syscall 427
+#   was never going to be one; the backend read whatever it returned as a time
+#   and produced a value below the unix epoch. migrated to clock_gettime(3),
+#   which macOS has exported since 10.12. all three now pass.
 
-time: now returns non-zero
-time: since returns positive for past time
-time: monotonic returns non-zero
 std.process.exec.run:success_exits_zero
 std.process.exec.run:failure_exits_one
 std.process.exec.spawn:wait_matches_run

--- a/test/darwin/verify.sh
+++ b/test/darwin/verify.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# run the suite natively on darwin and gate it against known-failures.txt.
+#
+# darwin carries a set of failures that predate the libSystem migration (#415);
+# they are enumerated, with evidence, in known-failures.txt. this script exists
+# so that set can be tolerated WITHOUT tolerating anything else:
+#
+#   - a failure that is not on the list fails the build (a regression)
+#   - a listed test that PASSES fails the build (the list has gone stale and
+#     must shrink)
+#
+# both directions matter. only checking the first turns the list into a mute
+# button that silently outlives the bugs it describes.
+#
+# usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
+set -uo pipefail
+
+mach="${1:-mach}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+cd "$root"
+
+known="$here/known-failures.txt"
+
+# strip comments and blank lines
+expected="$(grep -vE '^[[:space:]]*(#|$)' "$known" | sed 's/[[:space:]]*$//' | sort -u)"
+
+out="$(mktemp)"
+"$mach" test . 2>&1 | tee "$out"
+
+if ! grep -qE '[0-9]+ passed, [0-9]+ failed' "$out"; then
+    echo "::error::the suite produced no result line -- it did not run to completion"
+    exit 1
+fi
+
+# "  FAIL  <name>  ./src/...:NN  (exit 1)" -> "<name>"
+actual="$(sed -n 's/^[[:space:]]*FAIL[[:space:]]\{1,\}\(.*\)[[:space:]]\{2,\}\.\/[^[:space:]]*[[:space:]]*(exit [0-9]*)[[:space:]]*$/\1/p' "$out" \
+          | sed 's/[[:space:]]*$//' | sort -u)"
+
+rc=0
+
+unexpected="$(comm -13 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual"))"
+if [ -n "$unexpected" ]; then
+    echo "::error::darwin test failures that are NOT known-pre-existing:"
+    printf '  %s\n' $unexpected
+    rc=1
+fi
+
+fixed="$(comm -23 <(printf '%s\n' "$expected") <(printf '%s\n' "$actual"))"
+if [ -n "$fixed" ]; then
+    echo "::error::these are listed in known-failures.txt but PASSED -- remove them from the list:"
+    printf '  %s\n' $fixed
+    rc=1
+fi
+
+if [ "$rc" = "0" ]; then
+    n="$(printf '%s\n' "$expected" | grep -c . || true)"
+    echo "OK: no new darwin failures; $n known pre-existing failures still outstanding (#415)"
+fi
+
+rm -f "$out"
+exit "$rc"


### PR DESCRIPTION
Integration merge for 0.26.0.

Moves darwin's clocks, threads and filesystem layer off the trap table and onto libSystem (#415). All darwin lanes green on both arches.

Unblocks mach 4.17.0, whose darwin release gate fails because every duration in the tree reads zero: `SYS_CLOCK_GETTIME = 427` names a syscall XNU does not have at any number, so both clocks have returned zero since `f19a4ce` on 2026-03-11.