### PR TITLE
feat(os): expose portable SIGPIPE suppression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Relative-target directory symlink
         run: bash test/symlink/verify.sh
 
+      - name: SIGPIPE suppression
+        run: bash test/sigpipe/verify.sh
+
       # derive's refusals are `$error`s that fire during instantiation, so they
       # are evidenced by a build that fails rather than by a test that runs. the
       # classification is over field shapes and is target-independent, so one
@@ -75,6 +78,9 @@ jobs:
       - name: RELRO re-protection contract (riscv64)
         run: bash test/relro/verify.sh mach linux-riscv64 qemu-riscv64
 
+      - name: SIGPIPE suppression (riscv64)
+        run: bash test/sigpipe/verify.sh mach linux-riscv64 qemu-riscv64
+
   # aarch64 runs NATIVE, not under qemu-user. qemu-user does not faithfully model
   # the kernel ABI: its aarch64 target accepts 0x4000 as O_DIRECTORY, which is
   # O_DIRECT's value and is refused by a real kernel, while its riscv64 target
@@ -99,6 +105,9 @@ jobs:
 
       - name: RELRO re-protection contract (aarch64)
         run: bash test/relro/verify.sh mach linux-arm64
+
+      - name: SIGPIPE suppression (aarch64)
+        run: bash test/sigpipe/verify.sh mach linux-arm64
 
   # windows runs the symlink probe only, not the suite. the property in #454 is
   # a filesystem fact that only a real windows kernel can settle: wine's
@@ -125,6 +134,10 @@ jobs:
       - name: Relative-target directory symlink
         shell: bash
         run: bash test/symlink/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
+
+      - name: SIGPIPE suppression
+        shell: bash
+        run: bash test/sigpipe/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
 
   # darwin runs NATIVE on both architectures, for the same reason the arm64 job
   # above is native rather than emulated -- and with a sharper edge now that the
@@ -175,6 +188,9 @@ jobs:
       # shrink to empty as the rest of #415 lands.
       - name: Run the test suite natively on darwin
         run: bash test/darwin/verify.sh
+
+      - name: SIGPIPE suppression
+        run: bash test/sigpipe/verify.sh mach "darwin-${{ matrix.arch }}"
 
       # std itself is a static artifact, so the dependency list only becomes
       # observable once something LINKS it. this builds the backends smoke test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,10 @@ jobs:
       - name: SIGPIPE suppression (aarch64)
         run: bash test/sigpipe/verify.sh mach linux-arm64
 
-  # windows runs the symlink probe only, not the suite. the property in #454 is
-  # a filesystem fact that only a real windows kernel can settle: wine's
-  # filesystem is unix-backed, so it creates a genuine unix symlink and reports
-  # a false pass on exactly this bug, and a cross-build hosted on linux never
-  # runs anything. every other repo's windows job is a cross-build, which is why
-  # no job had ever created a symlink on a windows host.
-  windows-symlink:
+  # windows runs the process probes, not the full suite. both require a real
+  # kernel: wine's unix-backed filesystem gives the symlink probe a false pass,
+  # while a cross-build cannot observe the broken-pipe error WriteFile returns.
+  windows:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### os: pipe writers can opt out of SIGPIPE termination (#468)
+
+`std.system.os.ignore_sigpipe()` installs the process-wide ignored disposition
+on Linux and Darwin, so subsequent broken-pipe writes from every thread return
+`EPIPE` instead of terminating the process. Windows exposes the same portable
+call as a successful no-op because its writes already report broken pipes as
+ordinary errors.
+
 ## [0.26.1] - 2026-08-10
 
 ### Changed

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -147,6 +147,14 @@ fwd impl.spawn_redirected_in;
 fwd impl.spawn_shell;
 fwd impl.getpid;
 fwd impl.pipe;
+# ignore SIGPIPE for this process
+#
+# on POSIX this changes the process-wide signal disposition, so subsequent
+# writes from every thread return EPIPE instead of terminating the process.
+# windows has no SIGPIPE and returns success without changing process state.
+# ---
+# ret: 0 on success, or negative errno
+fwd impl.ignore_sigpipe;
 fwd impl.sleep;
 fwd impl.cpu_count;
 fwd impl.getcwd;

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -136,6 +136,7 @@ fwd impl.spawn_redirected_in;
 fwd impl.spawn_shell;
 fwd impl.getpid;
 fwd impl.pipe;
+fwd impl.ignore_sigpipe;
 fwd impl.sleep;
 fwd impl.cpu_count;
 fwd impl.getcwd;

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -123,6 +123,7 @@ fwd shared.spawn_redirected;
 fwd shared.spawn_redirected_in;
 fwd shared.spawn_shell;
 fwd shared.getpid;
+fwd shared.ignore_sigpipe;
 fwd shared.sleep;
 fwd shared.cpu_count;
 fwd shared.getcwd;

--- a/src/system/os/darwin/libsystem.mach
+++ b/src/system/os/darwin/libsystem.mach
@@ -180,6 +180,15 @@ pub ext fun getcwd(buf: *u8, size: usize) *u8;
 #[library("libSystem")]
 pub ext fun pipe(fds: *i32) i32;
 
+# install a process-wide signal disposition
+#
+# signal(3) is sufficient for SIG_IGN and keeps darwin on its supported
+# libSystem surface instead of reproducing the platform's sigaction layout.
+# ---
+# ret: previous handler, or all-bits-one with errno set on failure
+#[library("libSystem")]
+pub ext fun signal(sig: i32, handler: usize) usize;
+
 # time
 #
 # darwin has no `clock_gettime` BSD trap at all. the backend used to call

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -55,6 +55,9 @@ val RLIMIT_NOFILE:        usize = 8;
 val SYS_DUP2:             usize = 90;
 
 val SIGABRT: i32 = 6;
+val SIGPIPE: i32 = 13;
+val SIG_IGN: usize = 1;
+val SIG_ERR: usize = (-1)::isize::usize;
 
 # fcntl commands
 #
@@ -1062,6 +1065,18 @@ pub fun spawn_shell(command: *u8, envp: **u8, cwd: *u8) i64 {
 # ret: process ID
 pub fun getpid() i64 {
     ret syscall0(SYS_GETPID);
+}
+
+# ignore SIGPIPE for this process
+#
+# signal(3) installs the disposition through public libSystem. it is
+# process-wide, so subsequent writes from every thread return EPIPE when their
+# pipe has no reader instead of terminating the process.
+# ---
+# ret: 0 on success, or negative errno
+pub fun ignore_sigpipe() i64 {
+    if (ls.signal(SIGPIPE, SIG_IGN) == SIG_ERR) { ret ls.fail_errno(); }
+    ret 0;
 }
 
 # suspend execution for the given number of nanoseconds

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -123,6 +123,7 @@ fwd shared.spawn_redirected;
 fwd shared.spawn_redirected_in;
 fwd shared.spawn_shell;
 fwd shared.getpid;
+fwd shared.ignore_sigpipe;
 fwd shared.sleep;
 fwd shared.cpu_count;
 fwd shared.getcwd;

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -148,6 +148,7 @@ fwd impl.spawn_redirected_in;
 fwd impl.spawn_shell;
 fwd impl.getpid;
 fwd impl.pipe;
+fwd impl.ignore_sigpipe;
 fwd impl.sleep;
 fwd impl.cpu_count;
 fwd impl.getcwd;

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -275,6 +275,7 @@ fwd shared.spawn_redirected_in;
 fwd shared.spawn_shell;
 fwd shared.getpid;
 fwd shared.pipe;
+fwd shared.ignore_sigpipe;
 fwd shared.sleep;
 fwd shared.cpu_count;
 fwd shared.getcwd;

--- a/src/system/os/linux/riscv64.mach
+++ b/src/system/os/linux/riscv64.mach
@@ -271,6 +271,7 @@ fwd shared.spawn_redirected_in;
 fwd shared.spawn_shell;
 fwd shared.getpid;
 fwd shared.pipe;
+fwd shared.ignore_sigpipe;
 fwd shared.sleep;
 fwd shared.cpu_count;
 fwd shared.getcwd;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -33,6 +33,7 @@ $if ($mach.build.arch == $mach.arch.x86_64) {
     val SYS_MPROTECT:      usize = 10;
     val SYS_MUNMAP:        usize = 11;
     val SYS_BRK:           usize = 12;
+    val SYS_RT_SIGACTION:  usize = 13;
     val SYS_MREMAP:        usize = 25;
     val SYS_MSYNC:         usize = 26;
     val SYS_MADVISE:       usize = 28;
@@ -92,6 +93,7 @@ $or ($mach.build.arch == $mach.arch.aarch64) {
     val SYS_MSYNC:         usize = 227;
     val SYS_MADVISE:       usize = 233;
     val SYS_NANOSLEEP:     usize = 101;
+    val SYS_RT_SIGACTION:  usize = 134;
     val SYS_GETPID:        usize = 172;
     val SYS_CLONE:         usize = 220;
     val SYS_EXECVE:        usize = 221;
@@ -145,6 +147,7 @@ $or ($mach.build.arch == $mach.arch.riscv64) {
     val SYS_MSYNC:         usize = 227;
     val SYS_MADVISE:       usize = 233;
     val SYS_NANOSLEEP:     usize = 101;
+    val SYS_RT_SIGACTION:  usize = 134;
     val SYS_GETPID:        usize = 172;
     val SYS_CLONE:         usize = 220;
     val SYS_EXECVE:        usize = 221;
@@ -206,6 +209,12 @@ pub val CLONE_SYSVSEM: usize = 0x00040000;
 # the parent until the child execs or exits. identical across linux arches.
 val CLONE_VFORK: usize = 0x00004000;
 val SIGCHLD:     usize = 17;
+val SIGPIPE:     usize = 13;
+val SIG_IGN:     usize = 1;
+
+# linux's kernel signal set has 64 bits on every supported 64-bit ISA. this is
+# the size rt_sigaction expects, not userspace libc's larger sigset_t size.
+val KERNEL_SIGSET_SIZE: usize = 8;
 
 val MREMAP_MAYMOVE: usize = 1;
 
@@ -1677,6 +1686,27 @@ pub fun getpid() i64 {
 # ret: 0 on success, or negative errno
 pub fun pipe(fds: *i32) i64 {
     ret syscall2(SYS_PIPE2, fds::usize, 0);
+}
+
+# ignore SIGPIPE for this process
+#
+# rt_sigaction's first two words are the handler and flags on every supported
+# ISA. x86_64 and aarch64 then carry a restorer word before the signal mask;
+# riscv64 puts the mask in the third word. a zeroed four-word buffer satisfies
+# both layouts because this disposition has no flags, restorer, or masked
+# signals. the kernel reads only its own layout and the trailing word is inert.
+#
+# the disposition is process-wide: after success, writes from every thread
+# return EPIPE when their pipe has no reader instead of terminating the process.
+# ---
+# ret: 0 on success, or negative errno
+pub fun ignore_sigpipe() i64 {
+    var action: [4]usize;
+    action[0] = SIG_IGN;
+    action[1] = 0;
+    action[2] = 0;
+    action[3] = 0;
+    ret syscall4(SYS_RT_SIGACTION, SIGPIPE, (?action[0])::usize, 0, KERNEL_SIGSET_SIZE);
 }
 
 # suspend execution for the given number of nanoseconds

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -266,6 +266,7 @@ fwd shared.spawn_redirected_in;
 fwd shared.spawn_shell;
 fwd shared.getpid;
 fwd shared.pipe;
+fwd shared.ignore_sigpipe;
 fwd shared.sleep;
 fwd shared.cpu_count;
 fwd shared.getcwd;

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -124,6 +124,7 @@ fwd impl.spawn_redirected_in;
 fwd impl.spawn_shell;
 fwd impl.getpid;
 fwd impl.pipe;
+fwd impl.ignore_sigpipe;
 fwd impl.sleep;
 fwd impl.cpu_count;
 fwd impl.getcwd;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -115,6 +115,7 @@ val ERROR_TOO_MANY_OPEN_FILES: u32 = 4;
 val ERROR_BROKEN_PIPE:      u32 = 109;
 val ERROR_BUSY:             u32 = 170;
 val ERROR_ENVVAR_NOT_FOUND: u32 = 203;
+val ERROR_NO_DATA:          u32 = 232;
 val ERROR_PRIVILEGE_NOT_HELD: u32 = 1314;
 
 # CreateSymbolicLink flags
@@ -750,7 +751,9 @@ fun last_error() i64 {
     or (err == ERROR_NOT_ENOUGH_MEMORY || err == ERROR_OUTOFMEMORY) { ret ENOMEM; }
     or (err == ERROR_DIR_NOT_EMPTY) { ret ENOTEMPTY; }
     or (err == ERROR_DISK_FULL || err == ERROR_HANDLE_DISK_FULL) { ret ENOSPC; }
-    or (err == ERROR_BROKEN_PIPE) { ret EPIPE; }
+    # a closed anonymous-pipe reader surfaces as either "broken pipe" or
+    # "the pipe is being closed", depending on where teardown is observed.
+    or (err == ERROR_BROKEN_PIPE || err == ERROR_NO_DATA) { ret EPIPE; }
     or (err == ERROR_DIRECTORY) { ret ENOTDIR; }
     or (err == ERROR_TOO_MANY_OPEN_FILES) { ret EMFILE; }
     or (err == ERROR_BUSY) { ret EBUSY; }

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -740,8 +740,7 @@ fun count_procs() usize {
 }
 
 # Win32 error → negated POSIX errno
-fun last_error() i64 {
-    val err: u32 = GetLastError();
+fun win32_error(err: u32) i64 {
     if (err == ERROR_FILE_NOT_FOUND || err == ERROR_PATH_NOT_FOUND) { ret ENOENT; }
     or (err == ERROR_ACCESS_DENIED) { ret EACCES; }
     # symlink creation without developer mode or SeCreateSymbolicLinkPrivilege
@@ -751,15 +750,17 @@ fun last_error() i64 {
     or (err == ERROR_NOT_ENOUGH_MEMORY || err == ERROR_OUTOFMEMORY) { ret ENOMEM; }
     or (err == ERROR_DIR_NOT_EMPTY) { ret ENOTEMPTY; }
     or (err == ERROR_DISK_FULL || err == ERROR_HANDLE_DISK_FULL) { ret ENOSPC; }
-    # a closed anonymous-pipe reader surfaces as either "broken pipe" or
-    # "the pipe is being closed", depending on where teardown is observed.
-    or (err == ERROR_BROKEN_PIPE || err == ERROR_NO_DATA) { ret EPIPE; }
+    or (err == ERROR_BROKEN_PIPE) { ret EPIPE; }
     or (err == ERROR_DIRECTORY) { ret ENOTDIR; }
     or (err == ERROR_TOO_MANY_OPEN_FILES) { ret EMFILE; }
     or (err == ERROR_BUSY) { ret EBUSY; }
     or (err == ERROR_WRITE_PROTECT) { ret EROFS; }
     or (err == ERROR_NOT_SUPPORTED) { ret ENOTSUP; }
     or { ret EIO; }
+}
+
+fun last_error() i64 {
+    ret win32_error(GetLastError());
 }
 
 # FILETIME → unix seconds + nanoseconds
@@ -1058,7 +1059,11 @@ pub fun write(fd: i32, buf: *u8, count: usize) i64 {
     var bytes_written: u32 = 0;
     val ok: i32 = WriteFile(h, buf, count::u32, ?bytes_written, nil);
     if (ok == 0) {
-        ret last_error();
+        val err: u32 = GetLastError();
+        # a local anonymous-pipe reader closing can surface as "the pipe is
+        # being closed" rather than WriteFile's usual ERROR_BROKEN_PIPE.
+        if (err == ERROR_NO_DATA) { ret EPIPE; }
+        ret win32_error(err);
     }
     ret bytes_written::i64;
 }

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -1951,6 +1951,16 @@ pub fun getpid() i64 {
     ret GetCurrentProcessId()::i64;
 }
 
+# ignore SIGPIPE for this process
+#
+# windows does not deliver SIGPIPE for a broken pipe, so this portable surface
+# is a no-op. writes already report EPIPE through their normal error return.
+# ---
+# ret: always 0
+pub fun ignore_sigpipe() i64 {
+    ret 0;
+}
+
 # create a unidirectional pipe
 # ---
 # fds: pointer to two i32s; fds[0] = read end, fds[1] = write end

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -123,6 +123,7 @@ fwd shared.spawn_redirected_in;
 fwd shared.spawn_shell;
 fwd shared.getpid;
 fwd shared.pipe;
+fwd shared.ignore_sigpipe;
 fwd shared.sleep;
 fwd shared.cpu_count;
 fwd shared.getcwd;

--- a/test/sigpipe/mach.toml
+++ b/test/sigpipe/mach.toml
@@ -1,0 +1,51 @@
+[project]
+id = "sigpipeprobe"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux-x86_64]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[target.windows-x86_64]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[profile.debug]
+opt = 0
+debug = true
+simd = "scalarize"
+
+[artifact.sigpipe_probe]
+kind = "bin"
+entry = "main.mach"
+out = "bin/sigpipe_probe"
+targets = ["*"]
+link = []
+need = []
+
+[dep.std]
+path = "dep/std"

--- a/test/sigpipe/src/main.mach
+++ b/test/sigpipe/src/main.mach
@@ -1,0 +1,22 @@
+# process-level SIGPIPE suppression probe (#468)
+#
+# writing after the read end closes must reach the EPIPE return. on POSIX, a
+# missing or broken ignore_sigpipe implementation kills this whole executable
+# before it can return, which verify.sh distinguishes from its normal exit.
+use std.runtime;
+use os: std.system.os;
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    if (os.ignore_sigpipe() != 0) { ret 10; }
+
+    var fds: [2]i32;
+    if (os.pipe(?fds[0]) != 0) { ret 11; }
+    if (os.close(fds[0]) != 0) { ret 12; }
+
+    var byte: u8 = 'x'::u8;
+    val result: i64 = os.write(fds[1], ?byte, 1);
+    if (os.close(fds[1]) != 0) { ret 13; }
+    if (result != os.EPIPE) { ret 20; }
+    ret 0;
+}

--- a/test/sigpipe/verify.sh
+++ b/test/sigpipe/verify.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# build and run the SIGPIPE suppression probe against this checkout's std.
+# normal exit is part of the assertion: without the POSIX disposition change,
+# the closed-reader write terminates the probe by SIGPIPE before main returns.
+#
+# usage: verify.sh [path-to-mach] [target] [runner]
+set -euo pipefail
+
+mach="${1:-mach}"
+target="${2:-linux-x86_64}"
+runner="${3:-}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+decode() {
+    case "$1" in
+        10) echo "ignore_sigpipe setup failed" ;;
+        11) echo "pipe creation failed" ;;
+        12) echo "closing the read end failed" ;;
+        13) echo "closing the write end failed" ;;
+        20) echo "the protected write did not return EPIPE" ;;
+        141) echo "the process was terminated by SIGPIPE" ;;
+        *) echo "unexpected exit code $1" ;;
+    esac
+}
+
+# copy this checkout into the fixture rather than relying on symlink behaviour
+# under the native windows runner.
+rm -rf dep
+mkdir -p dep/std
+cp ../../mach.toml dep/std/mach.toml
+cp -r ../../src dep/std/src
+
+echo "building the SIGPIPE probe with $mach (target $target)"
+rm -rf out
+"$mach" build . --target "$target" --profile debug
+exe="$(find out -name 'sigpipe_probe*' -type f -print -quit)"
+[ -n "$exe" ] || fail "no sigpipe_probe binary produced"
+exe="$(cd "$(dirname "$exe")" && pwd)/$(basename "$exe")"
+
+echo "running $exe"
+set +e
+if [ -n "$runner" ]; then "$runner" "$exe"; else "$exe"; fi
+code=$?
+set -e
+[ "$code" -eq 0 ] || fail "$(decode "$code")"
+
+echo "OK: the protected broken-pipe write returned EPIPE and the process exited normally"


### PR DESCRIPTION
Closes #468

Adds a narrow portable `std.system.os.ignore_sigpipe()` operation so long-lived pipe writers can observe `EPIPE` instead of being terminated.

- Linux installs `SIG_IGN` with `rt_sigaction` on x86_64, aarch64, and riscv64.
- Darwin installs it through public libSystem.
- Windows exposes the same operation as a successful no-op and normalizes its native closed-pipe write spelling to `EPIPE`.
- A dedicated child-process probe closes a pipe reader and requires the protected write to return `EPIPE` followed by normal process exit. Native/emulated CI executes it on every supported OS/ISA.