### PR TITLE
feat(process): terminate tracked child processes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: SIGPIPE suppression
         run: bash test/sigpipe/verify.sh
 
+      - name: Tracked child termination
+        run: bash test/terminate-child/verify.sh
+
       # derive's refusals are `$error`s that fire during instantiation, so they
       # are evidenced by a build that fails rather than by a test that runs. the
       # classification is over field shapes and is target-independent, so one
@@ -81,6 +84,9 @@ jobs:
       - name: SIGPIPE suppression (riscv64)
         run: bash test/sigpipe/verify.sh mach linux-riscv64 qemu-riscv64
 
+      - name: Tracked child termination (riscv64)
+        run: bash test/terminate-child/verify.sh mach linux-riscv64 qemu-riscv64
+
   # aarch64 runs NATIVE, not under qemu-user. qemu-user does not faithfully model
   # the kernel ABI: its aarch64 target accepts 0x4000 as O_DIRECTORY, which is
   # O_DIRECT's value and is refused by a real kernel, while its riscv64 target
@@ -109,6 +115,9 @@ jobs:
       - name: SIGPIPE suppression (aarch64)
         run: bash test/sigpipe/verify.sh mach linux-arm64
 
+      - name: Tracked child termination (aarch64)
+        run: bash test/terminate-child/verify.sh mach linux-arm64
+
   # windows runs the process probes, not the full suite. both require a real
   # kernel: wine's unix-backed filesystem gives the symlink probe a false pass,
   # while a cross-build cannot observe the broken-pipe error WriteFile returns.
@@ -135,6 +144,10 @@ jobs:
       - name: SIGPIPE suppression
         shell: bash
         run: bash test/sigpipe/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
+
+      - name: Tracked child termination
+        shell: bash
+        run: bash test/terminate-child/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
 
   # darwin runs NATIVE on both architectures, for the same reason the arm64 job
   # above is native rather than emulated -- and with a sharper edge now that the
@@ -188,6 +201,9 @@ jobs:
 
       - name: SIGPIPE suppression
         run: bash test/sigpipe/verify.sh mach "darwin-${{ matrix.arch }}"
+
+      - name: Tracked child termination
+        run: bash test/terminate-child/verify.sh mach "darwin-${{ matrix.arch }}"
 
       # std itself is a static artifact, so the dependency list only becomes
       # observable once something LINKS it. this builds the backends smoke test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,9 +118,9 @@ jobs:
       - name: Tracked child termination (aarch64)
         run: bash test/terminate-child/verify.sh mach linux-arm64
 
-  # windows runs the process probes, not the full suite. both require a real
+  # windows runs the process probes, not the full suite. they require a real
   # kernel: wine's unix-backed filesystem gives the symlink probe a false pass,
-  # while a cross-build cannot observe the broken-pipe error WriteFile returns.
+  # while a cross-build cannot observe Win32 pipe or process-handle behaviour.
   windows:
     runs-on: windows-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### process: spawned children can be force-stopped without being reaped (#470)
+
+`std.process.exec.terminate_child()` forcefully stops one `Child` while leaving
+its status available to `wait()` / `wait_any()`. The portable OS primitive uses
+`SIGKILL` after a non-reaping child-ownership check on Linux and Darwin, and
+`TerminateProcess` through the retained child handle on Windows. Unknown and
+already-reaped children return `ECHILD` instead of falling through to a raw PID
+operation that could affect a reused process ID.
+
 #### os: pipe writers can opt out of SIGPIPE termination (#468)
 
 `std.system.os.ignore_sigpipe()` installs the process-wide ignored disposition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,9 @@ its status available to `wait()` / `wait_any()`. The portable OS primitive uses
 `SIGKILL` after a non-reaping child-ownership check on Linux and Darwin, and
 `TerminateProcess` through the retained child handle on Windows. Unknown and
 already-reaped children return `ECHILD` instead of falling through to a raw PID
-operation that could affect a reused process ID.
+operation that could affect a reused process ID. Termination and reaping of the
+same child must be serialized; a concurrent wait could release that numeric ID
+between POSIX's ownership check and signal delivery.
 
 #### os: pipe writers can opt out of SIGPIPE termination (#468)
 

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -190,8 +190,6 @@ pub fun spawn_redirected(pathname: str, argv: **u8, envp: **u8, stdout_fd: i32, 
 # child. once one of the wait operations begins reaping a child, its numeric
 # process ID can be released for reuse.
 # ---
-# terminate_child must not run concurrently for this child; see its contract.
-# ---
 # child: child handle from spawn
 # ret:   true on success, or an error message
 pub fun terminate_child(child: Child) R.Result[bool, str] {

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -180,6 +180,21 @@ pub fun spawn_redirected(pathname: str, argv: **u8, envp: **u8, stdout_fd: i32, 
     ret R.ok[Child, str](Child{pid: pid});
 }
 
+# forcefully stop a child without reaping it
+#
+# the child remains waitable after this succeeds. callers must still pass it
+# to wait (or collect it through wait_any) to obtain its status and release
+# retained platform resources.
+# ---
+# child: child handle from spawn
+# ret:   true on success, or an error message
+pub fun terminate_child(child: Child) R.Result[bool, str] {
+    if (os.terminate_child(child.pid) < 0) {
+        ret R.err[bool, str]("terminate child failed");
+    }
+    ret R.ok[bool, str](true);
+}
+
 # wait for a child process to exit
 # ---
 # child: child handle from spawn

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -185,6 +185,12 @@ pub fun spawn_redirected(pathname: str, argv: **u8, envp: **u8, stdout_fd: i32, 
 # the child remains waitable after this succeeds. callers must still pass it
 # to wait (or collect it through wait_any) to obtain its status and release
 # retained platform resources.
+#
+# terminate_child, wait, and wait_any must not run concurrently for the same
+# child. once one of the wait operations begins reaping a child, its numeric
+# process ID can be released for reuse.
+# ---
+# terminate_child must not run concurrently for this child; see its contract.
 # ---
 # child: child handle from spawn
 # ret:   true on success, or an error message
@@ -214,6 +220,9 @@ pub fun wait(child: Child) R.Result[ExitStatus, str] {
 # identifies which child was reaped and how it exited, so a caller juggling
 # several children can map the exit back to its work item. errs when there is
 # no child to wait for.
+#
+# wait_any must not run concurrently with terminate_child, because it may reap
+# and release the process ID that termination is validating.
 # ---
 # ret: the reaped child and its exit status, or an error message
 pub fun wait_any() R.Result[Reaped, str] {

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -140,6 +140,7 @@ fwd impl.seek;
 # process
 fwd impl.terminate;
 fwd impl.abort;
+fwd impl.terminate_child;
 fwd impl.spawn;
 fwd impl.spawn_in;
 fwd impl.spawn_redirected;

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -129,6 +129,7 @@ fwd impl.seek;
 # process
 fwd impl.terminate;
 fwd impl.abort;
+fwd impl.terminate_child;
 fwd impl.spawn;
 fwd impl.spawn_in;
 fwd impl.spawn_redirected;

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -117,6 +117,7 @@ fwd shared.syscall6;
 # process
 fwd shared.terminate;
 fwd shared.abort;
+fwd shared.terminate_child;
 fwd shared.spawn;
 fwd shared.spawn_in;
 fwd shared.spawn_redirected;

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -930,6 +930,8 @@ pub fun wait_pid(pid: i64, wstatus: *i32, options: i32) i64 {
 # waitid with WNOWAIT first asks the kernel to verify that `pid` is still a
 # child of this process. this rejects unknown and already-reaped PIDs before
 # kill can affect them, while preserving an exited child's wait status.
+# callers must not concurrently reap this child through wait or wait_pid: a
+# reaper could release the numeric PID between the ownership check and kill.
 # ---
 # pid: child process ID returned by spawn
 # ret: 0 on success, or negative errno

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -27,6 +27,7 @@ val SYS_FORK:             usize = 2;
 val SYS_CLOSE:            usize = 6;
 val SYS_CHDIR:            usize = 12;
 val SYS_WAIT4:            usize = 7;
+val SYS_WAITID:           usize = 173;
 val SYS_MMAP:             usize = 197;
 val SYS_MUNMAP:           usize = 73;
 val SYS_MPROTECT:         usize = 74;
@@ -55,6 +56,7 @@ val RLIMIT_NOFILE:        usize = 8;
 val SYS_DUP2:             usize = 90;
 
 val SIGABRT: i32 = 6;
+val SIGKILL: i32 = 9;
 val SIGPIPE: i32 = 13;
 val SIG_IGN: usize = 1;
 val SIG_ERR: usize = (-1)::isize::usize;
@@ -166,6 +168,10 @@ pub val S_IFLNK: u32 = 0o120000;
 pub val WNOHANG:    i32 = 1;
 pub val WUNTRACED:  i32 = 2;
 pub val WCONTINUED: i32 = 0x10;
+
+val P_PID:   usize = 1;
+val WEXITED: usize = 4;
+val WNOWAIT: usize = 0x20;
 
 pub val CLOCK_REALTIME:  i32 = 0;
 pub val CLOCK_MONOTONIC: i32 = 6;
@@ -917,6 +923,29 @@ pub fun wait(pid: i64, wstatus: *i32, options: i32, rusage: *u8) i64 {
 
 pub fun wait_pid(pid: i64, wstatus: *i32, options: i32) i64 {
     ret wait(pid, wstatus, options, nil);
+}
+
+# forcefully stop a spawned child without reaping it
+#
+# waitid with WNOWAIT first asks the kernel to verify that `pid` is still a
+# child of this process. this rejects unknown and already-reaped PIDs before
+# kill can affect them, while preserving an exited child's wait status.
+# ---
+# pid: child process ID returned by spawn
+# ret: 0 on success, or negative errno
+pub fun terminate_child(pid: i64) i64 {
+    if (pid <= 0) { ret EINVAL; }
+
+    var info: [128]u8;
+    val probe: i64 = syscall4(
+        SYS_WAITID,
+        P_PID,
+        pid::usize,
+        (?info[0])::usize,
+        WEXITED | WNOHANG::usize | WNOWAIT,
+    );
+    if (probe < 0) { ret probe; }
+    ret syscall2(SYS_KILL, pid::usize, SIGKILL::usize);
 }
 
 # wait status (POSIX encoding, shared across all targets)

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -117,6 +117,7 @@ fwd shared.syscall6;
 # process
 fwd shared.terminate;
 fwd shared.abort;
+fwd shared.terminate_child;
 fwd shared.spawn;
 fwd shared.spawn_in;
 fwd shared.spawn_redirected;

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -141,6 +141,7 @@ fwd impl.seek;
 # process
 fwd impl.terminate;
 fwd impl.abort;
+fwd impl.terminate_child;
 fwd impl.spawn;
 fwd impl.spawn_in;
 fwd impl.spawn_redirected;

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -268,6 +268,7 @@ fwd shared.seek;
 # process
 fwd shared.terminate;
 fwd shared.abort;
+fwd shared.terminate_child;
 fwd shared.spawn;
 fwd shared.spawn_in;
 fwd shared.spawn_redirected;

--- a/src/system/os/linux/riscv64.mach
+++ b/src/system/os/linux/riscv64.mach
@@ -264,6 +264,7 @@ fwd shared.seek;
 # process
 fwd shared.terminate;
 fwd shared.abort;
+fwd shared.terminate_child;
 fwd shared.spawn;
 fwd shared.spawn_in;
 fwd shared.spawn_redirected;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -1371,6 +1371,8 @@ pub fun wait_pid(pid: i64, wstatus: *i32, options: i32) i64 {
 # waitid with WNOWAIT first asks the kernel to verify that `pid` is still a
 # child of this process. this rejects unknown and already-reaped PIDs before
 # kill can affect them, while preserving an exited child's wait status.
+# callers must not concurrently reap this child through wait or wait_pid: a
+# reaper could release the numeric PID between the ownership check and kill.
 # ---
 # pid: child process ID returned by spawn
 # ret: 0 on success, or negative errno

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -46,6 +46,8 @@ $if ($mach.build.arch == $mach.arch.x86_64) {
     val SYS_EXIT:          usize = 60;
     val SYS_EXIT_GROUP:    usize = 231;
     val SYS_WAIT4:         usize = 61;
+    val SYS_WAITID:        usize = 247;
+    val SYS_KILL:          usize = 62;
     val SYS_SCHED_GETAFFINITY: usize = 204;
     val SYS_PIPE2:         usize = 293;
     val SYS_GETCWD:        usize = 79;
@@ -100,6 +102,8 @@ $or ($mach.build.arch == $mach.arch.aarch64) {
     val SYS_EXIT:          usize = 93;
     val SYS_EXIT_GROUP:    usize = 94;
     val SYS_WAIT4:         usize = 260;
+    val SYS_WAITID:        usize = 95;
+    val SYS_KILL:          usize = 129;
     val SYS_SCHED_GETAFFINITY: usize = 123;
     val SYS_PIPE2:         usize = 59;
     val SYS_GETCWD:        usize = 17;
@@ -154,6 +158,8 @@ $or ($mach.build.arch == $mach.arch.riscv64) {
     val SYS_EXIT:          usize = 93;
     val SYS_EXIT_GROUP:    usize = 94;
     val SYS_WAIT4:         usize = 260;
+    val SYS_WAITID:        usize = 95;
+    val SYS_KILL:          usize = 129;
     val SYS_SCHED_GETAFFINITY: usize = 123;
     val SYS_PIPE2:         usize = 59;
     val SYS_GETCWD:        usize = 17;
@@ -209,6 +215,7 @@ pub val CLONE_SYSVSEM: usize = 0x00040000;
 # the parent until the child execs or exits. identical across linux arches.
 val CLONE_VFORK: usize = 0x00004000;
 val SIGCHLD:     usize = 17;
+val SIGKILL:     usize = 9;
 val SIGPIPE:     usize = 13;
 val SIG_IGN:     usize = 1;
 
@@ -399,6 +406,10 @@ pub val S_IFLNK: u32 = 0o120000;
 pub val WNOHANG:    i32 = 1;
 pub val WUNTRACED:  i32 = 2;
 pub val WCONTINUED: i32 = 8;
+
+val P_PID:   usize = 1;
+val WEXITED: usize = 4;
+val WNOWAIT: usize = 0x01000000;
 
 pub val CLOCK_REALTIME:  i32 = 0;
 pub val CLOCK_MONOTONIC: i32 = 1;
@@ -1353,6 +1364,30 @@ pub fun wait(pid: i64, wstatus: *i32, options: i32, rusage: *u8) i64 {
 # ret:     child PID or negative errno
 pub fun wait_pid(pid: i64, wstatus: *i32, options: i32) i64 {
     ret wait(pid, wstatus, options, nil);
+}
+
+# forcefully stop a spawned child without reaping it
+#
+# waitid with WNOWAIT first asks the kernel to verify that `pid` is still a
+# child of this process. this rejects unknown and already-reaped PIDs before
+# kill can affect them, while preserving an exited child's wait status.
+# ---
+# pid: child process ID returned by spawn
+# ret: 0 on success, or negative errno
+pub fun terminate_child(pid: i64) i64 {
+    if (pid <= 0) { ret EINVAL; }
+
+    var info: [128]u8;
+    val probe: i64 = syscall5(
+        SYS_WAITID,
+        P_PID,
+        pid::usize,
+        (?info[0])::usize,
+        WEXITED | WNOHANG::usize | WNOWAIT,
+        0,
+    );
+    if (probe < 0) { ret probe; }
+    ret syscall2(SYS_KILL, pid::usize, SIGKILL);
 }
 
 # wait status (POSIX encoding, shared across all targets)

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -259,6 +259,7 @@ fwd shared.seek;
 # process
 fwd shared.terminate;
 fwd shared.abort;
+fwd shared.terminate_child;
 fwd shared.spawn;
 fwd shared.spawn_in;
 fwd shared.spawn_redirected;

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -117,6 +117,7 @@ fwd impl.seek;
 # process
 fwd impl.terminate;
 fwd impl.abort;
+fwd impl.terminate_child;
 fwd impl.spawn;
 fwd impl.spawn_in;
 fwd impl.spawn_redirected;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -1961,6 +1961,8 @@ pub fun spawn_shell(command: *u8, envp: **u8, cwd: *u8) i64 {
 # reused its numeric PID. the handle stays registered and open after
 # TerminateProcess, so wait_pid remains responsible for collecting the exit
 # status and closing it.
+# for parity with POSIX, callers must serialize termination and reaping of the
+# same child; concurrent waits on one child are not supported.
 # ---
 # pid: child process ID returned by spawn
 # ret: 0 on success, or negative errno

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -118,6 +118,8 @@ val ERROR_ENVVAR_NOT_FOUND: u32 = 203;
 val ERROR_NO_DATA:          u32 = 232;
 val ERROR_PRIVILEGE_NOT_HELD: u32 = 1314;
 
+val TERMINATE_CHILD_EXIT_CODE: u32 = 137;
+
 # CreateSymbolicLink flags
 val SYMBOLIC_LINK_FLAG_DIRECTORY:                 u32 = 0x1;
 val SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE: u32 = 0x2;
@@ -655,7 +657,7 @@ fun reserve_proc() i32 {
     init_procs();
     var i: usize = 0;
     for (i < MAX_PROCS) {
-        # free slots already hold pid 0 (init_procs/free_proc invariant)
+        # free slots already hold pid 0 (init_procs/close_proc invariant)
         if (_proc_handles[i] == INVALID_HANDLE_VALUE) {
             _proc_handles[i] = PROC_RESERVED;
             proc_spin_unlock();
@@ -704,7 +706,7 @@ fun get_proc_handle(pid: u32) isize {
     ret INVALID_HANDLE_VALUE;
 }
 
-fun free_proc(pid: u32) {
+fun close_proc(pid: u32, handle: isize) {
     # pid 0 is never a child; rejecting it keeps a bogus lookup from
     # matching a reserved slot's zero pid
     if (pid == 0) {
@@ -713,9 +715,10 @@ fun free_proc(pid: u32) {
     proc_spin_lock();
     var i: usize = 0;
     for (i < MAX_PROCS) {
-        if (_proc_pids[i] == pid && proc_slot_live(_proc_handles[i])) {
+        if (_proc_pids[i] == pid && _proc_handles[i] == handle) {
             _proc_handles[i] = INVALID_HANDLE_VALUE;
             _proc_pids[i] = 0;
+            CloseHandle(handle);
             proc_spin_unlock();
             ret;
         }
@@ -1952,6 +1955,38 @@ pub fun spawn_shell(command: *u8, envp: **u8, cwd: *u8) i64 {
     ret r;
 }
 
+# forcefully stop a spawned child without reaping it
+#
+# the retained process handle identifies the exact child even if Windows has
+# reused its numeric PID. the handle stays registered and open after
+# TerminateProcess, so wait_pid remains responsible for collecting the exit
+# status and closing it.
+# ---
+# pid: child process ID returned by spawn
+# ret: 0 on success, or negative errno
+pub fun terminate_child(pid: i64) i64 {
+    if (pid <= 0 || pid > 4294967295) { ret EINVAL; }
+
+    val child_pid: u32 = pid::u32;
+    proc_spin_lock();
+    init_procs();
+    var i: usize = 0;
+    for (i < MAX_PROCS) {
+        if (_proc_pids[i] == child_pid && proc_slot_live(_proc_handles[i])) {
+            if (TerminateProcess(_proc_handles[i], TERMINATE_CHILD_EXIT_CODE) == 0) {
+                val e: i64 = last_error();
+                proc_spin_unlock();
+                ret e;
+            }
+            proc_spin_unlock();
+            ret 0;
+        }
+        i = i + 1;
+    }
+    proc_spin_unlock();
+    ret ECHILD;
+}
+
 # return the current process ID
 # ---
 # ret: process ID
@@ -2237,8 +2272,7 @@ pub fun wait(pid: i64, wstatus: *i32, options: i32, rusage: *u8) i64 {
         if (result == WAIT_FAILED) {
             # dead handle: purge the slot so it cannot pin the table
             val e: i64 = last_error();
-            CloseHandle(h);
-            free_proc(pid::u32);
+            close_proc(pid::u32, h);
             ret e;
         }
 
@@ -2247,8 +2281,7 @@ pub fun wait(pid: i64, wstatus: *i32, options: i32, rusage: *u8) i64 {
         if (wstatus != nil) {
             @wstatus = (ec::i32 << 8);
         }
-        CloseHandle(h);
-        free_proc(pid::u32);
+        close_proc(pid::u32, h);
         ret pid;
     }
 
@@ -2298,8 +2331,7 @@ pub fun wait(pid: i64, wstatus: *i32, options: i32, rusage: *u8) i64 {
                 i = 0;
                 for (i < n) {
                     if (WaitForSingleObject(wait_handles[i], 0) == WAIT_FAILED) {
-                        CloseHandle(wait_handles[i]);
-                        free_proc(wait_pids[i]);
+                        close_proc(wait_pids[i], wait_handles[i]);
                         purged = purged + 1;
                     }
                     i = i + 1;
@@ -2319,8 +2351,7 @@ pub fun wait(pid: i64, wstatus: *i32, options: i32, rusage: *u8) i64 {
                     @wstatus = (ec::i32 << 8);
                 }
                 val child_pid: u32 = wait_pids[idx];
-                CloseHandle(wait_handles[idx]);
-                free_proc(child_pid);
+                close_proc(child_pid, wait_handles[idx]);
                 ret child_pid::i64;
             }
         }

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -116,6 +116,7 @@ fwd shared.seek;
 # process
 fwd shared.terminate;
 fwd shared.abort;
+fwd shared.terminate_child;
 fwd shared.spawn;
 fwd shared.spawn_in;
 fwd shared.spawn_redirected;

--- a/test/terminate-child/mach.toml
+++ b/test/terminate-child/mach.toml
@@ -1,0 +1,51 @@
+[project]
+id = "terminatechildprobe"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux-x86_64]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[target.windows-x86_64]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[profile.debug]
+opt = 0
+debug = true
+simd = "scalarize"
+
+[artifact.terminate_child_probe]
+kind = "bin"
+entry = "main.mach"
+out = "bin/terminate_child_probe"
+targets = ["*"]
+link = []
+need = []
+
+[dep.std]
+path = "dep/std"

--- a/test/terminate-child/src/main.mach
+++ b/test/terminate-child/src/main.mach
@@ -1,0 +1,109 @@
+# tracked-child force-termination probe (#470)
+#
+# the parent kills and reaps several blocking children, checks an unrelated
+# child remains alive, and verifies stale and unknown PIDs are rejected.
+use std.runtime;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use os: std.system.os;
+use exec: std.process.exec;
+use R: std.types.result;
+
+fun spawn_blocker(program: *u8) i64 {
+    $if ($mach.build.os == $mach.os.windows) {
+        var argv: [3]usize;
+        argv[0] = program::usize;
+        argv[1] = ("--child")::usize;
+        argv[2] = 0;
+        ret os.spawn(program, (?argv[0])::**u8, nil);
+    }
+    $or {
+        # exec keeps the shell's PID while replacing it with the blocking
+        # program. this also runs under qemu-user, where the guest parent can
+        # launch the host's /bin/sh and /bin/sleep.
+        ret os.spawn_shell("exec sleep 3600", nil, nil);
+    }
+}
+
+fun cleanup(pid: i64) {
+    if (pid <= 0) { ret; }
+    os.terminate_child(pid);
+    var status: i32 = 0;
+    os.wait_pid(pid, ?status, 0);
+}
+
+fun status_ok(status: exec.ExitStatus) i64 {
+    $if ($mach.build.os == $mach.os.windows) {
+        if (!exec.exited(status) || exec.code(status) != 137) { ret 0; }
+    }
+    $or {
+        if (!exec.signaled(status) || exec.signal(status) != 9) { ret 0; }
+    }
+    ret 1;
+}
+
+fun terminate_and_wait(pid: i64) i64 {
+    val child: exec.Child = exec.Child{pid: pid};
+    val tr: R.Result[bool, str] = exec.terminate_child(child);
+    if (R.is_err[bool, str](tr)) { ret 0; }
+    val wr: R.Result[exec.ExitStatus, str] = exec.wait(child);
+    if (R.is_err[exec.ExitStatus, str](wr)) { ret 0; }
+    ret status_ok(R.unwrap_ok[exec.ExitStatus, str](wr));
+}
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    if (argc > 1) {
+        for (true) { os.sleep(1000000000); }
+        ret 0;
+    }
+
+    val first: i64 = spawn_blocker(argv[0]);
+    if (first < 0) { ret 10; }
+    val second: i64 = spawn_blocker(argv[0]);
+    if (second < 0) { cleanup(first); ret 11; }
+
+    val tr: R.Result[bool, str] = exec.terminate_child(exec.Child{pid: first});
+    if (R.is_err[bool, str](tr)) {
+        cleanup(first); cleanup(second); ret 20;
+    }
+
+    # force-stopping one child must not disturb a different tracked child.
+    var status: i32 = 0;
+    if (os.wait_pid(second, ?status, os.WNOHANG) != 0) {
+        cleanup(first); cleanup(second); ret 21;
+    }
+
+    val first_wait: R.Result[exec.ExitStatus, str] = exec.wait(exec.Child{pid: first});
+    if (R.is_err[exec.ExitStatus, str](first_wait)) {
+        cleanup(second); ret 22;
+    }
+    if (status_ok(R.unwrap_ok[exec.ExitStatus, str](first_wait)) == 0) {
+        cleanup(second); ret 23;
+    }
+
+    # reaped and never-spawned PIDs both fail as ECHILD; neither lookup can
+    # fall through to a raw PID-directed termination.
+    if (os.terminate_child(first) != os.ECHILD) {
+        cleanup(second); ret 24;
+    }
+    if (os.terminate_child(2147483647) != os.ECHILD) {
+        cleanup(second); ret 25;
+    }
+    if (os.wait_pid(second, ?status, os.WNOHANG) != 0) {
+        cleanup(second); ret 26;
+    }
+
+    if (os.terminate_child(second) != 0) { cleanup(second); ret 27; }
+    val second_wait: R.Result[exec.ExitStatus, str] = exec.wait(exec.Child{pid: second});
+    if (R.is_err[exec.ExitStatus, str](second_wait)) { ret 28; }
+    if (status_ok(R.unwrap_ok[exec.ExitStatus, str](second_wait)) == 0) { ret 29; }
+
+    # a fresh slot/child still terminates and reaps after the earlier cycles.
+    val third: i64 = spawn_blocker(argv[0]);
+    if (third < 0) { ret 30; }
+    if (terminate_and_wait(third) == 0) { cleanup(third); ret 31; }
+    ret 0;
+}

--- a/test/terminate-child/src/main.mach
+++ b/test/terminate-child/src/main.mach
@@ -92,6 +92,9 @@ fun main(argc: i64, argv: **u8) i64 {
     if (os.terminate_child(2147483647) != os.ECHILD) {
         cleanup(second); ret 25;
     }
+    if (os.terminate_child(0) != os.EINVAL) {
+        cleanup(second); ret 32;
+    }
     if (os.wait_pid(second, ?status, os.WNOHANG) != 0) {
         cleanup(second); ret 26;
     }

--- a/test/terminate-child/verify.sh
+++ b/test/terminate-child/verify.sh
@@ -25,6 +25,7 @@ decode() {
         28|29) echo "the terminated second child was not waitable with force-stop status" ;;
         30) echo "failed to spawn after earlier terminate/reap cycles" ;;
         31) echo "repeated terminate/reap cycle failed" ;;
+        32) echo "an invalid child PID was not EINVAL" ;;
         *) echo "unexpected exit code $1" ;;
     esac
 }

--- a/test/terminate-child/verify.sh
+++ b/test/terminate-child/verify.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# build and run the tracked-child force-termination probe against this checkout.
+#
+# usage: verify.sh [path-to-mach] [target] [runner]
+set -euo pipefail
+
+mach="${1:-mach}"
+target="${2:-linux-x86_64}"
+runner="${3:-}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+decode() {
+    case "$1" in
+        10|11) echo "failed to spawn blocking child $(( $1 - 9 ))" ;;
+        20) echo "high-level terminate_child failed" ;;
+        21) echo "terminating the first child disturbed the second" ;;
+        22|23) echo "the terminated first child was not waitable with force-stop status" ;;
+        24) echo "an already-reaped child was not ECHILD" ;;
+        25) echo "an unknown child was not ECHILD" ;;
+        26) echo "the unknown-child operation disturbed the second child" ;;
+        27) echo "low-level terminate_child failed" ;;
+        28|29) echo "the terminated second child was not waitable with force-stop status" ;;
+        30) echo "failed to spawn after earlier terminate/reap cycles" ;;
+        31) echo "repeated terminate/reap cycle failed" ;;
+        *) echo "unexpected exit code $1" ;;
+    esac
+}
+
+# copy this checkout rather than relying on symlink behaviour on Windows.
+rm -rf dep
+mkdir -p dep/std
+cp ../../mach.toml dep/std/mach.toml
+cp -r ../../src dep/std/src
+
+echo "building the terminate-child probe with $mach (target $target)"
+rm -rf out
+"$mach" build . --target "$target" --profile debug
+exe="$(find out -name 'terminate_child_probe*' -type f -print -quit)"
+[ -n "$exe" ] || fail "no terminate_child_probe binary produced"
+exe="$(cd "$(dirname "$exe")" && pwd)/$(basename "$exe")"
+
+echo "running $exe"
+set +e
+if [ -n "$runner" ]; then "$runner" "$exe"; else "$exe"; fi
+code=$?
+set -e
+[ "$code" -eq 0 ] || fail "$(decode "$code")"
+
+echo "OK: force-stop is exact, non-reaping, repeatable, and rejects stale children"


### PR DESCRIPTION
Closes #470

Adds a portable force-termination primitive for spawned children. The operation does not reap: callers must still wait to collect status and release platform resources.

- validate POSIX child ownership with `waitid(..., WNOWAIT)` before sending `SIGKILL`
- terminate Windows children through retained process handles and preserve those handles until `wait_pid` reaps them
- expose `std.process.exec.terminate_child(Child)` with the same forceful, non-reaping contract
- reject invalid, unknown, and already-reaped children without issuing a raw PID-directed kill
- require callers to serialize terminate/reap operations for the same child, closing the POSIX waitid-to-kill PID-reuse race contractually
- cover exact targeting, stale children, forced status, and repeated terminate/reap cycles on all supported targets

Verification:

- `mach build .`
- `mach test .` (790 passed)
- `mach test . --target linux-riscv64 --runner qemu-riscv64` (790 passed)
- native tracked-child probe: Linux x86_64/aarch64, Darwin x86_64/aarch64, Windows x86_64
- emulated tracked-child probe: Linux riscv64
- `bash test/backends/verify.sh`
- full CI matrix green at head `9ae8dc8`