### PR TITLE
feat(path): add portable lexical cleaning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Tracked child termination
         run: bash test/terminate-child/verify.sh
 
+      - name: Lexical path cleaning
+        run: bash test/path-clean/verify.sh
+
       # derive's refusals are `$error`s that fire during instantiation, so they
       # are evidenced by a build that fails rather than by a test that runs. the
       # classification is over field shapes and is target-independent, so one
@@ -118,6 +121,9 @@ jobs:
       - name: Tracked child termination (aarch64)
         run: bash test/terminate-child/verify.sh mach linux-arm64
 
+      - name: Lexical path cleaning (aarch64)
+        run: bash test/path-clean/verify.sh mach linux-arm64
+
   # windows runs the process probes, not the full suite. they require a real
   # kernel: wine's unix-backed filesystem gives the symlink probe a false pass,
   # while a cross-build cannot observe Win32 pipe or process-handle behaviour.
@@ -148,6 +154,10 @@ jobs:
       - name: Tracked child termination
         shell: bash
         run: bash test/terminate-child/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
+
+      - name: Lexical path cleaning
+        shell: bash
+        run: bash test/path-clean/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
 
   # darwin runs NATIVE on both architectures, for the same reason the arm64 job
   # above is native rather than emulated -- and with a sharper edge now that the
@@ -204,6 +214,9 @@ jobs:
 
       - name: Tracked child termination
         run: bash test/terminate-child/verify.sh mach "darwin-${{ matrix.arch }}"
+
+      - name: Lexical path cleaning
+        run: bash test/path-clean/verify.sh mach "darwin-${{ matrix.arch }}"
 
       # std itself is a static artifact, so the dependency list only becomes
       # observable once something LINKS it. this builds the backends smoke test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+#### path: portable lexical normalization (#472)
+
+`std.types.path.clean()` now produces an allocator-owned, stable spelling
+without consulting the filesystem. It removes repeated separators and `.`
+segments, resolves safe `..` segments, clamps climbs at absolute roots, and
+preserves leading relative climbs. POSIX roots, Windows drive and
+drive-relative prefixes, and UNC share roots keep their identities; Windows
+accepts both separator spellings and emits `\`, while POSIX keeps `\` as a
+filename byte. The operation deliberately does not resolve symlinks, make paths
+absolute, or normalize case.
+
 #### process: spawned children can be force-stopped without being reaped (#470)
 
 `std.process.exec.terminate_child()` forcefully stops one `Child` while leaving

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -746,9 +746,16 @@ test "std.types.path.clean:relative_segments" {
     var a: allocator.Allocator;
     fixed.make(?a, ?st, ?buf[0], 4096);
 
-    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a//./b/../c/")), "a/c")) { ret 1; }
-    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a/../../b")), "../b"))    { ret 1; }
-    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "../a/..")), ".."))       { ret 1; }
+    $if ($mach.build.os == $mach.os.windows) {
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a//./b/../c/")), "a\\c"))  { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a/../../b")), "..\\b"))    { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "../a/..")), ".."))          { ret 1; }
+    }
+    $or {
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a//./b/../c/")), "a/c")) { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a/../../b")), "../b"))    { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "../a/..")), ".."))       { ret 1; }
+    }
     if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "")), "."))              { ret 1; }
     if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a/..")), "."))          { ret 1; }
     ret 0;

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -767,8 +767,14 @@ test "std.types.path.clean:absolute_root_clamps" {
     var a: allocator.Allocator;
     fixed.make(?a, ?st, ?buf[0], 4096);
 
-    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "///a/../../b")), "/b")) { ret 1; }
-    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "/../..")), "/"))       { ret 1; }
+    $if ($mach.build.os == $mach.os.windows) {
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "/a/../../b")), "\\b")) { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "/../..")), "\\"))      { ret 1; }
+    }
+    $or {
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "/a/../../b")), "/b")) { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "/../..")), "/"))     { ret 1; }
+    }
     ret 0;
 }
 

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -23,7 +23,8 @@
 #
 # nil contract: a nil Path means "no path". predicates answer false for nil,
 # views return nil, and clone/stem propagate nil as ok(nil) rather than
-# allocating an empty path.
+# allocating an empty path. paths are null-terminated: the first NUL is the
+# end of the value, and bytes beyond it are not part of the path.
 
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -303,6 +304,176 @@ pub fun clone(a: *allocator.Allocator, p: Path) R.Result[Path, str] {
     ret R.ok[Path, str](buf);
 }
 
+# lexically normalize a path without filesystem access
+#
+# repeated separators and `.` segments are removed. `..` removes the prior
+# ordinary segment, is clamped at an absolute root, and is preserved when a
+# relative path cannot climb further. an empty result becomes `.`. windows
+# accepts both separator spellings and emits `\`; drive roots, drive-relative
+# prefixes, and UNC share roots remain indivisible. posix emits `/` and treats
+# `\` as an ordinary filename byte.
+#
+# clean does not resolve symlinks, inspect the filesystem, make a relative path
+# absolute, or normalize case. because Path is null-terminated, the first NUL
+# ends the input; bytes beyond it are not inspected. nil propagates as ok(nil).
+# ---
+# a: allocator for the normalized path
+# p: path to normalize
+# ret: an owned normalized path, or an error message
+pub fun clean(a: *allocator.Allocator, p: Path) R.Result[Path, str] {
+    if (a == nil) { ret R.err[Path, str]("allocator is nil"); }
+    if (p == nil) { ret R.ok[Path, str](nil); }
+
+    val n: usize = str_len(p);
+    # normalization cannot grow a nonempty path by more than the `.` appended
+    # to an empty or bare drive-relative result.
+    val r: R.Result[*u8, str] = allocator.allocate[u8](a, n + 2);
+    if (R.is_err[*u8, str](r)) {
+        ret R.err[Path, str](R.unwrap_err[*u8, str](r));
+    }
+    val out: *u8 = R.unwrap_ok[*u8, str](r);
+
+    val sep: u8 = separator();
+    var read: usize = 0;
+    var write: usize = 0;
+    var floor: usize = 0;
+    var rooted: bool = false;
+    var drive_relative: bool = false;
+
+    $if ($mach.build.os == $mach.os.windows) {
+        # a drive prefix is a volume even without a following separator.
+        if (n >= 2 && char_is_alpha(p[0]) && p[1] == ':') {
+            out[0] = p[0];
+            out[1] = ':';
+            read = 2;
+            write = 2;
+            floor = 2;
+            if (read < n && is_separator(p[read])) {
+                rooted = true;
+                out[write] = sep;
+                write = write + 1;
+                floor = write;
+                for (read < n && is_separator(p[read])) { read = read + 1; }
+            }
+            or {
+                drive_relative = true;
+            }
+        }
+        # a valid UNC volume is `\\server\share`; normalize both separators
+        # and all separator runs inside its root before walking descendants.
+        or (n >= 2 && is_separator(p[0]) && is_separator(p[1])) {
+            var server_start: usize = 2;
+            for (server_start < n && is_separator(p[server_start])) {
+                server_start = server_start + 1;
+            }
+            var server_end: usize = server_start;
+            for (server_end < n && !is_separator(p[server_end])) {
+                server_end = server_end + 1;
+            }
+            var share_start: usize = server_end;
+            for (share_start < n && is_separator(p[share_start])) {
+                share_start = share_start + 1;
+            }
+            var share_end: usize = share_start;
+            for (share_end < n && !is_separator(p[share_end])) {
+                share_end = share_end + 1;
+            }
+
+            if (server_end > server_start && share_end > share_start) {
+                out[write] = sep; write = write + 1;
+                out[write] = sep; write = write + 1;
+                memory.raw_copy((?out[write])::ptr, (?p[server_start])::ptr, server_end - server_start);
+                write = write + server_end - server_start;
+                out[write] = sep; write = write + 1;
+                memory.raw_copy((?out[write])::ptr, (?p[share_start])::ptr, share_end - share_start);
+                write = write + share_end - share_start;
+                read = share_end;
+                for (read < n && is_separator(p[read])) { read = read + 1; }
+                floor = write;
+                rooted = true;
+            }
+            or (server_end > server_start) {
+                # existing path helpers treat a bare `\\server` as one
+                # unusable-but-indivisible root unit; cleaning preserves it.
+                out[write] = sep; write = write + 1;
+                out[write] = sep; write = write + 1;
+                memory.raw_copy((?out[write])::ptr, (?p[server_start])::ptr, server_end - server_start);
+                write = write + server_end - server_start;
+                read = server_end;
+                for (read < n && is_separator(p[read])) { read = read + 1; }
+                floor = write;
+                rooted = true;
+            }
+            or {
+                # a separator-only spelling is the ordinary rooted path.
+                out[write] = sep;
+                write = write + 1;
+                floor = write;
+                rooted = true;
+                for (read < n && is_separator(p[read])) { read = read + 1; }
+            }
+        }
+        or (n > 0 && is_separator(p[0])) {
+            out[write] = sep;
+            write = write + 1;
+            floor = write;
+            rooted = true;
+            for (read < n && is_separator(p[read])) { read = read + 1; }
+        }
+    }
+    $or {
+        if (n > 0 && is_separator(p[0])) {
+            out[write] = sep;
+            write = write + 1;
+            floor = write;
+            rooted = true;
+            for (read < n && is_separator(p[read])) { read = read + 1; }
+        }
+    }
+
+    for (read < n) {
+        for (read < n && is_separator(p[read])) { read = read + 1; }
+        if (read >= n) { brk; }
+
+        val start: usize = read;
+        for (read < n && !is_separator(p[read])) { read = read + 1; }
+        val seg_len: usize = read - start;
+
+        if (seg_len == 1 && p[start] == '.') { cnt; }
+        if (seg_len == 2 && p[start] == '.' && p[start + 1] == '.') {
+            var prior_start: usize = write;
+            for (prior_start > floor && out[prior_start - 1] != sep) {
+                prior_start = prior_start - 1;
+            }
+            val prior_len: usize = write - prior_start;
+            val prior_is_dotdot: bool = prior_len == 2
+                && out[prior_start] == '.' && out[prior_start + 1] == '.';
+
+            if (write > floor && !prior_is_dotdot) {
+                if (prior_start > floor) { write = prior_start - 1; }
+                or { write = floor; }
+                cnt;
+            }
+            if (rooted) { cnt; }
+        }
+
+        val omit_sep: bool = drive_relative && write == floor;
+        if (write > 0 && out[write - 1] != sep && !omit_sep) {
+            out[write] = sep;
+            write = write + 1;
+        }
+        memory.raw_copy((?out[write])::ptr, (?p[start])::ptr, seg_len);
+        write = write + seg_len;
+    }
+
+    if (write == 0 || (drive_relative && write == floor)) {
+        out[write] = '.';
+        write = write + 1;
+    }
+    out[write] = 0;
+    ret R.ok[Path, str](out);
+}
+
 # join two path segments with the platform separator
 # ---
 # a:     allocator for the resulting path
@@ -566,6 +737,77 @@ test "std.types.path.clone:distinct_and_nil" {
     if (got::usize == src::usize) { ret 1; }
 
     if (R.unwrap_ok[Path, str](clone(?a, nil)) != nil) { ret 1; }
+    ret 0;
+}
+
+test "std.types.path.clean:relative_segments" {
+    var buf: [4096]u8;
+    var st: fixed.FixedState;
+    var a: allocator.Allocator;
+    fixed.make(?a, ?st, ?buf[0], 4096);
+
+    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a//./b/../c/")), "a/c")) { ret 1; }
+    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a/../../b")), "../b"))    { ret 1; }
+    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "../a/..")), ".."))       { ret 1; }
+    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "")), "."))              { ret 1; }
+    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a/..")), "."))          { ret 1; }
+    ret 0;
+}
+
+test "std.types.path.clean:absolute_root_clamps" {
+    var buf: [4096]u8;
+    var st: fixed.FixedState;
+    var a: allocator.Allocator;
+    fixed.make(?a, ?st, ?buf[0], 4096);
+
+    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "///a/../../b")), "/b")) { ret 1; }
+    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "/../..")), "/"))       { ret 1; }
+    ret 0;
+}
+
+test "std.types.path.clean:nul_terminates_input" {
+    var raw: [4]u8;
+    raw[0] = 'a'; raw[1] = 0; raw[2] = 'b'; raw[3] = 0;
+    var buf: [64]u8;
+    var st: fixed.FixedState;
+    var a: allocator.Allocator;
+    fixed.make(?a, ?st, ?buf[0], 64);
+
+    if (!str_equals(R.unwrap_ok[Path, str](clean(?a, ?raw[0])), "a")) { ret 1; }
+    if (R.unwrap_ok[Path, str](clean(?a, nil)) != nil) { ret 1; }
+    ret 0;
+}
+
+# on posix a backslash is data, not a separator
+test "std.types.path.clean:posix_backslash_is_data" {
+    $if ($mach.build.os != $mach.os.windows) {
+        var buf: [64]u8;
+        var st: fixed.FixedState;
+        var a: allocator.Allocator;
+        fixed.make(?a, ?st, ?buf[0], 64);
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "a\\b/./c")), "a\\b/c")) { ret 1; }
+    }
+    ret 0;
+}
+
+test "std.types.path.clean:windows_drive_and_unc_roots" {
+    $if ($mach.build.os == $mach.os.windows) {
+        var buf: [4096]u8;
+        var st: fixed.FixedState;
+        var a: allocator.Allocator;
+        fixed.make(?a, ?st, ?buf[0], 4096);
+
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "C:\\foo\\.\\bar\\..\\baz")), "C:\\foo\\baz")) { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "C:/foo//../bar")), "C:\\bar"))                  { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "C:foo\\..\\bar")), "C:bar"))                  { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "C:foo\\..\\..")), "C:.."))                   { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "C:")), "C:."))                                 { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "\\\\server\\share\\dir\\..\\file")), "\\\\server\\share\\file")) { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "//server/share/../../x")), "\\\\server\\share\\x"))         { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "\\\\server\\share\\\\")), "\\\\server\\share"))    { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "\\\\server")), "\\\\server"))                             { ret 1; }
+        if (!str_equals(R.unwrap_ok[Path, str](clean(?a, "\\foo\\..\\..")), "\\"))                                 { ret 1; }
+    }
     ret 0;
 }
 

--- a/test/path-clean/mach.toml
+++ b/test/path-clean/mach.toml
@@ -1,0 +1,46 @@
+[project]
+id = "pathcleanprobe"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux-x86_64]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[target.windows-x86_64]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[profile.debug]
+opt = 0
+debug = true
+simd = "scalarize"
+
+[artifact.path_clean_probe]
+kind = "bin"
+entry = "main.mach"
+out = "bin/path_clean_probe"
+targets = ["*"]
+link = []
+need = []
+
+[dep.std]
+path = "dep/std"

--- a/test/path-clean/src/main.mach
+++ b/test/path-clean/src/main.mach
@@ -23,9 +23,16 @@ fun main(argc: i64, argv: **u8) i64 {
     var a: A.Allocator;
     fixed.make(?a, ?st, ?buf[0], 16384);
 
-    if (!expect(?a, "a//./b/../c/", "a/c")) { ret 10; }
-    if (!expect(?a, "a/../../b", "../b"))    { ret 11; }
-    if (!expect(?a, "../../a/..", "../..")) { ret 12; }
+    $if ($mach.build.os == $mach.os.windows) {
+        if (!expect(?a, "a//./b/../c/", "a\\c"))    { ret 10; }
+        if (!expect(?a, "a/../../b", "..\\b"))      { ret 11; }
+        if (!expect(?a, "../../a/..", "..\\.."))   { ret 12; }
+    }
+    $or {
+        if (!expect(?a, "a//./b/../c/", "a/c")) { ret 10; }
+        if (!expect(?a, "a/../../b", "../b"))    { ret 11; }
+        if (!expect(?a, "../../a/..", "../..")) { ret 12; }
+    }
     if (!expect(?a, "a/..", "."))           { ret 13; }
     if (!expect(?a, "", "."))               { ret 14; }
 

--- a/test/path-clean/src/main.mach
+++ b/test/path-clean/src/main.mach
@@ -1,0 +1,50 @@
+# portable lexical path-cleaning probe (#472)
+use std.runtime;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.string.str;
+use std.types.string.str_equals;
+use A: std.allocator;
+use fixed: std.allocator.fixed;
+use path: std.types.path;
+use R: std.types.result;
+
+fun expect(a: *A.Allocator, input: str, wanted: str) bool {
+    val r: R.Result[path.Path, str] = path.clean(a, input);
+    if (R.is_err[path.Path, str](r)) { ret false; }
+    ret str_equals(R.unwrap_ok[path.Path, str](r), wanted);
+}
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    var buf: [16384]u8;
+    var st: fixed.FixedState;
+    var a: A.Allocator;
+    fixed.make(?a, ?st, ?buf[0], 16384);
+
+    if (!expect(?a, "a//./b/../c/", "a/c")) { ret 10; }
+    if (!expect(?a, "a/../../b", "../b"))    { ret 11; }
+    if (!expect(?a, "../../a/..", "../..")) { ret 12; }
+    if (!expect(?a, "a/..", "."))           { ret 13; }
+    if (!expect(?a, "", "."))               { ret 14; }
+
+    $if ($mach.build.os == $mach.os.windows) {
+        if (!expect(?a, "C:\\foo\\.\\bar\\..\\baz", "C:\\foo\\baz")) { ret 20; }
+        if (!expect(?a, "C:/foo//../bar", "C:\\bar"))                 { ret 21; }
+        if (!expect(?a, "C:foo\\..\\bar", "C:bar"))                 { ret 22; }
+        if (!expect(?a, "C:foo\\..\\..", "C:.."))                  { ret 23; }
+        if (!expect(?a, "C:\\..\\..", "C:\\"))                   { ret 24; }
+        if (!expect(?a, "\\\\server\\share\\dir\\..\\file", "\\\\server\\share\\file")) { ret 25; }
+        if (!expect(?a, "//server/share/../../x", "\\\\server\\share\\x"))        { ret 26; }
+        if (!expect(?a, "\\\\server\\share\\\\", "\\\\server\\share"))   { ret 27; }
+        if (!expect(?a, "\\foo\\..\\..", "\\"))                                { ret 28; }
+    }
+    $or {
+        if (!expect(?a, "///a/../../b", "/b"))     { ret 30; }
+        if (!expect(?a, "/../..", "/"))           { ret 31; }
+        if (!expect(?a, "a\\b/./c", "a\\b/c")) { ret 32; }
+    }
+
+    ret 0;
+}

--- a/test/path-clean/verify.sh
+++ b/test/path-clean/verify.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# build and run the portable lexical path-cleaning probe against this checkout.
+#
+# usage: verify.sh [path-to-mach] [target]
+set -euo pipefail
+
+mach="${1:-mach}"
+target="${2:-linux-x86_64}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$here"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+decode() {
+    case "$1" in
+        10) echo "repeated separator/dot collapse failed" ;;
+        11|12) echo "relative dotdot preservation failed" ;;
+        13|14) echo "empty normalized result was not dot" ;;
+        20|21) echo "windows drive-root normalization failed" ;;
+        22|23) echo "windows drive-relative normalization failed" ;;
+        24) echo "windows drive root did not clamp dotdot" ;;
+        25|26|27) echo "windows UNC root normalization failed" ;;
+        28) echo "windows rooted path did not clamp dotdot" ;;
+        30|31) echo "posix root normalization failed" ;;
+        32) echo "posix treated backslash as a separator" ;;
+        *) echo "unexpected exit code $1" ;;
+    esac
+}
+
+# copy this checkout rather than relying on symlink behaviour on Windows.
+rm -rf dep
+mkdir -p dep/std
+cp ../../mach.toml dep/std/mach.toml
+cp -r ../../src dep/std/src
+
+echo "building the path-clean probe with $mach (target $target)"
+rm -rf out
+"$mach" build . --target "$target" --profile debug
+exe="$(find out -name 'path_clean_probe*' -type f -print -quit)"
+[ -n "$exe" ] || fail "no path_clean_probe binary produced"
+exe="$(cd "$(dirname "$exe")" && pwd)/$(basename "$exe")"
+
+echo "running $exe"
+set +e
+"$exe"
+code=$?
+set -e
+[ "$code" -eq 0 ] || fail "$(decode "$code")"
+
+echo "OK: lexical cleaning preserves native roots and resolves safe segments"


### PR DESCRIPTION
Closes #472

Adds allocator-owned `std.types.path.clean` without filesystem access.

- collapse repeated separators and `.` segments
- resolve safe `..`, clamp at absolute roots, preserve leading relative climbs
- preserve POSIX, Windows drive, drive-relative, and UNC roots
- accept both Windows separators and emit the native spelling
- define nil and null-terminated input behavior
- execute focused public-API probes on Linux x86_64/aarch64, Darwin x86_64/aarch64, and Windows x86_64

Verification:

- `mach build .`
- `mach test .` (795 passed)
- `bash test/path-clean/verify.sh`
- Windows fixture cross-build + execution under Wine
- `bash test/backends/verify.sh`
- full CI matrix green at head `f32424b`, including native Linux x86_64/aarch64, Darwin x86_64/aarch64, Windows x86_64, and riscv64 QEMU