### PR TITLE
chore(release): 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.27.0] - 2026-08-20
 
 ### Added
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.26.1"
+version = "0.27.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 


### PR DESCRIPTION
Promotes `[Unreleased]` to `[0.27.0]` and bumps `mach.toml`.

Contents: `terminate_child` (#470), `ignore_sigpipe` (#468), and the toml teardown and ownership fix (#474). Additions without a break, so a minor bump.

Cut so briar-systems/mach can advance its `branch/main` pin to a mach-std carrying `toml.dnit`, which briar-systems/mach#3001 needs.