### PR TITLE
chore(release): 0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.28.1] - 2026-08-21
 
 ### Fixed
 

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.28.0"
+version = "0.28.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 


### PR DESCRIPTION
Patch for #478: a cleaned path is now freed to exactly nothing.