### PR TITLE
mach-std 0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.28.1] - 2026-08-21
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+#### types(path): a cleaned path is freed to exactly nothing (#478)
+
+`clean` worked in a buffer sized for its INPUT and returned it untrimmed, so a caller
+freeing the result with `str_free` - which releases `str_len + 1` - returned less than
+was taken and leaked the difference. Every other allocating function here reserves
+exactly `str_len + 1`; cleaning cannot know its output length until it has produced
+it, so the working buffer is now shrunk before it is handed back rather than making
+this one return value the odd one out.
+
+Caught by leak assertions one repo over (briar-systems/mach#3001), which is exactly
+how far a size mismatch travels before anyone notices - so the new test asserts the
+balance directly, through a counting allocator, on the inputs whose cleaned length
+differs most from their input length.
+
 ## [0.28.0] - 2026-08-21
 
 ### Added

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.28.0"
+version = "0.28.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/types/path.mach
+++ b/src/types/path.mach
@@ -40,6 +40,8 @@ use std.allocator.page;
 use std.allocator.Allocator;
 use std.system.os;
 
+use std.text.string.str_free;
+use O: std.types.option;
 use R: std.types.result;
 
 # a null-terminated filesystem path
@@ -522,6 +524,18 @@ pub fun clean(a: *allocator.Allocator, p: Path) R.Result[Path, str] {
         ret clone_dot(a);
     }
     out[w] = 0;
+
+    # SHRINK TO THE EXACT SIZE EVERY OTHER PATH RETURN USES. `clone`, `join` and
+    # `parent` all allocate exactly `str_len + 1`, which is the size `str_free`
+    # releases - so a `Path` that came back larger is freed short, and the remainder
+    # leaks. Cleaning cannot know its own output length until it has produced it, so
+    # the working buffer is sized for the input and handed back trimmed rather than
+    # making this one return value the odd one out.
+    if (w + 1 < len + 2) {
+        val rr: R.Result[*u8, str] = allocator.reallocate[u8](a, out, len + 2, w + 1);
+        if (R.is_err[*u8, str](rr)) { ret R.err[Path, str](R.unwrap_err[*u8, str](rr)); }
+        ret R.ok[Path, str](R.unwrap_ok[*u8, str](rr)::str);
+    }
     ret R.ok[Path, str](out::str);
 }
 
@@ -861,4 +875,67 @@ fun clean_is(a: *Allocator, input: str, want: str) bool {
     }
     buf[wl] = 0;
     ret str_equals(got, (?buf[0])::str);
+}
+
+# A RETURNED PATH IS FREEABLE WITH `str_free`, which is the contract every other
+# allocating function here already keeps: `clone`, `join` and `parent` all reserve
+# exactly `str_len + 1`. `clean` cannot know its output length until it has produced
+# it, so it works in a buffer sized for the input and must hand back a trimmed one -
+# otherwise a consumer frees `str_len + 1` of a larger allocation and the remainder
+# leaks. Caught by a leak test one repo over (briar-systems/mach#3001's steady-state
+# assertions), which is exactly the distance a size mismatch travels before anyone
+# notices, hence this one asserts the balance directly.
+rec CleanCount {
+    backing: Allocator;
+    live:    i64;
+}
+
+fun clean_count_alloc(ctx: ptr, size: usize, align: usize) O.Option[ptr] {
+    val c: *CleanCount = ctx::*CleanCount;
+    val r: O.Option[ptr] = c.backing.fn_allocate(c.backing.ctx, size, align);
+    if (O.is_some[ptr](r)) { c.live = c.live + size::i64; }
+    ret r;
+}
+fun clean_count_realloc(ctx: ptr, p: ptr, o: usize, n: usize, align: usize) O.Option[ptr] {
+    val c: *CleanCount = ctx::*CleanCount;
+    val r: O.Option[ptr] = c.backing.fn_reallocate(c.backing.ctx, p, o, n, align);
+    if (O.is_some[ptr](r)) { c.live = c.live - o::i64 + n::i64; }
+    ret r;
+}
+fun clean_count_dealloc(ctx: ptr, p: ptr, size: usize, align: usize) i64 {
+    val c: *CleanCount = ctx::*CleanCount;
+    c.live = c.live - size::i64;
+    ret c.backing.fn_deallocate(c.backing.ctx, p, size, align);
+}
+
+test "path: a cleaned path frees to exactly nothing" {
+    var cc: CleanCount;
+    if (O.is_some[str](page.make(?cc.backing))) { ret 1; }
+    cc.live = 0;
+    var a: Allocator;
+    a.ctx = (?cc)::ptr;
+    a.fn_allocate = clean_count_alloc;
+    a.fn_reallocate = clean_count_realloc;
+    a.fn_deallocate = clean_count_dealloc;
+
+    # the shapes whose cleaned length differs most from their input length
+    var inputs: [6]str;
+    inputs[0] = "a/./b";
+    inputs[1] = "./src/f.mach";
+    inputs[2] = "/r/./src/./deep/../f.mach";
+    inputs[3] = "a//////b";
+    inputs[4] = "a/b";
+    inputs[5] = "";
+
+    var i: usize = 0;
+    for (i < 6) {
+        val r: R.Result[Path, str] = clean(?a, inputs[i]);
+        if (R.is_err[Path, str](r)) { ret 2; }
+        val got: Path = R.unwrap_ok[Path, str](r);
+        str_free(?a, got);
+        # freeing by string length must return every byte the clean took
+        if (cc.live != 0) { ret 3; }
+        i = i + 1;
+    }
+    ret 0;
 }


### PR DESCRIPTION
Integration merge for 0.28.1: a cleaned path is freed to exactly nothing (#478).