### PR TITLE
ci: gate releases on the full native target suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Retain native evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-evidence-linux-x86_64
           path: test/native/results/
@@ -143,7 +143,7 @@ jobs:
 
       - name: Retain native evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-evidence-linux-arm64
           path: test/native/results/
@@ -194,7 +194,7 @@ jobs:
 
       - name: Retain native evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-evidence-windows-x86_64
           path: test/native/results/
@@ -257,7 +257,7 @@ jobs:
 
       - name: Retain native evidence
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-evidence-darwin-${{ matrix.arch }}
           path: test/native/results/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  workflow_call:
   pull_request:
     branches: [dev, main]
   # release branches also build on push. a pull_request trigger is selected from
@@ -12,7 +13,8 @@ on:
       - 'hotfix/*'
 
 jobs:
-  build:
+  linux-x86_64:
+    name: linux x86_64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -27,8 +29,14 @@ jobs:
       - name: Build
         run: mach build .
 
-      - name: Test
-        run: mach test .
+      - name: Run the complete native suite
+        run: bash test/native/verify.sh mach linux-x86_64
+
+      - name: Collect native ELF evidence
+        run: |
+          set -o pipefail
+          bash test/backends/verify-native.sh mach linux-x86_64 \
+            | tee test/native/results/linux-x86_64-format.log
 
       - name: RELRO re-protection contract
         run: bash test/relro/verify.sh
@@ -48,6 +56,15 @@ jobs:
       # leg is the whole signal.
       - name: std.derive comptime refusals
         run: bash test/derive/verify.sh
+
+      - name: Retain native evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-evidence-linux-x86_64
+          path: test/native/results/
+          if-no-files-found: warn
+          retention-days: 14
 
   cross-riscv64:
     runs-on: ubuntu-latest
@@ -106,8 +123,14 @@ jobs:
 
       - name: Report the seed
         run: mach info
-      - name: Run the test suite natively on aarch64
-        run: mach test .
+      - name: Run the complete native suite on aarch64
+        run: bash test/native/verify.sh mach linux-arm64
+
+      - name: Collect native ELF evidence
+        run: |
+          set -o pipefail
+          bash test/backends/verify-native.sh mach linux-arm64 \
+            | tee test/native/results/linux-arm64-format.log
 
       - name: RELRO re-protection contract (aarch64)
         run: bash test/relro/verify.sh mach linux-arm64
@@ -118,10 +141,19 @@ jobs:
       - name: Tracked child termination (aarch64)
         run: bash test/terminate-child/verify.sh mach linux-arm64
 
-  # windows runs the process probes, not the full suite. they require a real
-  # kernel: wine's unix-backed filesystem gives the symlink probe a false pass,
-  # while a cross-build cannot observe Win32 pipe or process-handle behaviour.
+      - name: Retain native evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-evidence-linux-arm64
+          path: test/native/results/
+          if-no-files-found: warn
+          retention-days: 14
+
+  # windows runs the complete suite and the host-specific process probes on a
+  # native kernel. the known-failure gate rejects new failures and stale entries.
   windows:
+    name: windows x86_64
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v6
@@ -133,6 +165,17 @@ jobs:
 
       - name: Report the seed
         run: mach info
+
+      - name: Run the complete native suite
+        shell: bash
+        run: bash test/native/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
+
+      - name: Collect native PE evidence
+        shell: bash
+        run: |
+          set -o pipefail
+          bash test/backends/verify-native.sh "$PWD/.mach-seed/mach.exe" windows-x86_64 \
+            | tee test/native/results/windows-x86_64-format.log
 
       # the explicit path rather than the PATH entry: this probe runs under bash on
       # the windows runner and takes the compiler as an argument, so it names the
@@ -148,6 +191,15 @@ jobs:
       - name: Tracked child termination
         shell: bash
         run: bash test/terminate-child/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
+
+      - name: Retain native evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-evidence-windows-x86_64
+          path: test/native/results/
+          if-no-files-found: warn
+          retention-days: 14
 
   # darwin runs NATIVE on both architectures, for the same reason the arm64 job
   # above is native rather than emulated -- and with a sharper edge now that the
@@ -188,16 +240,8 @@ jobs:
       - name: Build
         run: mach build .
 
-      # gated against test/darwin/known-failures.txt rather than run bare. this
-      # lane's FIRST execution found eleven failures on both architectures, all
-      # of them predating this migration -- confirmed by running untouched `dev`
-      # on the same two runners. they are enumerated with evidence in that file.
-      #
-      # the gate fails on any failure not listed AND on any listed test that
-      # starts passing, so the list cannot become a mute button: it has to
-      # shrink to empty as the rest of #415 lands.
-      - name: Run the test suite natively on darwin
-        run: bash test/darwin/verify.sh
+      - name: Run the complete native suite on darwin
+        run: bash test/native/verify.sh mach "darwin-${{ matrix.arch }}"
 
       - name: SIGPIPE suppression
         run: bash test/sigpipe/verify.sh mach "darwin-${{ matrix.arch }}"
@@ -205,64 +249,20 @@ jobs:
       - name: Tracked child termination
         run: bash test/terminate-child/verify.sh mach "darwin-${{ matrix.arch }}"
 
-      # std itself is a static artifact, so the dependency list only becomes
-      # observable once something LINKS it. this builds the backends smoke test
-      # natively -- an executable -- and inspects that.
-      #
-      # the image must name exactly one libSystem, under its install path. two
-      # LC_LOAD_DYLIB commands -- the implicit platform dependency plus a
-      # manifest entry spelled differently enough not to match it -- load and
-      # run here, so nothing else in this job would notice.
-      - name: One libSystem dependency, at its install path
+      - name: Collect native Mach-O evidence
         run: |
-          set -euo pipefail
-          cd test/backends
-          mkdir -p dep
-          ln -sfn "$(cd ../.. && pwd)" dep/std
-          mach build . --profile debug
-          exe="$(find out -type f -name backends -print -quit)"
-          [ -n "$exe" ] || { echo "::error::no native darwin executable was produced"; exit 1; }
-          echo "inspecting $exe"
-          otool -L "$exe"
-          n="$(otool -L "$exe" | tail -n +2 | grep -c 'libSystem' || true)"
-          [ "$n" = "1" ] || { echo "::error::expected exactly 1 libSystem dependency, found $n"; exit 1; }
-          otool -L "$exe" | grep -q '/usr/lib/libSystem.B.dylib' \
-            || { echo "::error::libSystem is not named by its install path"; exit 1; }
-          # and it runs: the binary dyld-binds libSystem and reaches main
-          ./"$exe"
+          set -o pipefail
+          bash test/backends/verify-native.sh mach "darwin-${{ matrix.arch }}" \
+            | tee "test/native/results/darwin-${{ matrix.arch }}-format.log"
 
-      # the stat family is reached through the `$INODE64` variant symbol on
-      # x86_64 and the plain name on arm64. binding the plain name on x86_64
-      # would link, run, and quietly fill stat_t from a different struct
-      # layout, so the bound symbol name is asserted per architecture.
-      - name: The stat family binds the right symbol for this architecture
-        run: |
-          set -euo pipefail
-          exe="$(find test/backends/out -type f -name backends -print -quit)"
-          # the undefined-symbol list is the stable spelling across xcode
-          # versions; the bind-table dumpers move around, the symbol table does not
-          undef="$(nm -u "$exe")"
-          printf '%s\n' "$undef" | grep -F '_fstat' || true
-
-          if [ "${{ matrix.arch }}" = "x86_64" ]; then
-            if ! printf '%s\n' "$undef" | grep -qF '_fstat$INODE64'; then
-              echo "::error::x86_64 must bind _fstat\$INODE64, not the legacy 32-bit-inode _fstat"
-              exit 1
-            fi
-            if ! printf '%s\n' "$undef" | grep -qF '_fstatat$INODE64'; then
-              echo "::error::x86_64 must bind _fstatat\$INODE64"
-              exit 1
-            fi
-          else
-            if ! printf '%s\n' "$undef" | grep -qx '_fstat'; then
-              echo "::error::arm64 must bind the plain _fstat"
-              exit 1
-            fi
-            if printf '%s\n' "$undef" | grep -qF 'INODE64'; then
-              echo "::error::arm64 has no \$INODE64 variant; binding one is wrong"
-              exit 1
-            fi
-          fi
+      - name: Retain native evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-evidence-darwin-${{ matrix.arch }}
+          path: test/native/results/
+          if-no-files-found: warn
+          retention-days: 14
 
   cross-backends:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,11 @@ permissions:
   contents: write
 
 jobs:
+  native-matrix:
+    uses: ./.github/workflows/ci.yml
+
   release:
+    needs: native-matrix
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/test/backends/src/main.mach
+++ b/test/backends/src/main.mach
@@ -1,7 +1,5 @@
-# cross-compile smoke test for the non-linux backends: imports the
-# top-level OS and filesystem surfaces so the target-gated windows / darwin
-# modules are actually instantiated instead of skipped as dead $if branches.
-# this only needs to compile, not run.
+# imports the top-level os and filesystem surfaces so target-gated backend
+# modules are instantiated for cross-builds and native artifact checks.
 use std.runtime;
 use std.system.os;
 use std.filesystem;

--- a/test/backends/verify-native.sh
+++ b/test/backends/verify-native.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mach="${1:-mach}"
+target="${2:-linux-x86_64}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+rm -rf "$here/dep"
+mkdir -p "$here/dep/std"
+cp "$root/mach.toml" "$here/dep/std/mach.toml"
+cp -R "$root/src" "$here/dep/std/src"
+
+cd "$here"
+rm -rf "out/$target"
+"$mach" build . --target "$target" --profile debug
+exe="$(find "out/$target" -type f \( -name backends -o -name 'backends.exe' \) -print -quit)"
+[ -n "$exe" ] || fail "$target produced no native executable"
+
+echo "running $exe"
+"$exe"
+echo
+
+case "$target" in
+    linux-x86_64)
+        readelf -h -l -d "$exe"
+        readelf -h "$exe" | grep -q 'Class:[[:space:]]*ELF64' \
+            || fail "$target did not produce ELF64"
+        readelf -h "$exe" | grep -q 'Machine:[[:space:]]*Advanced Micro Devices X86-64' \
+            || fail "$target produced the wrong machine"
+        ;;
+    linux-arm64)
+        readelf -h -l -d "$exe"
+        readelf -h "$exe" | grep -q 'Class:[[:space:]]*ELF64' \
+            || fail "$target did not produce ELF64"
+        readelf -h "$exe" | grep -q 'Machine:[[:space:]]*AArch64' \
+            || fail "$target produced the wrong machine"
+        ;;
+    darwin-x86_64|darwin-aarch64)
+        otool -hv "$exe"
+        otool -L "$exe"
+        deps="$(otool -L "$exe" | tail -n +2 | grep -c 'libSystem' || true)"
+        [ "$deps" = "1" ] || fail "$target expected one libSystem dependency, found $deps"
+        otool -L "$exe" | grep -q '/usr/lib/libSystem.B.dylib' \
+            || fail "$target does not name libSystem by its install path"
+
+        undef="$(nm -u "$exe")"
+        printf '%s\n' "$undef"
+        if [ "$target" = "darwin-x86_64" ]; then
+            printf '%s\n' "$undef" | grep -qF "_fstat\$INODE64" \
+                || fail "$target does not bind _fstat\$INODE64"
+            printf '%s\n' "$undef" | grep -qF "_fstatat\$INODE64" \
+                || fail "$target does not bind _fstatat\$INODE64"
+        else
+            printf '%s\n' "$undef" | grep -qx '_fstat' \
+                || fail "$target does not bind plain _fstat"
+            ! printf '%s\n' "$undef" | grep -qF 'INODE64' \
+                || fail "$target must not bind an INODE64 variant"
+        fi
+        ;;
+    windows-x86_64)
+        command -v llvm-readobj >/dev/null \
+            || fail "llvm-readobj is unavailable on the native windows runner"
+        llvm-readobj --file-headers --coff-imports "$exe"
+        llvm-readobj --file-headers "$exe" | grep -q 'Format: COFF-x86-64' \
+            || fail "$target did not produce x86-64 COFF"
+        ;;
+    *)
+        fail "unsupported native evidence target $target"
+        ;;
+esac
+
+echo "OK: $target native executable ran and matches its target format"

--- a/test/native/.gitignore
+++ b/test/native/.gitignore
@@ -1,0 +1,4 @@
+/dep/
+/out/
+/results/
+

--- a/test/native/known-failures/darwin-aarch64.txt
+++ b/test/native/known-failures/darwin-aarch64.txt
@@ -1,0 +1,9 @@
+# owner: mach-std maintainers, issue #415
+# baseline: 2026-08-26
+
+std.process.exec.run:success_exits_zero
+std.process.exec.run:failure_exits_one
+std.process.exec.spawn:wait_matches_run
+std.process.exec.run:repeated_spawns_stay_correct
+std.process.exec.wait_any:reaps_each_child_once
+

--- a/test/native/known-failures/darwin-x86_64.txt
+++ b/test/native/known-failures/darwin-x86_64.txt
@@ -1,0 +1,9 @@
+# owner: mach-std maintainers, issue #415
+# baseline: 2026-08-26
+
+std.process.exec.run:success_exits_zero
+std.process.exec.run:failure_exits_one
+std.process.exec.spawn:wait_matches_run
+std.process.exec.run:repeated_spawns_stay_correct
+std.process.exec.wait_any:reaps_each_child_once
+

--- a/test/native/known-failures/linux-arm64.txt
+++ b/test/native/known-failures/linux-arm64.txt
@@ -1,0 +1,4 @@
+# owner: mach-std maintainers, issue #500
+# baseline: 2026-08-26
+# no known failures
+

--- a/test/native/known-failures/linux-x86_64.txt
+++ b/test/native/known-failures/linux-x86_64.txt
@@ -1,0 +1,4 @@
+# owner: mach-std maintainers, issue #500
+# baseline: 2026-08-26
+# no known failures
+

--- a/test/native/known-failures/windows-x86_64.txt
+++ b/test/native/known-failures/windows-x86_64.txt
@@ -1,0 +1,4 @@
+# owner: mach-std maintainers, issue #500
+# baseline: 2026-08-26
+# the initial native run must establish this list
+

--- a/test/native/known-failures/windows-x86_64.txt
+++ b/test/native/known-failures/windows-x86_64.txt
@@ -1,4 +1,10 @@
 # owner: mach-std maintainers, issue #500
 # baseline: 2026-08-26
-# the initial native run must establish this list
+# confirmed by the first complete native windows run
 
+path: clean degenerate and root inputs
+path: clean preserves windows drive and UNC roots
+std.filesystem.write_bytes:read_string_roundtrip
+std.process.exec.resolve:finds_a_real_program_on_path
+std.types.path.join:single_separator
+std.types.path.resolve:abs_verbatim_rel_joined

--- a/test/native/mach.toml
+++ b/test/native/mach.toml
@@ -1,46 +1,52 @@
 [project]
-id = "backends"
+id = "native-suite"
 version = "0.0.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 
 [target.linux-x86_64]
 isa = "x86_64"
-os  = "linux"
+os = "linux"
 abi = "sysv64"
 
 [target.linux-arm64]
 isa = "aarch64"
-os  = "linux"
+os = "linux"
 abi = "aapcs64"
-
-[target.windows-x86_64]
-isa = "x86_64"
-os  = "windows"
-abi = "win64"
 
 [target.darwin-x86_64]
 isa = "x86_64"
-os  = "darwin"
+os = "darwin"
 abi = "sysv64"
 
 [target.darwin-aarch64]
 isa = "aarch64"
-os  = "darwin"
+os = "darwin"
 abi = "aapcs64"
+
+[target.windows-x86_64]
+isa = "x86_64"
+os = "windows"
+abi = "win64"
 
 [profile.debug]
 opt = 0
 debug = true
 simd = "scalarize"
 
-[artifact.backends]
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.native-suite]
 kind = "bin"
 entry = "main.mach"
-out = "bin/backends"
+out = "bin/native-suite"
 targets = ["*"]
 link = []
 need = []
 
 [dep.std]
 path = "dep/std"
+

--- a/test/native/src/main.mach
+++ b/test/native/src/main.mach
@@ -1,0 +1,8 @@
+use std.lib.libstd;
+use std.runtime;
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    ret 0;
+}
+

--- a/test/native/verify.sh
+++ b/test/native/verify.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+mach="${1:-mach}"
+target="${2:-linux-x86_64}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+known="${3:-$here/known-failures/$target.txt}"
+root="$(cd "$here/../.." && pwd)"
+result="$here/results/$target.log"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+[ -f "$known" ] || fail "$target has no known-failure policy at $known"
+grep -qE '^# owner: .+' "$known" || fail "$known has no owner"
+grep -qE '^# baseline: [0-9]{4}-[0-9]{2}-[0-9]{2}$' "$known" \
+    || fail "$known has no baseline date"
+
+rm -rf "$here/dep"
+mkdir -p "$here/dep/std" "$here/results"
+cp "$root/mach.toml" "$here/dep/std/mach.toml"
+cp -R "$root/src" "$here/dep/std/src"
+
+cd "$here"
+
+list="$(mktemp)"
+expected_file="$(mktemp)"
+actual_file="$(mktemp)"
+trap 'rm -f "$list" "$expected_file" "$actual_file"' EXIT
+
+"$mach" test . --target "$target" --include-deps --list > "$list" \
+    || fail "$target suite could not be listed"
+
+required=(
+    'src/sync/thread.mach'
+    'src/process/exec.mach'
+    'src/filesystem.mach'
+    'src/net/tcp.mach'
+    'src/net/udp.mach'
+    'src/chrono/time.mach'
+)
+for source in "${required[@]}"; do
+    grep -qF "$source" "$list" || fail "$target omitted required tests from $source"
+done
+
+grep -vE '^[[:space:]]*(#|$)' "$known" \
+    | sed 's/[[:space:]]*$//' | sort -u > "$expected_file"
+
+set +e
+"$mach" test . --target "$target" --include-deps 2>&1 | tee "$result"
+code=${PIPESTATUS[0]}
+set -e
+
+[ "$code" -le 1 ] || fail "$target suite did not run to completion (exit $code)"
+
+summary="$(grep -E '[0-9]+ passed, [0-9]+ failed, [0-9]+ total' "$result" | tail -1)"
+[ -n "$summary" ] || fail "$target suite produced no result line"
+
+failed="$(printf '%s\n' "$summary" \
+    | sed -n 's/.* passed, \([0-9][0-9]*\) failed,.*/\1/p')"
+[ -n "$failed" ] || fail "$target suite result could not be parsed"
+
+sed -n 's/^[[:space:]]*FAIL[[:space:]]\{1,\}\(.*\)[[:space:]]\{2,\}[^[:space:]]*:[0-9][0-9]*[[:space:]]*(.*)[[:space:]]*$/\1/p' "$result" \
+    | sed 's/[[:space:]]*$//' | sort -u > "$actual_file"
+
+actual_count="$(wc -l < "$actual_file" | tr -d '[:space:]')"
+[ "$actual_count" = "$failed" ] \
+    || fail "$target reported $failed failures but $actual_count failure names were parsed"
+
+unexpected="$(comm -13 "$expected_file" "$actual_file")"
+if [ -n "$unexpected" ]; then
+    echo "::error::$target has failures outside its known-failure policy:"
+    while IFS= read -r name; do printf '  %s\n' "$name"; done <<< "$unexpected"
+    exit 1
+fi
+
+fixed="$(comm -23 "$expected_file" "$actual_file")"
+if [ -n "$fixed" ]; then
+    echo "::error::$target has known failures that passed and must be removed:"
+    while IFS= read -r name; do printf '  %s\n' "$name"; done <<< "$fixed"
+    exit 1
+fi
+
+expected_count="$(wc -l < "$expected_file" | tr -d '[:space:]')"
+echo "OK: $target ran the complete native suite with $expected_count known failures"
+echo "OK: thread, process, file, socket, and timer coverage is present"
+

--- a/test/native/verify.sh
+++ b/test/native/verify.sh
@@ -28,7 +28,7 @@ actual_file="$(mktemp)"
 trap 'rm -f "$expected_file" "$actual_file"' EXIT
 
 "$mach" test . --target "$target" --include-deps --list \
-    | tr '\\' '/' > "$list" \
+    | tr '\134' '/' > "$list" \
     || fail "$target suite could not be listed"
 
 required=(

--- a/test/native/verify.sh
+++ b/test/native/verify.sh
@@ -22,12 +22,13 @@ cp -R "$root/src" "$here/dep/std/src"
 
 cd "$here"
 
-list="$(mktemp)"
+list="$here/results/$target-list.txt"
 expected_file="$(mktemp)"
 actual_file="$(mktemp)"
-trap 'rm -f "$list" "$expected_file" "$actual_file"' EXIT
+trap 'rm -f "$expected_file" "$actual_file"' EXIT
 
-"$mach" test . --target "$target" --include-deps --list > "$list" \
+"$mach" test . --target "$target" --include-deps --list \
+    | tr '\\' '/' > "$list" \
     || fail "$target suite could not be listed"
 
 required=(
@@ -83,4 +84,3 @@ fi
 expected_count="$(wc -l < "$expected_file" | tr -d '[:space:]')"
 echo "OK: $target ran the complete native suite with $expected_count known failures"
 echo "OK: thread, process, file, socket, and timer coverage is present"
-

--- a/test/native/verify.sh
+++ b/test/native/verify.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -uo pipefail
+set -euo pipefail
 
 mach="${1:-mach}"
 target="${2:-linux-x86_64}"
@@ -43,7 +43,7 @@ for source in "${required[@]}"; do
     grep -qF "$source" "$list" || fail "$target omitted required tests from $source"
 done
 
-grep -vE '^[[:space:]]*(#|$)' "$known" \
+{ grep -vE '^[[:space:]]*(#|$)' "$known" || true; } \
     | sed 's/[[:space:]]*$//' | sort -u > "$expected_file"
 
 set +e


### PR DESCRIPTION
## Summary

- run the complete standard-library suite natively on Linux x86-64, Linux arm64, Darwin x86-64, Darwin arm64, and Windows x86-64
- enforce dated, owned known-failure policies against both unexpected failures and unexpected passes
- retain native suite and executable-format evidence for every supported target
- keep riscv64 as explicitly emulated logic coverage
- make release publication depend on the reusable native CI matrix

## Local verification

- native Linux suite: 800 passed, 0 failed
- native Linux ELF probe built, ran, and matched x86-64 ELF
- native fixture cross-built for all five target rows
- backend smoke test cross-built for Windows and both Darwin targets
- actionlint, shellcheck, bash syntax, and git diff checks pass

Closes #500