### PR TITLE
feat(io): normalize resource handles and errors

### DIFF
--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -27,6 +27,8 @@ use std.collections.vector;
 use std.crypto.rand;
 use std.memory;
 use std.allocator.fixed;
+use io_error: std.io.error;
+use io_handle: std.io.handle;
 
 use A: std.allocator;
 use R: std.types.result;
@@ -35,8 +37,21 @@ use O: std.types.option;
 use m_reader: std.io.reader;
 use m_writer: std.io.writer;
 
-# an open file, identified by its descriptor
-pub def File: i32;
+# an open file with a native-width opaque handle
+pub rec File {
+    handle: io_handle.FileHandle;
+}
+
+fun error_text(error: io_error.Error) str {
+    ret io_error.message(error);
+}
+
+fun error_option_text(error: O.Option[io_error.Error]) O.Option[str] {
+    if (O.is_some[io_error.Error](error)) {
+        ret O.some[str](error_text(O.unwrap[io_error.Error](error)));
+    }
+    ret O.none[str]();
+}
 
 # what a path resolves to
 pub def Kind: u8;
@@ -63,9 +78,9 @@ pub rec Metadata {
 }
 
 # the standard streams, as already-open files
-pub val STDIN:  File = 0;
-pub val STDOUT: File = 1;
-pub val STDERR: File = 2;
+pub val STDIN:  File = File{handle: io_handle.FileHandle{value: 0}};
+pub val STDOUT: File = File{handle: io_handle.FileHandle{value: 1}};
+pub val STDERR: File = File{handle: io_handle.FileHandle{value: 2}};
 
 # seek anchors for `seek`
 fwd os.SEEK_SET;
@@ -76,13 +91,13 @@ fwd os.SEEK_END;
 # ---
 # p:   file path
 # ret: the open file, or an error
-pub fun open(p: Path) R.Result[File, str] {
-    if (p == nil) { ret R.err[File, str]("path is nil"); }
+pub fun open(p: Path) R.Result[File, io_error.Error] {
+    if (p == nil) { ret R.err[File, io_error.Error](io_error.from_code(os.EINVAL, io_error.OP_OPEN)); }
 
     val raw: i64 = os.open(os.AT_FDCWD, p, os.O_RDONLY, 0);
-    if (raw < 0) { ret R.err[File, str](os.message(raw)); }
+    if (raw < 0) { ret R.err[File, io_error.Error](io_error.from_code(raw, io_error.OP_OPEN)); }
 
-    ret R.ok[File, str](raw::File);
+    ret R.ok[File, io_error.Error](File{handle: io_handle.FileHandle{value: raw::usize}});
 }
 
 # create or truncate a file for writing
@@ -90,36 +105,41 @@ pub fun open(p: Path) R.Result[File, str] {
 # p:    file path
 # mode: permission bits for a newly created file
 # ret:  the open file, or an error
-pub fun create(p: Path, mode: i32) R.Result[File, str] {
-    if (p == nil) { ret R.err[File, str]("path is nil"); }
+pub fun create(p: Path, mode: i32) R.Result[File, io_error.Error] {
+    if (p == nil) { ret R.err[File, io_error.Error](io_error.from_code(os.EINVAL, io_error.OP_CREATE)); }
 
     val flags: i32 = os.O_CREAT | os.O_TRUNC | os.O_WRONLY;
     val raw:   i64 = os.open(os.AT_FDCWD, p, flags, mode);
-    if (raw < 0) { ret R.err[File, str](os.message(raw)); }
+    if (raw < 0) { ret R.err[File, io_error.Error](io_error.from_code(raw, io_error.OP_CREATE)); }
 
-    ret R.ok[File, str](raw::File);
+    ret R.ok[File, io_error.Error](File{handle: io_handle.FileHandle{value: raw::usize}});
 }
 
 # close an open file
 # ---
 # f:   file to close
 # ret: none on success, or an error
-pub fun close(f: File) O.Option[str] {
-    val raw: i64 = os.close(f);
-    if (raw < 0) { ret O.some[str](os.message(raw)); }
+pub fun close(f: *File) O.Option[io_error.Error] {
+    if (f == nil || !io_handle.file_is_valid(f.handle)) {
+        ret O.some[io_error.Error](io_error.from_code(os.EBADF, io_error.OP_CLOSE));
+    }
+    val value: usize = f.handle.value;
+    f.handle = io_handle.invalid_file();
+    val raw: i64 = os.close(value::i32);
+    if (raw < 0) { ret O.some[io_error.Error](io_error.from_code(raw, io_error.OP_CLOSE)); }
 
-    ret O.none[str]();
+    ret O.none[io_error.Error]();
 }
 
 # flush an open file's data and metadata to its backing storage
 # ---
 # f:   file to flush
 # ret: none on success, or an error
-pub fun sync(f: File) O.Option[str] {
-    val raw: i64 = os.sync_fd(f);
-    if (raw < 0) { ret O.some[str](os.message(raw)); }
+pub fun sync(f: File) O.Option[io_error.Error] {
+    val raw: i64 = os.sync_fd(f.handle.value::i32);
+    if (raw < 0) { ret O.some[io_error.Error](io_error.from_code(raw, io_error.OP_SYNC)); }
 
-    ret O.none[str]();
+    ret O.none[io_error.Error]();
 }
 
 # read up to len bytes into buf
@@ -128,11 +148,11 @@ pub fun sync(f: File) O.Option[str] {
 # buf: destination buffer
 # len: maximum bytes to read
 # ret: bytes read (0 at end of file), or an error
-pub fun read(f: File, buf: *u8, len: usize) R.Result[usize, str] {
-    val n: i64 = os.read(f, buf, len);
-    if (n < 0) { ret R.err[usize, str](os.message(n)); }
+pub fun read(f: File, buf: *u8, len: usize) R.Result[usize, io_error.Error] {
+    val n: i64 = os.read(f.handle.value::i32, buf, len);
+    if (n < 0) { ret R.err[usize, io_error.Error](io_error.from_code(n, io_error.OP_READ)); }
 
-    ret R.ok[usize, str](n::usize);
+    ret R.ok[usize, io_error.Error](n::usize);
 }
 
 # write up to len bytes from buf
@@ -141,11 +161,11 @@ pub fun read(f: File, buf: *u8, len: usize) R.Result[usize, str] {
 # buf: source buffer
 # len: bytes to write
 # ret: bytes written, or an error
-pub fun write(f: File, buf: *u8, len: usize) R.Result[usize, str] {
-    val n: i64 = os.write(f, buf, len);
-    if (n < 0) { ret R.err[usize, str](os.message(n)); }
+pub fun write(f: File, buf: *u8, len: usize) R.Result[usize, io_error.Error] {
+    val n: i64 = os.write(f.handle.value::i32, buf, len);
+    if (n < 0) { ret R.err[usize, io_error.Error](io_error.from_code(n, io_error.OP_WRITE)); }
 
-    ret R.ok[usize, str](n::usize);
+    ret R.ok[usize, io_error.Error](n::usize);
 }
 
 # reposition the file offset
@@ -154,21 +174,31 @@ pub fun write(f: File, buf: *u8, len: usize) R.Result[usize, str] {
 # offset: byte offset relative to whence
 # whence: SEEK_SET, SEEK_CUR, or SEEK_END
 # ret:    the resulting absolute offset, or an error
-pub fun seek(f: File, offset: i64, whence: i32) R.Result[i64, str] {
-    val n: i64 = os.seek(f, offset, whence);
-    if (n < 0) { ret R.err[i64, str](os.message(n)); }
+pub fun seek(f: File, offset: i64, whence: i32) R.Result[i64, io_error.Error] {
+    val n: i64 = os.seek(f.handle.value::i32, offset, whence);
+    if (n < 0) { ret R.err[i64, io_error.Error](io_error.from_code(n, io_error.OP_SEEK)); }
 
-    ret R.ok[i64, str](n);
+    ret R.ok[i64, io_error.Error](n);
 }
 
 # io read callback; the file's fd rides in the ctx slot
 fun file_read_cb(ctx: ptr, buf: *u8, len: usize) R.Result[usize, str] {
-    ret read((ctx::usize)::i32, buf, len);
+    val file: File = File{handle: io_handle.FileHandle{value: ctx::usize}};
+    val result: R.Result[usize, io_error.Error] = read(file, buf, len);
+    if (R.is_err[usize, io_error.Error](result)) {
+        ret R.err[usize, str](io_error.message(R.unwrap_err[usize, io_error.Error](result)));
+    }
+    ret R.ok[usize, str](R.unwrap_ok[usize, io_error.Error](result));
 }
 
 # io write callback; the file's fd rides in the ctx slot
 fun file_write_cb(ctx: ptr, buf: *u8, len: usize) R.Result[usize, str] {
-    ret write((ctx::usize)::i32, buf, len);
+    val file: File = File{handle: io_handle.FileHandle{value: ctx::usize}};
+    val result: R.Result[usize, io_error.Error] = write(file, buf, len);
+    if (R.is_err[usize, io_error.Error](result)) {
+        ret R.err[usize, str](io_error.message(R.unwrap_err[usize, io_error.Error](result)));
+    }
+    ret R.ok[usize, str](R.unwrap_ok[usize, io_error.Error](result));
 }
 
 # adapt a file to an io.Reader (the file must outlive the reader)
@@ -177,7 +207,7 @@ fun file_write_cb(ctx: ptr, buf: *u8, len: usize) R.Result[usize, str] {
 # ret: a Reader drawing from f
 pub fun reader(f: File) m_reader.Reader {
     var r: m_reader.Reader;
-    r.ctx    = (f::usize)::ptr;
+    r.ctx    = f.handle.value::ptr;
     r.f_read = file_read_cb;
     ret r;
 }
@@ -188,7 +218,7 @@ pub fun reader(f: File) m_reader.Reader {
 # ret: a Writer feeding f
 pub fun writer(f: File) m_writer.Writer {
     var w: m_writer.Writer;
-    w.ctx     = (f::usize)::ptr;
+    w.ctx     = f.handle.value::ptr;
     w.f_write = file_write_cb;
     ret w;
 }
@@ -202,13 +232,13 @@ pub fun writer(f: File) m_writer.Writer {
 # p:   file path
 # ret: the file contents, or an error
 pub fun read_bytes(a: *A.Allocator, p: Path) R.Result[Vector[u8], str] {
-    val ro: R.Result[File, str] = open(p);
-    if (R.is_err[File, str](ro)) { ret R.err[Vector[u8], str](R.unwrap_err[File, str](ro)); }
-    val f: File = R.unwrap_ok[File, str](ro);
+    val ro: R.Result[File, io_error.Error] = open(p);
+    if (R.is_err[File, io_error.Error](ro)) { ret R.err[Vector[u8], str](error_text(R.unwrap_err[File, io_error.Error](ro))); }
+    var f: File = R.unwrap_ok[File, io_error.Error](ro);
 
     var rd: m_reader.Reader = reader(f);
     val res: R.Result[Vector[u8], str] = m_reader.read_all(a, ?rd);
-    close(f);
+    close(?f);
 
     ret res;
 }
@@ -223,23 +253,23 @@ pub fun read_bytes(a: *A.Allocator, p: Path) R.Result[Vector[u8], str] {
 # p:   file path
 # ret: the file contents, or an error
 pub fun read_string(a: *A.Allocator, p: Path) R.Result[str, str] {
-    val ro: R.Result[File, str] = open(p);
-    if (R.is_err[File, str](ro)) { ret R.err[str, str](R.unwrap_err[File, str](ro)); }
-    val f: File = R.unwrap_ok[File, str](ro);
+    val ro: R.Result[File, io_error.Error] = open(p);
+    if (R.is_err[File, io_error.Error](ro)) { ret R.err[str, str](error_text(R.unwrap_err[File, io_error.Error](ro))); }
+    var f: File = R.unwrap_ok[File, io_error.Error](ro);
 
     # size the buffer from the open handle
     var st: os.stat_t;
-    val sr: i64 = os.stat(f, ?st);
-    if (sr < 0) { close(f); ret R.err[str, str](os.message(sr)); }
+    val sr: i64 = os.stat(f.handle.value::i32, ?st);
+    if (sr < 0) { close(?f); ret R.err[str, str](os.message(sr)); }
     val size: usize = st.st_size::usize;
 
     val ar: R.Result[*u8, *u8] = A.allocate[u8](a, size + 1);
-    if (R.is_err[*u8, *u8](ar)) { close(f); ret R.err[str, str]("out of memory"); }
+    if (R.is_err[*u8, *u8](ar)) { close(?f); ret R.err[str, str]("out of memory"); }
     val buf: *u8 = R.unwrap_ok[*u8, *u8](ar);
 
     var rd: m_reader.Reader = reader(f);
     val e: O.Option[str] = m_reader.read_exact(?rd, buf, size);
-    close(f);
+    close(?f);
     if (O.is_some[str](e)) { ret R.err[str, str](O.unwrap[str](e)); }
 
     buf[size] = 0;
@@ -256,13 +286,13 @@ pub fun read_string(a: *A.Allocator, p: Path) R.Result[str, str] {
 # mode: permission bits for a newly created file
 # ret:  none on success, or an error
 pub fun write_bytes(p: Path, data: *u8, len: usize, mode: i32) O.Option[str] {
-    val co: R.Result[File, str] = create(p, mode);
-    if (R.is_err[File, str](co)) { ret O.some[str](R.unwrap_err[File, str](co)); }
-    val f: File = R.unwrap_ok[File, str](co);
+    val co: R.Result[File, io_error.Error] = create(p, mode);
+    if (R.is_err[File, io_error.Error](co)) { ret O.some[str](error_text(R.unwrap_err[File, io_error.Error](co))); }
+    var f: File = R.unwrap_ok[File, io_error.Error](co);
 
     var w: m_writer.Writer = writer(f);
     val e: O.Option[str] = m_writer.write_all(?w, data, len);
-    close(f);
+    close(?f);
 
     ret e;
 }
@@ -309,25 +339,25 @@ pub fun replace_bytes_atomic(a: *A.Allocator, p: Path, data: *u8, len: usize, fi
     var w: m_writer.Writer = writer(temp.file);
     val we: O.Option[str] = m_writer.write_all(?w, data, len);
     if (O.is_some[str](we)) {
-        close(temp.file);
+        close(?temp.file);
         remove_file(temp.path);
         atomic_paths_free(a, parent, temp.path);
         ret we;
     }
 
-    val se: O.Option[str] = sync(temp.file);
-    if (O.is_some[str](se)) {
-        close(temp.file);
+    val se: O.Option[io_error.Error] = sync(temp.file);
+    if (O.is_some[io_error.Error](se)) {
+        close(?temp.file);
         remove_file(temp.path);
         atomic_paths_free(a, parent, temp.path);
-        ret se;
+        ret error_option_text(se);
     }
 
-    val ce: O.Option[str] = close(temp.file);
-    if (O.is_some[str](ce)) {
+    val ce: O.Option[io_error.Error] = close(?temp.file);
+    if (O.is_some[io_error.Error](ce)) {
         remove_file(temp.path);
         atomic_paths_free(a, parent, temp.path);
-        ret ce;
+        ret error_option_text(ce);
     }
 
     val re: O.Option[str] = rename(temp.path, p);
@@ -370,7 +400,7 @@ fun meta_from_stat(st: *os.stat_t) Metadata {
 # ret: the metadata, or an error
 pub fun stat_of(f: File) R.Result[Metadata, str] {
     var st: os.stat_t;
-    val raw: i64 = os.stat(f, ?st);
+    val raw: i64 = os.stat(f.handle.value::i32, ?st);
     if (raw < 0) { ret R.err[Metadata, str](os.message(raw)); }
 
     ret R.ok[Metadata, str](meta_from_stat(?st));
@@ -722,7 +752,7 @@ pub fun temp_create(a: *A.Allocator, prefix: str) R.Result[TempFile, str] {
         val flags: i32 = os.O_CREAT | os.O_EXCL | os.O_RDWR;
         val raw: i64 = os.open(os.AT_FDCWD, tp, flags, 0o600);
         if (raw >= 0) {
-            ret R.ok[TempFile, str](TempFile{file: raw::File, path: tp});
+            ret R.ok[TempFile, str](TempFile{file: File{handle: io_handle.FileHandle{value: raw::usize}}, path: tp});
         }
 
         A.deallocate[u8](a, tp, str_len(tp) + 1);
@@ -740,7 +770,7 @@ pub fun temp_path(tf: *TempFile) Path {
 
 # close a temporary file without removing it
 pub fun temp_close(tf: *TempFile) O.Option[str] {
-    ret close(tf.file);
+    ret error_option_text(close(?tf.file));
 }
 
 # remove a temporary file from disk
@@ -750,7 +780,7 @@ pub fun temp_remove(tf: *TempFile) O.Option[str] {
 
 # close and remove a temporary file
 pub fun temp_close_and_remove(tf: *TempFile) O.Option[str] {
-    val cr: O.Option[str] = close(tf.file);
+    val cr: O.Option[str] = error_option_text(close(?tf.file));
     val rr: O.Option[str] = remove_file(tf.path);
     if (O.is_some[str](cr)) { ret cr; }
 
@@ -818,7 +848,7 @@ fun sibling_temp_create(a: *A.Allocator, parent: Path, name: str, mode: i32) R.R
         val flags: i32 = os.O_CREAT | os.O_EXCL | os.O_WRONLY;
         val raw: i64 = os.open(os.AT_FDCWD, temp_path, flags, mode);
         if (raw >= 0) {
-            ret R.ok[TempFile, str](TempFile{file: raw::File, path: temp_path});
+            ret R.ok[TempFile, str](TempFile{file: File{handle: io_handle.FileHandle{value: raw::usize}}, path: temp_path});
         }
 
         A.deallocate[u8](a, temp_path, str_len(temp_path) + 1);
@@ -869,10 +899,10 @@ fun sync_directory(p: Path) O.Option[str] {
     $or {
         val raw: i64 = os.open(os.AT_FDCWD, p, os.O_RDONLY | os.O_DIRECTORY, 0);
         if (raw < 0) { ret O.some[str](os.message(raw)); }
-        val f: File = raw::File;
+        var f: File = File{handle: io_handle.FileHandle{value: raw::usize}};
 
-        val se: O.Option[str] = sync(f);
-        val ce: O.Option[str] = close(f);
+        val se: O.Option[str] = error_option_text(sync(f));
+        val ce: O.Option[str] = error_option_text(close(?f));
         if (O.is_some[str](se)) { ret se; }
         ret ce;
     }
@@ -990,10 +1020,24 @@ test "std.filesystem.read_bytes:content_and_len" {
 # a missing path fails open and answers false to every predicate
 test "std.filesystem.open:missing_path" {
     val p: Path = "/tmp/mach_std_fs_missing";
-    if (R.is_ok[File, str](open(p))) { ret 1; }
+    if (R.is_ok[File, io_error.Error](open(p))) { ret 1; }
     if (exists(p))                   { ret 1; }
     if (is_file(p))                  { ret 1; }
     if (is_dir(p))                   { ret 1; }
+    ret 0;
+}
+
+test "std.filesystem.close:duplicate_is_normalized" {
+    val p: Path = "/tmp/mach_std_fs_close";
+    if (O.is_some[str](write_bytes(p, "x", 1, 0o600))) { ret 1; }
+    val opened: R.Result[File, io_error.Error] = open(p);
+    if (R.is_err[File, io_error.Error](opened)) { remove_file(p); ret 1; }
+    var file: File = R.unwrap_ok[File, io_error.Error](opened);
+    if (O.is_some[io_error.Error](close(?file))) { remove_file(p); ret 1; }
+    val second: O.Option[io_error.Error] = close(?file);
+    remove_file(p);
+    if (!O.is_some[io_error.Error](second)) { ret 1; }
+    if (O.unwrap[io_error.Error](second).kind != io_error.CLOSED) { ret 1; }
     ret 0;
 }
 
@@ -1066,15 +1110,15 @@ test "std.filesystem.rename:replaces_existing_destination" {
 
     # the destination carries the source's bytes, not the ones it had
     var scratch: [3]u8;
-    val ro: R.Result[File, str] = open(to);
-    if (R.is_err[File, str](ro)) { bad = 1; }
+    val ro: R.Result[File, io_error.Error] = open(to);
+    if (R.is_err[File, io_error.Error](ro)) { bad = 1; }
     or {
-        val f: File = R.unwrap_ok[File, str](ro);
-        val rr: R.Result[usize, str] = read(f, ?scratch[0], 3);
-        if (R.is_err[usize, str](rr))         { bad = 1; }
-        or (R.unwrap_ok[usize, str](rr) != 3) { bad = 1; }
+        var f: File = R.unwrap_ok[File, io_error.Error](ro);
+        val rr: R.Result[usize, io_error.Error] = read(f, ?scratch[0], 3);
+        if (R.is_err[usize, io_error.Error](rr))         { bad = 1; }
+        or (R.unwrap_ok[usize, io_error.Error](rr) != 3) { bad = 1; }
         or (scratch[0] != 'n' || scratch[1] != 'e' || scratch[2] != 'w') { bad = 1; }
-        close(f);
+        close(?f);
     }
 
     remove_file(to);
@@ -1136,21 +1180,21 @@ test "std.filesystem.seek:reposition_and_read" {
     val p: Path = "/tmp/mach_std_fs_seek";
     if (O.is_some[str](write_bytes(p, "hello", 5, 0o644))) { ret 1; }
 
-    val ro: R.Result[File, str] = open(p);
-    if (R.is_err[File, str](ro)) { remove_file(p); ret 1; }
-    val f: File = R.unwrap_ok[File, str](ro);
+    val ro: R.Result[File, io_error.Error] = open(p);
+    if (R.is_err[File, io_error.Error](ro)) { remove_file(p); ret 1; }
+    var f: File = R.unwrap_ok[File, io_error.Error](ro);
 
     var bad: i32 = 0;
-    val sk: R.Result[i64, str] = seek(f, 1, SEEK_SET);
-    if (R.is_err[i64, str](sk))                 { bad = 1; }
-    or (R.unwrap_ok[i64, str](sk) != 1)         { bad = 1; }
+    val sk: R.Result[i64, io_error.Error] = seek(f, 1, SEEK_SET);
+    if (R.is_err[i64, io_error.Error](sk))                 { bad = 1; }
+    or (R.unwrap_ok[i64, io_error.Error](sk) != 1)         { bad = 1; }
 
-    val rd: R.Result[usize, str] = read(f, ?scratch[0], 4);
-    if (R.is_err[usize, str](rd))               { bad = 1; }
-    or (R.unwrap_ok[usize, str](rd) != 4)       { bad = 1; }
+    val rd: R.Result[usize, io_error.Error] = read(f, ?scratch[0], 4);
+    if (R.is_err[usize, io_error.Error](rd))               { bad = 1; }
+    or (R.unwrap_ok[usize, io_error.Error](rd) != 4)       { bad = 1; }
     or (scratch[0] != 'e' || scratch[3] != 'o') { bad = 1; }
 
-    close(f);
+    close(?f);
     remove_file(p);
     ret bad;
 }

--- a/src/input.mach
+++ b/src/input.mach
@@ -13,7 +13,7 @@ use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.string.str;
 
-use reader: std.io.reader;
+use std.io.reader;
 use std.filesystem;
 
 fun stdin_reader(r: *reader.Reader) {

--- a/src/io/error.mach
+++ b/src/io/error.mach
@@ -1,0 +1,88 @@
+# normalized I/O errors with target detail and operation context
+
+use std.types.bool.bool;
+use std.types.string.str;
+use std.system.os;
+
+pub def Kind: u8;
+pub val INTERRUPTED:        Kind = 0;
+pub val WOULD_BLOCK:        Kind = 1;
+pub val TIMEOUT:            Kind = 2;
+pub val CANCELLED:          Kind = 3;
+pub val REFUSED:            Kind = 4;
+pub val RESET:              Kind = 5;
+pub val ABORTED:            Kind = 6;
+pub val CLOSED:             Kind = 7;
+pub val ADDRESS_IN_USE:     Kind = 8;
+pub val UNREACHABLE:        Kind = 9;
+pub val PERMISSION:         Kind = 10;
+pub val RESOURCE_EXHAUSTED: Kind = 11;
+pub val INVALID:            Kind = 12;
+pub val UNSUPPORTED:        Kind = 13;
+pub val OTHER:              Kind = 14;
+
+pub def Operation: u8;
+pub val OP_UNKNOWN:  Operation = 0;
+pub val OP_OPEN:     Operation = 1;
+pub val OP_CLOSE:    Operation = 2;
+pub val OP_READ:     Operation = 3;
+pub val OP_WRITE:    Operation = 4;
+pub val OP_CREATE:   Operation = 5;
+pub val OP_BIND:     Operation = 6;
+pub val OP_LISTEN:   Operation = 7;
+pub val OP_ACCEPT:   Operation = 8;
+pub val OP_CONNECT:  Operation = 9;
+pub val OP_RECEIVE:  Operation = 10;
+pub val OP_SEND:     Operation = 11;
+pub val OP_SHUTDOWN: Operation = 12;
+pub val OP_OPTION:   Operation = 13;
+pub val OP_SEEK:     Operation = 14;
+pub val OP_SYNC:     Operation = 15;
+
+pub rec Error {
+    kind: Kind;
+    code: i64;
+    operation: Operation;
+}
+
+pub fun from_code(code: i64, operation: Operation) Error {
+    var kind: Kind = OTHER;
+    if (code == os.EINTR) { kind = INTERRUPTED; }
+    or (code == os.EAGAIN) { kind = WOULD_BLOCK; }
+    or (code == os.ETIMEDOUT) { kind = TIMEOUT; }
+    or (code == os.ECANCELED) { kind = CANCELLED; }
+    or (code == os.ECONNREFUSED) { kind = REFUSED; }
+    or (code == os.ECONNRESET) { kind = RESET; }
+    or (code == os.ECONNABORTED) { kind = ABORTED; }
+    or (code == os.EBADF || code == os.EPIPE || code == os.ENOTCONN) { kind = CLOSED; }
+    or (code == os.EADDRINUSE) { kind = ADDRESS_IN_USE; }
+    or (code == os.ENETUNREACH || code == os.EHOSTUNREACH) { kind = UNREACHABLE; }
+    or (code == os.EACCES || code == os.EPERM) { kind = PERMISSION; }
+    or (code == os.ENOMEM || code == os.ENFILE || code == os.EMFILE || code == os.ENOSPC) { kind = RESOURCE_EXHAUSTED; }
+    or (code == os.EINVAL) { kind = INVALID; }
+    or (code == os.ENOTSUP) { kind = UNSUPPORTED; }
+    ret Error{kind: kind, code: code, operation: operation};
+}
+
+pub fun message(error: Error) str {
+    ret os.message(error.code);
+}
+
+pub fun retryable(error: Error) bool {
+    ret error.kind == INTERRUPTED || error.kind == WOULD_BLOCK;
+}
+
+test "error: portable classifications retain target code" {
+    val timeout: Error = from_code(os.ETIMEDOUT, OP_READ);
+    if (timeout.kind != TIMEOUT) { ret 1; }
+    if (timeout.code != os.ETIMEDOUT) { ret 1; }
+    if (timeout.operation != OP_READ) { ret 1; }
+    ret 0;
+}
+
+test "error: retry classification is stable" {
+    if (!retryable(from_code(os.EINTR, OP_READ))) { ret 1; }
+    if (!retryable(from_code(os.EAGAIN, OP_READ))) { ret 1; }
+    if (retryable(from_code(os.EINVAL, OP_READ))) { ret 1; }
+    ret 0;
+}

--- a/src/io/handle.mach
+++ b/src/io/handle.mach
@@ -1,0 +1,48 @@
+# opaque native-width resource handles
+
+use std.types.bool.bool;
+use std.types.size.usize;
+use std.types.size.isize;
+
+# file handle owned by the filesystem layer
+pub rec FileHandle {
+    value: usize;
+}
+
+# socket handle owned by the networking layer
+pub rec SocketHandle {
+    value: usize;
+}
+
+pub val INVALID_VALUE: usize = (-1)::isize::usize;
+
+pub fun invalid_file() FileHandle {
+    ret FileHandle{value: INVALID_VALUE};
+}
+
+pub fun invalid_socket() SocketHandle {
+    ret SocketHandle{value: INVALID_VALUE};
+}
+
+pub fun file_is_valid(handle: FileHandle) bool {
+    ret handle.value != INVALID_VALUE;
+}
+
+pub fun socket_is_valid(handle: SocketHandle) bool {
+    ret handle.value != INVALID_VALUE;
+}
+
+test "handle: native width preserves every bit" {
+    val raw: usize = (-2)::isize::usize;
+    val socket: SocketHandle = SocketHandle{value: raw};
+    val file: FileHandle = FileHandle{value: raw};
+    if (socket.value != raw) { ret 1; }
+    if (file.value != raw) { ret 1; }
+    ret 0;
+}
+
+test "handle: invalid sentinels are explicit" {
+    if (socket_is_valid(invalid_socket())) { ret 1; }
+    if (file_is_valid(invalid_file())) { ret 1; }
+    ret 0;
+}

--- a/src/lib/libstd.mach
+++ b/src/lib/libstd.mach
@@ -27,6 +27,8 @@ fwd std.allocator.page;
 fwd std.memory;
 fwd std.io.writer;
 fwd std.io.reader;
+fwd std.io.handle;
+fwd std.io.error;
 fwd std.filesystem;
 
 fwd std.math;

--- a/src/net/dns.mach
+++ b/src/net/dns.mach
@@ -14,6 +14,7 @@ use std.system.os;
 use std.net.ip;
 use std.net.udp;
 use std.crypto.rand;
+use io_error: std.io.error;
 
 val DNS_PORT:       u16   = 53;
 val DNS_HEADER_LEN: usize = 12;
@@ -110,22 +111,24 @@ pub fun query(hostname: str, addr: *ip.IPv4) bool {
     if (qlen == 0) { ret false; }
 
     val ep: ip.Endpoint = ip.Endpoint{addr: ns, port: DNS_PORT};
-    val sr: Result[udp.Socket, str] = udp.create();
-    if (is_err[udp.Socket, str](sr)) { ret false; }
-    var sock: udp.Socket = unwrap_ok[udp.Socket, str](sr);
+    val sr: Result[udp.Socket, io_error.Error] = udp.create();
+    if (is_err[udp.Socket, io_error.Error](sr)) { ret false; }
+    var sock: udp.Socket = unwrap_ok[udp.Socket, io_error.Error](sr);
 
-    val sent: i64 = udp.send_to(?sock, ?pkt[0], qlen, ep);
-    if (sent < 0) {
+    val sent: Result[usize, io_error.Error] = udp.send_to(?sock, ?pkt[0], qlen, ep);
+    if (is_err[usize, io_error.Error](sent)) {
         udp.socket_close(?sock);
         ret false;
     }
 
     var resp: [512]u8;
-    val recvd: i64 = udp.recv_from(?sock, ?resp[0], 512, nil);
+    val recvd: Result[usize, io_error.Error] = udp.recv_from(?sock, ?resp[0], 512, nil);
     udp.socket_close(?sock);
-    if (recvd < DNS_HEADER_LEN::i64) { ret false; }
+    if (is_err[usize, io_error.Error](recvd)) { ret false; }
+    val received_len: usize = unwrap_ok[usize, io_error.Error](recvd);
+    if (received_len < DNS_HEADER_LEN) { ret false; }
 
-    ret parse_response(?resp[0], recvd::usize, addr, qid);
+    ret parse_response(?resp[0], received_len, addr, qid);
 }
 
 # resolve a hostname to an IPv4 address

--- a/src/net/tcp.mach
+++ b/src/net/tcp.mach
@@ -8,22 +8,25 @@ use std.types.result.ok;
 use std.types.result.err;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
 use std.types.string.str;
 use std.system.os;
 use std.net.ip;
+use io_error: std.io.error;
+use io_handle: std.io.handle;
 
 # a bound TCP socket listening for connections
 # ---
-# fd: the underlying socket file descriptor
+# handle: the native-width socket handle
 pub rec Listener {
-    fd: i32;
+    handle: io_handle.SocketHandle;
 }
 
 # a connected TCP socket for reading and writing
 # ---
-# fd: the underlying socket file descriptor
+# handle: the native-width socket handle
 pub rec Stream {
-    fd: i32;
+    handle: io_handle.SocketHandle;
 }
 
 # create a TCP listener bound to an endpoint
@@ -34,41 +37,47 @@ pub rec Stream {
 # ep:      endpoint to bind to
 # backlog: maximum pending connection queue length
 # ret:     the Listener, or an error message
-pub fun listen(ep: ip.Endpoint, backlog: i32) Result[Listener, str] {
-    val fd: i64 = os.sock_create(os.AF_INET, os.SOCK_STREAM, 0);
-    if (fd < 0) { ret err[Listener, str]("socket failed"); }
+pub fun listen(ep: ip.Endpoint, backlog: i32) Result[Listener, io_error.Error] {
+    var raw: usize = io_handle.INVALID_VALUE;
+    var code: i64 = os.sock_create(os.AF_INET, os.SOCK_STREAM, 0, ?raw);
+    if (code < 0) { ret err[Listener, io_error.Error](io_error.from_code(code, io_error.OP_CREATE)); }
 
     var opt: i32 = 1;
-    os.sock_setopt(fd::i32, os.SOL_SOCKET, os.SO_REUSEADDR, (?opt)::*u8, 4);
+    code = os.sock_setopt(raw, os.SOL_SOCKET, os.SO_REUSEADDR, (?opt)::*u8, 4);
+    if (code < 0) {
+        os.sock_close(raw);
+        ret err[Listener, io_error.Error](io_error.from_code(code, io_error.OP_OPTION));
+    }
 
     var sa: [16]u8;
     ip.to_sockaddr(ep, ?sa[0]);
 
-    val br: i64 = os.sock_bind(fd::i32, ?sa[0], os.SOCKADDR_IN_SIZE);
-    if (br < 0) {
-        os.sock_close(fd::i32);
-        ret err[Listener, str]("bind failed");
+    code = os.sock_bind(raw, ?sa[0], os.SOCKADDR_IN_SIZE);
+    if (code < 0) {
+        os.sock_close(raw);
+        ret err[Listener, io_error.Error](io_error.from_code(code, io_error.OP_BIND));
     }
 
-    val lr: i64 = os.sock_listen(fd::i32, backlog);
-    if (lr < 0) {
-        os.sock_close(fd::i32);
-        ret err[Listener, str]("listen failed");
+    code = os.sock_listen(raw, backlog);
+    if (code < 0) {
+        os.sock_close(raw);
+        ret err[Listener, io_error.Error](io_error.from_code(code, io_error.OP_LISTEN));
     }
 
-    ret ok[Listener, str](Listener{fd: fd::i32});
+    ret ok[Listener, io_error.Error](Listener{handle: io_handle.SocketHandle{value: raw}});
 }
 
 # accept a new connection on a listener
 # ---
 # ln:  the listener to accept on
 # ret: a connected Stream, or an error message
-pub fun accept(ln: *Listener) Result[Stream, str] {
+pub fun accept(ln: *Listener) Result[Stream, io_error.Error] {
     var sa: [16]u8;
     var sa_len: u32 = os.SOCKADDR_IN_SIZE::u32;
-    val fd: i64 = os.sock_accept(ln.fd, ?sa[0], ?sa_len);
-    if (fd < 0) { ret err[Stream, str]("accept failed"); }
-    ret ok[Stream, str](Stream{fd: fd::i32});
+    var raw: usize = io_handle.INVALID_VALUE;
+    val code: i64 = os.sock_accept(ln.handle.value, ?sa[0], ?sa_len, ?raw);
+    if (code < 0) { ret err[Stream, io_error.Error](io_error.from_code(code, io_error.OP_ACCEPT)); }
+    ret ok[Stream, io_error.Error](Stream{handle: io_handle.SocketHandle{value: raw}});
 }
 
 # accept a new connection and populate the remote endpoint
@@ -76,33 +85,35 @@ pub fun accept(ln: *Listener) Result[Stream, str] {
 # ln:  the listener to accept on
 # ep:  pointer to an Endpoint to fill with the remote address
 # ret: a connected Stream, or an error message
-pub fun accept_ep(ln: *Listener, ep: *ip.Endpoint) Result[Stream, str] {
+pub fun accept_ep(ln: *Listener, ep: *ip.Endpoint) Result[Stream, io_error.Error] {
     var sa: [16]u8;
     var sa_len: u32 = os.SOCKADDR_IN_SIZE::u32;
-    val fd: i64 = os.sock_accept(ln.fd, ?sa[0], ?sa_len);
-    if (fd < 0) { ret err[Stream, str]("accept failed"); }
+    var raw: usize = io_handle.INVALID_VALUE;
+    val code: i64 = os.sock_accept(ln.handle.value, ?sa[0], ?sa_len, ?raw);
+    if (code < 0) { ret err[Stream, io_error.Error](io_error.from_code(code, io_error.OP_ACCEPT)); }
     ip.from_sockaddr(?sa[0], ep);
-    ret ok[Stream, str](Stream{fd: fd::i32});
+    ret ok[Stream, io_error.Error](Stream{handle: io_handle.SocketHandle{value: raw}});
 }
 
 # establish a TCP connection to a remote endpoint
 # ---
 # ep:  endpoint to connect to
 # ret: a connected Stream, or an error message
-pub fun connect(ep: ip.Endpoint) Result[Stream, str] {
-    val fd: i64 = os.sock_create(os.AF_INET, os.SOCK_STREAM, 0);
-    if (fd < 0) { ret err[Stream, str]("socket failed"); }
+pub fun connect(ep: ip.Endpoint) Result[Stream, io_error.Error] {
+    var raw: usize = io_handle.INVALID_VALUE;
+    var code: i64 = os.sock_create(os.AF_INET, os.SOCK_STREAM, 0, ?raw);
+    if (code < 0) { ret err[Stream, io_error.Error](io_error.from_code(code, io_error.OP_CREATE)); }
 
     var sa: [16]u8;
     ip.to_sockaddr(ep, ?sa[0]);
 
-    val cr: i64 = os.sock_connect(fd::i32, ?sa[0], os.SOCKADDR_IN_SIZE);
-    if (cr < 0) {
-        os.sock_close(fd::i32);
-        ret err[Stream, str]("connect failed");
+    code = os.sock_connect(raw, ?sa[0], os.SOCKADDR_IN_SIZE);
+    if (code < 0) {
+        os.sock_close(raw);
+        ret err[Stream, io_error.Error](io_error.from_code(code, io_error.OP_CONNECT));
     }
 
-    ret ok[Stream, str](Stream{fd: fd::i32});
+    ret ok[Stream, io_error.Error](Stream{handle: io_handle.SocketHandle{value: raw}});
 }
 
 # read bytes from a TCP stream
@@ -110,28 +121,28 @@ pub fun connect(ep: ip.Endpoint) Result[Stream, str] {
 # s:   the stream to read from
 # buf: destination buffer
 # len: maximum bytes to read
-# ret: number of bytes read, 0 on peer close, or negative errno (os.EAGAIN once a
-#      read timeout set by stream_set_read_timeout elapses with no data)
-pub fun stream_read(s: *Stream, buf: *u8, len: usize) i64 {
-    ret os.sock_recv(s.fd, buf, len);
+# ret: bytes read, 0 on peer close, or a normalized I/O error
+pub fun stream_read(s: *Stream, buf: *u8, len: usize) Result[usize, io_error.Error] {
+    val n: i64 = os.sock_recv(s.handle.value, buf, len);
+    if (n < 0) { ret err[usize, io_error.Error](io_error.from_code(n, io_error.OP_READ)); }
+    ret ok[usize, io_error.Error](n::usize);
 }
 
 # bound blocking reads on a TCP stream to a timeout
 #
 # sets SO_RCVTIMEO on the stream. after ms elapses with no data pending, a
-# stream_read returns a negative errno (os.EAGAIN on posix) rather than blocking
-# indefinitely, letting a caller act on connection silence and distinguish a
-# timeout from a peer close (0) or a real I/O error. ms == 0 restores indefinite
-# blocking.
+# stream_read returns a normalized timeout or would-block error after the
+# interval, distinct from a peer close. ms == 0 restores indefinite blocking.
 # ---
 # s:   the stream to bound reads on
 # ms:  timeout in milliseconds, or 0 for no timeout
 # ret: ok on success, or an error message
-pub fun stream_set_read_timeout(s: *Stream, ms: u64) Result[bool, str] {
-    if (os.sock_set_rcvtimeo(s.fd, ms) < 0) {
-        ret err[bool, str]("set read timeout failed");
+pub fun stream_set_read_timeout(s: *Stream, ms: u64) Result[bool, io_error.Error] {
+    val code: i64 = os.sock_set_rcvtimeo(s.handle.value, ms);
+    if (code < 0) {
+        ret err[bool, io_error.Error](io_error.from_code(code, io_error.OP_OPTION));
     }
-    ret ok[bool, str](true);
+    ret ok[bool, io_error.Error](true);
 }
 
 # write bytes to a TCP stream
@@ -140,30 +151,48 @@ pub fun stream_set_read_timeout(s: *Stream, ms: u64) Result[bool, str] {
 # buf: source buffer
 # len: number of bytes to write
 # ret: number of bytes written, or negative on error
-pub fun stream_write(s: *Stream, buf: *u8, len: usize) i64 {
-    ret os.sock_send(s.fd, buf, len);
+pub fun stream_write(s: *Stream, buf: *u8, len: usize) Result[usize, io_error.Error] {
+    val n: i64 = os.sock_send(s.handle.value, buf, len);
+    if (n < 0) { ret err[usize, io_error.Error](io_error.from_code(n, io_error.OP_WRITE)); }
+    ret ok[usize, io_error.Error](n::usize);
 }
 
 # shut down part or all of a TCP stream
 # ---
 # s:   the stream to shut down
 # how: SHUT_RD (0), SHUT_WR (1), or SHUT_RDWR (2)
-pub fun stream_shutdown(s: *Stream, how: i32) i64 {
-    ret os.sock_shutdown(s.fd, how);
+pub fun stream_shutdown(s: *Stream, how: i32) Result[bool, io_error.Error] {
+    val code: i64 = os.sock_shutdown(s.handle.value, how);
+    if (code < 0) { ret err[bool, io_error.Error](io_error.from_code(code, io_error.OP_SHUTDOWN)); }
+    ret ok[bool, io_error.Error](true);
 }
 
 # close a TCP stream
 # ---
 # s: the stream to close
-pub fun stream_close(s: *Stream) {
-    os.sock_close(s.fd);
+pub fun stream_close(s: *Stream) Result[bool, io_error.Error] {
+    if (!io_handle.socket_is_valid(s.handle)) {
+        ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_CLOSE));
+    }
+    val raw: usize = s.handle.value;
+    s.handle = io_handle.invalid_socket();
+    val code: i64 = os.sock_close(raw);
+    if (code < 0) { ret err[bool, io_error.Error](io_error.from_code(code, io_error.OP_CLOSE)); }
+    ret ok[bool, io_error.Error](true);
 }
 
 # close a TCP listener
 # ---
 # ln: the listener to close
-pub fun listener_close(ln: *Listener) {
-    os.sock_close(ln.fd);
+pub fun listener_close(ln: *Listener) Result[bool, io_error.Error] {
+    if (!io_handle.socket_is_valid(ln.handle)) {
+        ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_CLOSE));
+    }
+    val raw: usize = ln.handle.value;
+    ln.handle = io_handle.invalid_socket();
+    val code: i64 = os.sock_close(raw);
+    if (code < 0) { ret err[bool, io_error.Error](io_error.from_code(code, io_error.OP_CLOSE)); }
+    ret ok[bool, io_error.Error](true);
 }
 
 $if ($mach.build.os == $mach.os.windows) {
@@ -177,19 +206,31 @@ val TIMEOUT_TEST_PORT: u16 = 39271;
 
 test "tcp: create and close socket" {
     val ep: ip.Endpoint = ip.endpoint(127, 0, 0, 1, 0);
-    val r: Result[Listener, str] = listen(ep, 1);
-    if (is_err[Listener, str](r)) { ret 1; }
-    var ln: Listener = unwrap_ok[Listener, str](r);
+    val r: Result[Listener, io_error.Error] = listen(ep, 1);
+    if (is_err[Listener, io_error.Error](r)) { ret 1; }
+    var ln: Listener = unwrap_ok[Listener, io_error.Error](r);
     listener_close(?ln);
     ret 0;
 }
 
 test "tcp: bind to loopback" {
     val ep: ip.Endpoint = ip.endpoint(127, 0, 0, 1, 0);
-    val r: Result[Listener, str] = listen(ep, 1);
-    if (is_err[Listener, str](r)) { ret 1; }
-    var ln: Listener = unwrap_ok[Listener, str](r);
+    val r: Result[Listener, io_error.Error] = listen(ep, 1);
+    if (is_err[Listener, io_error.Error](r)) { ret 1; }
+    var ln: Listener = unwrap_ok[Listener, io_error.Error](r);
     listener_close(?ln);
+    ret 0;
+}
+
+test "tcp: duplicate close is normalized" {
+    val ep: ip.Endpoint = ip.endpoint(127, 0, 0, 1, 0);
+    val r: Result[Listener, io_error.Error] = listen(ep, 1);
+    if (is_err[Listener, io_error.Error](r)) { ret 1; }
+    var ln: Listener = unwrap_ok[Listener, io_error.Error](r);
+    if (is_err[bool, io_error.Error](listener_close(?ln))) { ret 1; }
+    val second: Result[bool, io_error.Error] = listener_close(?ln);
+    if (!is_err[bool, io_error.Error](second)) { ret 1; }
+    if (unwrap_err[bool, io_error.Error](second).kind != io_error.CLOSED) { ret 1; }
     ret 0;
 }
 
@@ -201,47 +242,48 @@ test "tcp: read timeout bounds a blocking read" {
     }
 
     val ep: ip.Endpoint = ip.endpoint(127, 0, 0, 1, TIMEOUT_TEST_PORT);
-    val lr: Result[Listener, str] = listen(ep, 1);
-    if (is_err[Listener, str](lr)) { ret 1; }
-    var ln: Listener = unwrap_ok[Listener, str](lr);
+    val lr: Result[Listener, io_error.Error] = listen(ep, 1);
+    if (is_err[Listener, io_error.Error](lr)) { ret 1; }
+    var ln: Listener = unwrap_ok[Listener, io_error.Error](lr);
 
     # loopback connect to a listening socket completes in-kernel, so a single
     # thread can connect then accept the queued peer with no helper thread.
-    val cr: Result[Stream, str] = connect(ep);
-    if (is_err[Stream, str](cr)) { listener_close(?ln); ret 1; }
-    var client: Stream = unwrap_ok[Stream, str](cr);
+    val cr: Result[Stream, io_error.Error] = connect(ep);
+    if (is_err[Stream, io_error.Error](cr)) { listener_close(?ln); ret 1; }
+    var client: Stream = unwrap_ok[Stream, io_error.Error](cr);
 
-    val ar: Result[Stream, str] = accept(?ln);
-    if (is_err[Stream, str](ar)) { stream_close(?client); listener_close(?ln); ret 1; }
-    var server: Stream = unwrap_ok[Stream, str](ar);
+    val ar: Result[Stream, io_error.Error] = accept(?ln);
+    if (is_err[Stream, io_error.Error](ar)) { stream_close(?client); listener_close(?ln); ret 1; }
+    var server: Stream = unwrap_ok[Stream, io_error.Error](ar);
 
     var rc: i32 = 0;
     var buf: [8]u8;
 
     # a bounded read with nothing pending must time out, not block forever.
-    if (is_err[bool, str](stream_set_read_timeout(?server, 100))) { rc = 1; }
+    if (is_err[bool, io_error.Error](stream_set_read_timeout(?server, 100))) { rc = 1; }
     if (rc == 0) {
-        val n: i64 = stream_read(?server, ?buf[0], 8);
-        $if ($mach.build.os == $mach.os.windows) {
-            if (n >= 0) { rc = 1; }
-        }
-        $or {
-            if (n != os.EAGAIN) { rc = 1; }
+        val rr: Result[usize, io_error.Error] = stream_read(?server, ?buf[0], 8);
+        if (!is_err[usize, io_error.Error](rr)) { rc = 1; }
+        if (rc == 0) {
+            val read_error: io_error.Error = unwrap_err[usize, io_error.Error](rr);
+            if (read_error.kind != io_error.TIMEOUT && read_error.kind != io_error.WOULD_BLOCK) { rc = 1; }
         }
     }
 
     # a read with data pending returns the data.
     if (rc == 0) {
         val payload: str = "hi";
-        if (stream_write(?client, payload::*u8, 2) != 2) { rc = 1; }
+        val wr: Result[usize, io_error.Error] = stream_write(?client, payload::*u8, 2);
+        if (is_err[usize, io_error.Error](wr) || unwrap_ok[usize, io_error.Error](wr) != 2) { rc = 1; }
     }
     if (rc == 0) {
-        val n: i64 = stream_read(?server, ?buf[0], 8);
-        if (n != 2 || buf[0] != 'h' || buf[1] != 'i') { rc = 1; }
+        val rr: Result[usize, io_error.Error] = stream_read(?server, ?buf[0], 8);
+        if (is_err[usize, io_error.Error](rr)) { rc = 1; }
+        if (rc == 0 && (unwrap_ok[usize, io_error.Error](rr) != 2 || buf[0] != 'h' || buf[1] != 'i')) { rc = 1; }
     }
 
     # ms == 0 restores indefinite blocking (the call must succeed).
-    if (rc == 0 && is_err[bool, str](stream_set_read_timeout(?server, 0))) { rc = 1; }
+    if (rc == 0 && is_err[bool, io_error.Error](stream_set_read_timeout(?server, 0))) { rc = 1; }
 
     stream_close(?server);
     stream_close(?client);

--- a/src/net/udp.mach
+++ b/src/net/udp.mach
@@ -1,53 +1,62 @@
 # UDP socket operations
 
 use std.types.bool.bool;
+use std.types.bool.true;
 use std.types.size.usize;
 use std.types.result.Result;
 use std.types.result.ok;
 use std.types.result.err;
 use std.types.result.is_err;
 use std.types.result.unwrap_ok;
-use std.types.string.str;
+use std.types.result.unwrap_err;
 use std.system.os;
 use std.net.ip;
+use io_error: std.io.error;
+use io_handle: std.io.handle;
 
 # a bound or unbound UDP socket
 # ---
-# fd: the underlying socket file descriptor
+# handle: the native-width socket handle
 pub rec Socket {
-    fd: i32;
+    handle: io_handle.SocketHandle;
 }
 
 # create an unbound UDP socket
 # ---
 # ret: the Socket, or an error message
-pub fun create() Result[Socket, str] {
-    val fd: i64 = os.sock_create(os.AF_INET, os.SOCK_DGRAM, 0);
-    if (fd < 0) { ret err[Socket, str]("socket failed"); }
-    ret ok[Socket, str](Socket{fd: fd::i32});
+pub fun create() Result[Socket, io_error.Error] {
+    var raw: usize = io_handle.INVALID_VALUE;
+    val code: i64 = os.sock_create(os.AF_INET, os.SOCK_DGRAM, 0, ?raw);
+    if (code < 0) { ret err[Socket, io_error.Error](io_error.from_code(code, io_error.OP_CREATE)); }
+    ret ok[Socket, io_error.Error](Socket{handle: io_handle.SocketHandle{value: raw}});
 }
 
 # create a UDP socket bound to an endpoint
 # ---
 # ep:  endpoint to bind to
 # ret: the bound Socket, or an error message
-pub fun bind(ep: ip.Endpoint) Result[Socket, str] {
-    val fd: i64 = os.sock_create(os.AF_INET, os.SOCK_DGRAM, 0);
-    if (fd < 0) { ret err[Socket, str]("socket failed"); }
+pub fun bind(ep: ip.Endpoint) Result[Socket, io_error.Error] {
+    var raw: usize = io_handle.INVALID_VALUE;
+    var code: i64 = os.sock_create(os.AF_INET, os.SOCK_DGRAM, 0, ?raw);
+    if (code < 0) { ret err[Socket, io_error.Error](io_error.from_code(code, io_error.OP_CREATE)); }
 
     var opt: i32 = 1;
-    os.sock_setopt(fd::i32, os.SOL_SOCKET, os.SO_REUSEADDR, (?opt)::*u8, 4);
+    code = os.sock_setopt(raw, os.SOL_SOCKET, os.SO_REUSEADDR, (?opt)::*u8, 4);
+    if (code < 0) {
+        os.sock_close(raw);
+        ret err[Socket, io_error.Error](io_error.from_code(code, io_error.OP_OPTION));
+    }
 
     var sa: [16]u8;
     ip.to_sockaddr(ep, ?sa[0]);
 
-    val br: i64 = os.sock_bind(fd::i32, ?sa[0], os.SOCKADDR_IN_SIZE);
-    if (br < 0) {
-        os.sock_close(fd::i32);
-        ret err[Socket, str]("bind failed");
+    code = os.sock_bind(raw, ?sa[0], os.SOCKADDR_IN_SIZE);
+    if (code < 0) {
+        os.sock_close(raw);
+        ret err[Socket, io_error.Error](io_error.from_code(code, io_error.OP_BIND));
     }
 
-    ret ok[Socket, str](Socket{fd: fd::i32});
+    ret ok[Socket, io_error.Error](Socket{handle: io_handle.SocketHandle{value: raw}});
 }
 
 # send a datagram to a remote endpoint
@@ -57,10 +66,12 @@ pub fun bind(ep: ip.Endpoint) Result[Socket, str] {
 # len: number of bytes to send
 # ep:  destination endpoint
 # ret: number of bytes sent, or negative on error
-pub fun send_to(s: *Socket, buf: *u8, len: usize, ep: ip.Endpoint) i64 {
+pub fun send_to(s: *Socket, buf: *u8, len: usize, ep: ip.Endpoint) Result[usize, io_error.Error] {
     var sa: [16]u8;
     ip.to_sockaddr(ep, ?sa[0]);
-    ret os.sock_sendto(s.fd, buf, len, 0, ?sa[0], os.SOCKADDR_IN_SIZE);
+    val n: i64 = os.sock_sendto(s.handle.value, buf, len, 0, ?sa[0], os.SOCKADDR_IN_SIZE);
+    if (n < 0) { ret err[usize, io_error.Error](io_error.from_code(n, io_error.OP_SEND)); }
+    ret ok[usize, io_error.Error](n::usize);
 }
 
 # receive a datagram and populate the source endpoint
@@ -70,36 +81,55 @@ pub fun send_to(s: *Socket, buf: *u8, len: usize, ep: ip.Endpoint) i64 {
 # len: maximum bytes to receive
 # ep:  pointer to an Endpoint to fill with the source address
 # ret: number of bytes received, or negative on error
-pub fun recv_from(s: *Socket, buf: *u8, len: usize, ep: *ip.Endpoint) i64 {
+pub fun recv_from(s: *Socket, buf: *u8, len: usize, ep: *ip.Endpoint) Result[usize, io_error.Error] {
     var sa: [16]u8;
     var sa_len: u32 = os.SOCKADDR_IN_SIZE::u32;
-    val n: i64 = os.sock_recvfrom(s.fd, buf, len, 0, ?sa[0], ?sa_len);
+    val n: i64 = os.sock_recvfrom(s.handle.value, buf, len, 0, ?sa[0], ?sa_len);
     if (n >= 0 && ep != nil) {
         ip.from_sockaddr(?sa[0], ep);
     }
-    ret n;
+    if (n < 0) { ret err[usize, io_error.Error](io_error.from_code(n, io_error.OP_RECEIVE)); }
+    ret ok[usize, io_error.Error](n::usize);
 }
 
 # close a UDP socket
 # ---
 # s: the socket to close
-pub fun socket_close(s: *Socket) {
-    os.sock_close(s.fd);
+pub fun socket_close(s: *Socket) Result[bool, io_error.Error] {
+    if (!io_handle.socket_is_valid(s.handle)) {
+        ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_CLOSE));
+    }
+    val raw: usize = s.handle.value;
+    s.handle = io_handle.invalid_socket();
+    val code: i64 = os.sock_close(raw);
+    if (code < 0) { ret err[bool, io_error.Error](io_error.from_code(code, io_error.OP_CLOSE)); }
+    ret ok[bool, io_error.Error](true);
 }
 
 test "udp: create and close socket" {
-    val r: Result[Socket, str] = create();
-    if (is_err[Socket, str](r)) { ret 1; }
-    var s: Socket = unwrap_ok[Socket, str](r);
+    val r: Result[Socket, io_error.Error] = create();
+    if (is_err[Socket, io_error.Error](r)) { ret 1; }
+    var s: Socket = unwrap_ok[Socket, io_error.Error](r);
     socket_close(?s);
     ret 0;
 }
 
 test "udp: bind to loopback" {
     val ep: ip.Endpoint = ip.endpoint(127, 0, 0, 1, 0);
-    val r: Result[Socket, str] = bind(ep);
-    if (is_err[Socket, str](r)) { ret 1; }
-    var s: Socket = unwrap_ok[Socket, str](r);
+    val r: Result[Socket, io_error.Error] = bind(ep);
+    if (is_err[Socket, io_error.Error](r)) { ret 1; }
+    var s: Socket = unwrap_ok[Socket, io_error.Error](r);
     socket_close(?s);
+    ret 0;
+}
+
+test "udp: duplicate close is normalized" {
+    val r: Result[Socket, io_error.Error] = create();
+    if (is_err[Socket, io_error.Error](r)) { ret 1; }
+    var s: Socket = unwrap_ok[Socket, io_error.Error](r);
+    if (is_err[bool, io_error.Error](socket_close(?s))) { ret 1; }
+    val second: Result[bool, io_error.Error] = socket_close(?s);
+    if (!is_err[bool, io_error.Error](second)) { ret 1; }
+    if (unwrap_err[bool, io_error.Error](second).kind != io_error.CLOSED) { ret 1; }
     ret 0;
 }

--- a/src/process/exec.mach
+++ b/src/process/exec.mach
@@ -17,11 +17,12 @@ use std.allocator.fixed;
 use A: std.allocator;
 use R: std.types.result;
 
-use path: std.types.path;
-use env: std.process.env;
+use std.types.path;
+use std.process.env;
 
 use std.filesystem;
 use m_reader: std.io.reader;
+use io_handle: std.io.handle;
 
 use std.system.os;
 
@@ -129,7 +130,8 @@ pub fun output(a: *A.Allocator, pathname: str, argv: **u8, envp: **u8) R.Result[
     # once the child's stdout closes
     os.close(fds[1]);
 
-    var rd: m_reader.Reader = filesystem.reader(fds[0]);
+    val pipe_file: filesystem.File = filesystem.File{handle: io_handle.FileHandle{value: fds[0]::usize}};
+    var rd: m_reader.Reader = filesystem.reader(pipe_file);
     val bytes_r: R.Result[Vector[u8], str] = m_reader.read_all(a, ?rd);
     os.close(fds[0]);
 

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -105,6 +105,15 @@ fwd impl.EROFS;
 fwd impl.EPIPE;
 fwd impl.ENOTEMPTY;
 fwd impl.ENOTSUP;
+fwd impl.EADDRINUSE;
+fwd impl.ENETUNREACH;
+fwd impl.ECONNABORTED;
+fwd impl.ECONNRESET;
+fwd impl.ENOTCONN;
+fwd impl.ETIMEDOUT;
+fwd impl.ECONNREFUSED;
+fwd impl.EHOSTUNREACH;
+fwd impl.ECANCELED;
 
 # memory
 fwd impl.allocate;

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -18,6 +18,8 @@ $or {
     $error("std.system.os.darwin: unsupported architecture");
 }
 
+use platform: std.system.os.darwin.shared;
+
 # kernel ABI types
 fwd impl.stat_t;
 fwd impl.timespec;
@@ -83,6 +85,15 @@ fwd impl.EROFS;
 fwd impl.EPIPE;
 fwd impl.ENOTEMPTY;
 fwd impl.ENOTSUP;
+fwd platform.EADDRINUSE;
+fwd platform.ENETUNREACH;
+fwd platform.ECONNABORTED;
+fwd platform.ECONNRESET;
+fwd platform.ENOTCONN;
+fwd platform.ETIMEDOUT;
+fwd platform.ECONNREFUSED;
+fwd platform.EHOSTUNREACH;
+fwd platform.ECANCELED;
 
 fwd impl.EINTR_MAX_RETRIES;
 

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -204,6 +204,15 @@ pub val EPIPE:     i64 = -32;
 pub val ENOTEMPTY: i64 = -66;
 pub val ENOTSUP:   i64 = -45;
 pub val ERANGE:    i64 = -34;
+pub val EADDRINUSE:   i64 = -48;
+pub val ENETUNREACH:  i64 = -51;
+pub val ECONNABORTED: i64 = -53;
+pub val ECONNRESET:   i64 = -54;
+pub val ENOTCONN:     i64 = -57;
+pub val ETIMEDOUT:    i64 = -60;
+pub val ECONNREFUSED: i64 = -61;
+pub val EHOSTUNREACH: i64 = -65;
+pub val ECANCELED:    i64 = -89;
 
 pub val EINTR_MAX_RETRIES: usize = 8;
 
@@ -1992,52 +2001,62 @@ pub fun sock_addr_read(sa: *u8, port: *u16, addr: *u8) {
     addr[3] = sa[7];
 }
 
-pub fun sock_send(fd: i32, buf: *u8, len: usize) i64 {
-    ret write(fd, buf, len);
+pub fun sock_send(fd: usize, buf: *u8, len: usize) i64 {
+    ret write(fd::i32, buf, len);
 }
 
-pub fun sock_recv(fd: i32, buf: *u8, len: usize) i64 {
-    ret read(fd, buf, len);
+pub fun sock_recv(fd: usize, buf: *u8, len: usize) i64 {
+    ret read(fd::i32, buf, len);
 }
 
-pub fun sock_close(fd: i32) i64 {
-    ret close(fd);
+pub fun sock_close(fd: usize) i64 {
+    ret close(fd::i32);
 }
 
-pub fun sock_create(domain: i32, typ: i32, protocol: i32) i64 {
-    ret syscall3(SYS_SOCKET, domain::u32::usize, typ::u32::usize, protocol::u32::usize);
+pub fun sock_create(domain: i32, typ: i32, protocol: i32, out: *usize) i64 {
+    if (out == nil) { ret EINVAL; }
+    @out = (-1)::isize::usize;
+    val raw: i64 = syscall3(SYS_SOCKET, domain::u32::usize, typ::u32::usize, protocol::u32::usize);
+    if (raw < 0) { ret raw; }
+    @out = raw::usize;
+    ret 0;
 }
 
-pub fun sock_bind(fd: i32, addr: *u8, addrlen: usize) i64 {
-    ret syscall3(SYS_BIND, fd::isize::usize, addr::usize, addrlen);
+pub fun sock_bind(fd: usize, addr: *u8, addrlen: usize) i64 {
+    ret syscall3(SYS_BIND, fd, addr::usize, addrlen);
 }
 
-pub fun sock_listen(fd: i32, backlog: i32) i64 {
-    ret syscall2(SYS_LISTEN, fd::isize::usize, backlog::u32::usize);
+pub fun sock_listen(fd: usize, backlog: i32) i64 {
+    ret syscall2(SYS_LISTEN, fd, backlog::u32::usize);
 }
 
-pub fun sock_accept(fd: i32, addr: *u8, addrlen: *u32) i64 {
-    ret syscall3(SYS_ACCEPT, fd::isize::usize, addr::usize, addrlen::usize);
+pub fun sock_accept(fd: usize, addr: *u8, addrlen: *u32, out: *usize) i64 {
+    if (out == nil) { ret EINVAL; }
+    @out = (-1)::isize::usize;
+    val raw: i64 = syscall3(SYS_ACCEPT, fd, addr::usize, addrlen::usize);
+    if (raw < 0) { ret raw; }
+    @out = raw::usize;
+    ret 0;
 }
 
-pub fun sock_connect(fd: i32, addr: *u8, addrlen: usize) i64 {
-    ret syscall3(SYS_CONNECT, fd::isize::usize, addr::usize, addrlen);
+pub fun sock_connect(fd: usize, addr: *u8, addrlen: usize) i64 {
+    ret syscall3(SYS_CONNECT, fd, addr::usize, addrlen);
 }
 
-pub fun sock_sendto(fd: i32, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: usize) i64 {
-    ret syscall6(SYS_SENDTO, fd::isize::usize, buf::usize, len, flags::u32::usize, addr::usize, addrlen);
+pub fun sock_sendto(fd: usize, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: usize) i64 {
+    ret syscall6(SYS_SENDTO, fd, buf::usize, len, flags::u32::usize, addr::usize, addrlen);
 }
 
-pub fun sock_recvfrom(fd: i32, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: *u32) i64 {
-    ret syscall6(SYS_RECVFROM, fd::isize::usize, buf::usize, len, flags::u32::usize, addr::usize, addrlen::usize);
+pub fun sock_recvfrom(fd: usize, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: *u32) i64 {
+    ret syscall6(SYS_RECVFROM, fd, buf::usize, len, flags::u32::usize, addr::usize, addrlen::usize);
 }
 
-pub fun sock_shutdown(fd: i32, how: i32) i64 {
-    ret syscall2(SYS_SHUTDOWN, fd::isize::usize, how::u32::usize);
+pub fun sock_shutdown(fd: usize, how: i32) i64 {
+    ret syscall2(SYS_SHUTDOWN, fd, how::u32::usize);
 }
 
-pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
-    ret syscall5(SYS_SETSOCKOPT, fd::isize::usize, level::u32::usize, opt::u32::usize, value::usize, vallen);
+pub fun sock_setopt(fd: usize, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
+    ret syscall5(SYS_SETSOCKOPT, fd, level::u32::usize, opt::u32::usize, value::usize, vallen);
 }
 
 # set the receive timeout on a socket
@@ -2052,7 +2071,7 @@ pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i6
 # fd:  socket fd
 # ms:  timeout in milliseconds, or 0 for no timeout
 # ret: 0 on success, or negative errno
-pub fun sock_set_rcvtimeo(fd: i32, ms: u64) i64 {
+pub fun sock_set_rcvtimeo(fd: usize, ms: u64) i64 {
     var tv: [16]u8;
     val base: usize = (?tv[0])::usize;
     @(base::*i64)       = (ms / 1000)::i64;

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -21,6 +21,8 @@ $or {
     $error("std.system.os.linux: unsupported architecture");
 }
 
+use platform: std.system.os.linux.shared;
+
 # kernel ABI types
 fwd impl.stat_t;
 fwd impl.timespec;
@@ -86,6 +88,15 @@ fwd impl.EROFS;
 fwd impl.EPIPE;
 fwd impl.ENOTEMPTY;
 fwd impl.ENOTSUP;
+fwd platform.EADDRINUSE;
+fwd platform.ENETUNREACH;
+fwd platform.ECONNABORTED;
+fwd platform.ECONNRESET;
+fwd platform.ENOTCONN;
+fwd platform.ETIMEDOUT;
+fwd platform.ECONNREFUSED;
+fwd platform.EHOSTUNREACH;
+fwd platform.ECANCELED;
 
 fwd impl.EINTR_MAX_RETRIES;
 

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -442,6 +442,15 @@ pub val EPIPE:     i64 = -32;
 pub val ENOTEMPTY: i64 = -39;
 pub val ENOTSUP:   i64 = -95;
 pub val ERANGE:    i64 = -34;
+pub val EADDRINUSE:   i64 = -98;
+pub val ENETUNREACH:  i64 = -101;
+pub val ECONNABORTED: i64 = -103;
+pub val ECONNRESET:   i64 = -104;
+pub val ENOTCONN:     i64 = -107;
+pub val ETIMEDOUT:    i64 = -110;
+pub val ECONNREFUSED: i64 = -111;
+pub val EHOSTUNREACH: i64 = -113;
+pub val ECANCELED:    i64 = -125;
 
 pub val EINTR_MAX_RETRIES: usize = 8;
 
@@ -1947,8 +1956,8 @@ pub fun sock_addr_read(sa: *u8, port: *u16, addr: *u8) {
 # buf: source buffer
 # len: number of bytes to send
 # ret: bytes sent, or negative errno
-pub fun sock_send(fd: i32, buf: *u8, len: usize) i64 {
-    ret write(fd, buf, len);
+pub fun sock_send(fd: usize, buf: *u8, len: usize) i64 {
+    ret write(fd::i32, buf, len);
 }
 
 # receive data from a connected socket
@@ -1957,16 +1966,16 @@ pub fun sock_send(fd: i32, buf: *u8, len: usize) i64 {
 # buf: destination buffer
 # len: maximum bytes to receive
 # ret: bytes received, or negative errno
-pub fun sock_recv(fd: i32, buf: *u8, len: usize) i64 {
-    ret read(fd, buf, len);
+pub fun sock_recv(fd: usize, buf: *u8, len: usize) i64 {
+    ret read(fd::i32, buf, len);
 }
 
 # close a socket file descriptor
 # ---
 # fd:  socket fd
 # ret: 0 on success, or negative errno
-pub fun sock_close(fd: i32) i64 {
-    ret close(fd);
+pub fun sock_close(fd: usize) i64 {
+    ret close(fd::i32);
 }
 
 # create a socket file descriptor
@@ -1974,9 +1983,15 @@ pub fun sock_close(fd: i32) i64 {
 # domain:   address family (AF_INET)
 # typ:      socket type (SOCK_STREAM, SOCK_DGRAM)
 # protocol: protocol (0 for default)
-# ret:      fd on success, or negative errno
-pub fun sock_create(domain: i32, typ: i32, protocol: i32) i64 {
-    ret syscall3(SYS_SOCKET, domain::u32::usize, typ::u32::usize, protocol::u32::usize);
+# out:      receives the native-width handle
+# ret:      0 on success, or negative errno
+pub fun sock_create(domain: i32, typ: i32, protocol: i32, out: *usize) i64 {
+    if (out == nil) { ret EINVAL; }
+    @out = (-1)::isize::usize;
+    val raw: i64 = syscall3(SYS_SOCKET, domain::u32::usize, typ::u32::usize, protocol::u32::usize);
+    if (raw < 0) { ret raw; }
+    @out = raw::usize;
+    ret 0;
 }
 
 # bind a socket to an address
@@ -1985,8 +2000,8 @@ pub fun sock_create(domain: i32, typ: i32, protocol: i32) i64 {
 # addr:    pointer to sockaddr structure
 # addrlen: size of the sockaddr structure
 # ret:     0 on success, or negative errno
-pub fun sock_bind(fd: i32, addr: *u8, addrlen: usize) i64 {
-    ret syscall3(SYS_BIND, fd::isize::usize, addr::usize, addrlen);
+pub fun sock_bind(fd: usize, addr: *u8, addrlen: usize) i64 {
+    ret syscall3(SYS_BIND, fd, addr::usize, addrlen);
 }
 
 # mark a socket as a passive listener
@@ -1994,8 +2009,8 @@ pub fun sock_bind(fd: i32, addr: *u8, addrlen: usize) i64 {
 # fd:      socket fd
 # backlog: maximum pending connection queue length
 # ret:     0 on success, or negative errno
-pub fun sock_listen(fd: i32, backlog: i32) i64 {
-    ret syscall2(SYS_LISTEN, fd::isize::usize, backlog::u32::usize);
+pub fun sock_listen(fd: usize, backlog: i32) i64 {
+    ret syscall2(SYS_LISTEN, fd, backlog::u32::usize);
 }
 
 # accept a connection on a listening socket
@@ -2003,9 +2018,15 @@ pub fun sock_listen(fd: i32, backlog: i32) i64 {
 # fd:      socket fd
 # addr:    pointer to sockaddr to fill with peer address
 # addrlen: pointer to sockaddr length (in/out)
-# ret:     new fd on success, or negative errno
-pub fun sock_accept(fd: i32, addr: *u8, addrlen: *u32) i64 {
-    ret syscall3(SYS_ACCEPT, fd::isize::usize, addr::usize, addrlen::usize);
+# out:     receives the native-width accepted handle
+# ret:     0 on success, or negative errno
+pub fun sock_accept(fd: usize, addr: *u8, addrlen: *u32, out: *usize) i64 {
+    if (out == nil) { ret EINVAL; }
+    @out = (-1)::isize::usize;
+    val raw: i64 = syscall3(SYS_ACCEPT, fd, addr::usize, addrlen::usize);
+    if (raw < 0) { ret raw; }
+    @out = raw::usize;
+    ret 0;
 }
 
 # connect a socket to a remote address
@@ -2014,8 +2035,8 @@ pub fun sock_accept(fd: i32, addr: *u8, addrlen: *u32) i64 {
 # addr:    pointer to sockaddr structure
 # addrlen: size of the sockaddr structure
 # ret:     0 on success, or negative errno
-pub fun sock_connect(fd: i32, addr: *u8, addrlen: usize) i64 {
-    ret syscall3(SYS_CONNECT, fd::isize::usize, addr::usize, addrlen);
+pub fun sock_connect(fd: usize, addr: *u8, addrlen: usize) i64 {
+    ret syscall3(SYS_CONNECT, fd, addr::usize, addrlen);
 }
 
 # send data to a specific address
@@ -2027,8 +2048,8 @@ pub fun sock_connect(fd: i32, addr: *u8, addrlen: usize) i64 {
 # addr:    pointer to destination sockaddr
 # addrlen: size of the sockaddr structure
 # ret:     bytes sent on success, or negative errno
-pub fun sock_sendto(fd: i32, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: usize) i64 {
-    ret syscall6(SYS_SENDTO, fd::isize::usize, buf::usize, len, flags::u32::usize, addr::usize, addrlen);
+pub fun sock_sendto(fd: usize, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: usize) i64 {
+    ret syscall6(SYS_SENDTO, fd, buf::usize, len, flags::u32::usize, addr::usize, addrlen);
 }
 
 # receive data and source address
@@ -2040,8 +2061,8 @@ pub fun sock_sendto(fd: i32, buf: *u8, len: usize, flags: i32, addr: *u8, addrle
 # addr:    pointer to sockaddr to fill with source address
 # addrlen: pointer to sockaddr length (in/out)
 # ret:     bytes received on success, or negative errno
-pub fun sock_recvfrom(fd: i32, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: *u32) i64 {
-    ret syscall6(SYS_RECVFROM, fd::isize::usize, buf::usize, len, flags::u32::usize, addr::usize, addrlen::usize);
+pub fun sock_recvfrom(fd: usize, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: *u32) i64 {
+    ret syscall6(SYS_RECVFROM, fd, buf::usize, len, flags::u32::usize, addr::usize, addrlen::usize);
 }
 
 # shut down part or all of a socket connection
@@ -2049,8 +2070,8 @@ pub fun sock_recvfrom(fd: i32, buf: *u8, len: usize, flags: i32, addr: *u8, addr
 # fd:  socket fd
 # how: SHUT_RD (0), SHUT_WR (1), or SHUT_RDWR (2)
 # ret: 0 on success, or negative errno
-pub fun sock_shutdown(fd: i32, how: i32) i64 {
-    ret syscall2(SYS_SHUTDOWN, fd::isize::usize, how::u32::usize);
+pub fun sock_shutdown(fd: usize, how: i32) i64 {
+    ret syscall2(SYS_SHUTDOWN, fd, how::u32::usize);
 }
 
 # set a socket option
@@ -2061,8 +2082,8 @@ pub fun sock_shutdown(fd: i32, how: i32) i64 {
 # value:  pointer to option value
 # vallen: size of option value
 # ret:    0 on success, or negative errno
-pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
-    ret syscall5(SYS_SETSOCKOPT, fd::isize::usize, level::u32::usize, opt::u32::usize, value::usize, vallen);
+pub fun sock_setopt(fd: usize, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
+    ret syscall5(SYS_SETSOCKOPT, fd, level::u32::usize, opt::u32::usize, value::usize, vallen);
 }
 
 # set the receive timeout on a socket
@@ -2074,7 +2095,7 @@ pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i6
 # fd:  socket fd
 # ms:  timeout in milliseconds, or 0 for no timeout
 # ret: 0 on success, or negative errno
-pub fun sock_set_rcvtimeo(fd: i32, ms: u64) i64 {
+pub fun sock_set_rcvtimeo(fd: usize, ms: u64) i64 {
     var tv: [16]u8;
     val base: usize = (?tv[0])::usize;
     @(base::*i64)       = (ms / 1000)::i64;

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -15,6 +15,8 @@ $or {
     $error("std.system.os.windows: unsupported architecture");
 }
 
+use platform: std.system.os.windows.shared;
+
 # kernel ABI types
 fwd impl.stat_t;
 fwd impl.timespec;
@@ -80,6 +82,15 @@ fwd impl.EROFS;
 fwd impl.EPIPE;
 fwd impl.ENOTEMPTY;
 fwd impl.ENOTSUP;
+fwd platform.EADDRINUSE;
+fwd platform.ENETUNREACH;
+fwd platform.ECONNABORTED;
+fwd platform.ECONNRESET;
+fwd platform.ENOTCONN;
+fwd platform.ETIMEDOUT;
+fwd platform.ECONNREFUSED;
+fwd platform.EHOSTUNREACH;
+fwd platform.ECANCELED;
 
 fwd impl.EINTR_MAX_RETRIES;
 

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -151,6 +151,10 @@ val INVALID_SOCKET: usize = (-1)::isize::usize;
 val SOCKET_ERROR:   i32 = -1;
 
 val WSAEWOULDBLOCK:    i32 = 10035;
+val WSAEINTR:          i32 = 10004;
+val WSAEACCES:         i32 = 10013;
+val WSAEINVAL:         i32 = 10022;
+val WSAEMFILE:         i32 = 10024;
 val WSAEINPROGRESS:    i32 = 10036;
 val WSAENOTSOCK:       i32 = 10038;
 val WSAEMSGSIZE:       i32 = 10040;
@@ -160,24 +164,27 @@ val WSAEADDRNOTAVAIL:  i32 = 10049;
 val WSAENETUNREACH:    i32 = 10051;
 val WSAECONNABORTED:   i32 = 10053;
 val WSAECONNRESET:     i32 = 10054;
+val WSAENOBUFS:        i32 = 10055;
 val WSAENOTCONN:       i32 = 10057;
+val WSAESHUTDOWN:      i32 = 10058;
 val WSAETIMEDOUT:      i32 = 10060;
 val WSAECONNREFUSED:   i32 = 10061;
 val WSAEHOSTUNREACH:   i32 = 10065;
 
-val ECONNREFUSED:  i64 = -111;
-val ETIMEDOUT:     i64 = -110;
-val ECONNRESET:    i64 = -104;
-val ECONNABORTED:  i64 = -103;
-val ENETUNREACH:   i64 = -101;
-val EADDRINUSE:    i64 = -98;
+pub val ECONNREFUSED:  i64 = -111;
+pub val ETIMEDOUT:     i64 = -110;
+pub val ECONNRESET:    i64 = -104;
+pub val ECONNABORTED:  i64 = -103;
+pub val ENETUNREACH:   i64 = -101;
+pub val EADDRINUSE:    i64 = -98;
 val EADDRNOTAVAIL: i64 = -99;
-val EHOSTUNREACH:  i64 = -113;
-val ENOTCONN:      i64 = -107;
+pub val EHOSTUNREACH:  i64 = -113;
+pub val ENOTCONN:      i64 = -107;
 val EMSGSIZE:      i64 = -90;
 val EAFNOSUPPORT:  i64 = -97;
 val EINPROGRESS:   i64 = -115;
 val ENOTSOCK:      i64 = -88;
+pub val ECANCELED:     i64 = -125;
 
 # Win32 API imports (kernel32.dll)
 
@@ -2516,31 +2523,38 @@ pub fun sock_addr_read(sa: *u8, port: *u16, addr: *u8) {
     addr[3] = sa[7];
 }
 
-pub fun sock_send(fd: i32, buf: *u8, len: usize) i64 {
+pub fun sock_send(fd: usize, buf: *u8, len: usize) i64 {
     if (!ensure_wsa()) { ret EIO; }
-    val res: i32 = ws2_send(fd::usize, buf, len::i32, 0);
+    val res: i32 = ws2_send(fd, buf, len::i32, 0);
     if (res == SOCKET_ERROR) { ret wsa_last_error(); }
     ret res::i64;
 }
 
-pub fun sock_recv(fd: i32, buf: *u8, len: usize) i64 {
+pub fun sock_recv(fd: usize, buf: *u8, len: usize) i64 {
     if (!ensure_wsa()) { ret EIO; }
-    val res: i32 = ws2_recv(fd::usize, buf, len::i32, 0);
+    val res: i32 = ws2_recv(fd, buf, len::i32, 0);
     if (res == SOCKET_ERROR) { ret wsa_last_error(); }
     ret res::i64;
 }
 
-pub fun sock_close(fd: i32) i64 {
-    ret closesocket(fd::usize)::i64;
+pub fun sock_close(fd: usize) i64 {
+    val result: i32 = closesocket(fd);
+    if (result == SOCKET_ERROR) { ret wsa_last_error(); }
+    ret 0;
 }
 
 fun wsa_last_error() i64 {
     val err: i32 = WSAGetLastError();
-    if (err == WSAECONNREFUSED)  { ret ECONNREFUSED; }
+    if (err == WSAEINTR)         { ret EINTR; }
+    or (err == WSAEACCES)        { ret EACCES; }
+    or (err == WSAEINVAL)        { ret EINVAL; }
+    or (err == WSAEMFILE)        { ret EMFILE; }
+    or (err == WSAECONNREFUSED)  { ret ECONNREFUSED; }
     or (err == WSAETIMEDOUT)     { ret ETIMEDOUT; }
     or (err == WSAECONNRESET)    { ret ECONNRESET; }
     or (err == WSAECONNABORTED)  { ret ECONNABORTED; }
-    or (err == WSAENOTCONN)      { ret ENOTCONN; }
+    or (err == WSAENOBUFS)       { ret ENOMEM; }
+    or (err == WSAENOTCONN || err == WSAESHUTDOWN) { ret ENOTCONN; }
     or (err == WSAENETUNREACH)   { ret ENETUNREACH; }
     or (err == WSAEHOSTUNREACH)  { ret EHOSTUNREACH; }
     or (err == WSAEADDRINUSE)    { ret EADDRINUSE; }
@@ -2564,57 +2578,63 @@ fun ensure_wsa() bool {
     ret true;
 }
 
-pub fun sock_create(domain: i32, typ: i32, protocol: i32) i64 {
+pub fun sock_create(domain: i32, typ: i32, protocol: i32, out: *usize) i64 {
+    if (out == nil) { ret EINVAL; }
+    @out = INVALID_SOCKET;
     if (!ensure_wsa()) { ret EIO; }
     val s: usize = ws2_socket(domain, typ, protocol);
     if (s == INVALID_SOCKET) { ret wsa_last_error(); }
-    ret s::i64;
+    @out = s;
+    ret 0;
 }
 
-pub fun sock_bind(fd: i32, addr: *u8, addrlen: usize) i64 {
-    val res: i32 = ws2_bind(fd::usize, addr, addrlen::i32);
+pub fun sock_bind(fd: usize, addr: *u8, addrlen: usize) i64 {
+    val res: i32 = ws2_bind(fd, addr, addrlen::i32);
     if (res == SOCKET_ERROR) { ret wsa_last_error(); }
     ret 0;
 }
 
-pub fun sock_listen(fd: i32, backlog: i32) i64 {
-    val res: i32 = ws2_listen(fd::usize, backlog);
+pub fun sock_listen(fd: usize, backlog: i32) i64 {
+    val res: i32 = ws2_listen(fd, backlog);
     if (res == SOCKET_ERROR) { ret wsa_last_error(); }
     ret 0;
 }
 
-pub fun sock_accept(fd: i32, addr: *u8, addrlen: *u32) i64 {
-    val s: usize = ws2_accept(fd::usize, addr, addrlen::*i32);
+pub fun sock_accept(fd: usize, addr: *u8, addrlen: *u32, out: *usize) i64 {
+    if (out == nil) { ret EINVAL; }
+    @out = INVALID_SOCKET;
+    val s: usize = ws2_accept(fd, addr, addrlen::*i32);
     if (s == INVALID_SOCKET) { ret wsa_last_error(); }
-    ret s::i64;
+    @out = s;
+    ret 0;
 }
 
-pub fun sock_connect(fd: i32, addr: *u8, addrlen: usize) i64 {
-    val res: i32 = ws2_connect(fd::usize, addr, addrlen::i32);
+pub fun sock_connect(fd: usize, addr: *u8, addrlen: usize) i64 {
+    val res: i32 = ws2_connect(fd, addr, addrlen::i32);
     if (res == SOCKET_ERROR) { ret wsa_last_error(); }
     ret 0;
 }
 
-pub fun sock_sendto(fd: i32, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: usize) i64 {
-    val res: i32 = ws2_sendto(fd::usize, buf, len::i32, flags, addr, addrlen::i32);
+pub fun sock_sendto(fd: usize, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: usize) i64 {
+    val res: i32 = ws2_sendto(fd, buf, len::i32, flags, addr, addrlen::i32);
     if (res == SOCKET_ERROR) { ret wsa_last_error(); }
     ret res::i64;
 }
 
-pub fun sock_recvfrom(fd: i32, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: *u32) i64 {
-    val res: i32 = ws2_recvfrom(fd::usize, buf, len::i32, flags, addr, addrlen::*i32);
+pub fun sock_recvfrom(fd: usize, buf: *u8, len: usize, flags: i32, addr: *u8, addrlen: *u32) i64 {
+    val res: i32 = ws2_recvfrom(fd, buf, len::i32, flags, addr, addrlen::*i32);
     if (res == SOCKET_ERROR) { ret wsa_last_error(); }
     ret res::i64;
 }
 
-pub fun sock_shutdown(fd: i32, how: i32) i64 {
-    val res: i32 = ws2_shutdown(fd::usize, how);
+pub fun sock_shutdown(fd: usize, how: i32) i64 {
+    val res: i32 = ws2_shutdown(fd, how);
     if (res == SOCKET_ERROR) { ret wsa_last_error(); }
     ret 0;
 }
 
-pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
-    val res: i32 = ws2_setsockopt(fd::usize, level, opt, value, vallen::i32);
+pub fun sock_setopt(fd: usize, level: i32, opt: i32, value: *u8, vallen: usize) i64 {
+    val res: i32 = ws2_setsockopt(fd, level, opt, value, vallen::i32);
     if (res == SOCKET_ERROR) { ret wsa_last_error(); }
     ret 0;
 }
@@ -2628,7 +2648,7 @@ pub fun sock_setopt(fd: i32, level: i32, opt: i32, value: *u8, vallen: usize) i6
 # fd:  socket fd
 # ms:  timeout in milliseconds, or 0 for no timeout
 # ret: 0 on success, or negative errno
-pub fun sock_set_rcvtimeo(fd: i32, ms: u64) i64 {
+pub fun sock_set_rcvtimeo(fd: usize, ms: u64) i64 {
     var timeout: u32 = ms::u32;
     ret sock_setopt(fd, SOL_SOCKET, SO_RCVTIMEO, (?timeout)::*u8, 4);
 }

--- a/src/terminal.mach
+++ b/src/terminal.mach
@@ -20,7 +20,7 @@ use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.string.str;
 
-use key: std.terminal.key;
+use std.terminal.key;
 
 $if ($mach.build.os == $mach.os.linux) {
     use impl: std.terminal.linux;

--- a/src/terminal/darwin.mach
+++ b/src/terminal/darwin.mach
@@ -24,9 +24,9 @@ use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_none;
 
-use key: std.terminal.key;
+use std.terminal.key;
 use sys: std.system.os.darwin;
-use os:  std.system.os;
+use std.system.os;
 
 $if ($mach.build.os != $mach.os.darwin) {
     $error("std.terminal.darwin: requires darwin target");

--- a/src/terminal/linux.mach
+++ b/src/terminal/linux.mach
@@ -20,9 +20,9 @@ use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_none;
 
-use key: std.terminal.key;
+use std.terminal.key;
 use sys: std.system.os.linux;
-use os:  std.system.os;
+use std.system.os;
 
 $if ($mach.build.os != $mach.os.linux) {
     $error("std.terminal.linux: requires linux target");

--- a/src/terminal/windows.mach
+++ b/src/terminal/windows.mach
@@ -23,7 +23,7 @@ use std.types.option.some;
 use std.types.option.none;
 use std.types.option.is_none;
 
-use key: std.terminal.key;
+use std.terminal.key;
 
 $if ($mach.build.os != $mach.os.windows) {
     $error("std.terminal.windows: requires windows target");

--- a/test/symlink/src/main.mach
+++ b/test/symlink/src/main.mach
@@ -15,6 +15,7 @@ use std.types.path.Path;
 
 use R: std.types.result;
 use O: std.types.option;
+use io_error: std.io.error;
 
 #[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
@@ -39,15 +40,15 @@ fun probe(target: Path, link: Path, through: Path, base: i64) i64 {
     if (!fs.is_symlink(link))                     { ret base + 1; }
     if (!fs.is_dir(link))                         { ret base + 2; }
 
-    val ro: R.Result[fs.File, str] = fs.open(through);
-    if (R.is_err[fs.File, str](ro))               { ret base + 3; }
-    val f: fs.File = R.unwrap_ok[fs.File, str](ro);
+    val ro: R.Result[fs.File, io_error.Error] = fs.open(through);
+    if (R.is_err[fs.File, io_error.Error](ro))               { ret base + 3; }
+    var f: fs.File = R.unwrap_ok[fs.File, io_error.Error](ro);
 
     var buf: [8]u8;
-    val rd: R.Result[usize, str] = fs.read(f, ?buf[0], 6);
-    fs.close(f);
-    if (R.is_err[usize, str](rd))                 { ret base + 4; }
-    if (R.unwrap_ok[usize, str](rd) != 6)         { ret base + 5; }
+    val rd: R.Result[usize, io_error.Error] = fs.read(f, ?buf[0], 6);
+    fs.close(?f);
+    if (R.is_err[usize, io_error.Error](rd))                 { ret base + 4; }
+    if (R.unwrap_ok[usize, io_error.Error](rd) != 6)         { ret base + 5; }
     if (buf[0] != 'l'::u8 || buf[5] != 'd'::u8)   { ret base + 6; }
     ret 0;
 }


### PR DESCRIPTION
Closes #484

## Summary

- add native-width opaque file and socket handles
- preserve Windows socket values without narrowing
- normalize I/O error kinds while retaining target codes and operation context
- migrate public file, TCP, and UDP operations to typed handles and errors
- define explicit invalid and duplicate-close behavior

## Validation

- `mach test . --target linux-x86_64`
- `mach build . --all-targets`
- `bash test/backends/verify.sh`