### PR TITLE
feat(sync): add sleeping synchronization primitives

### DIFF
--- a/src/sync/condition.mach
+++ b/src/sync/condition.mach
@@ -1,0 +1,129 @@
+# condition variable over a generation word
+
+use std.types.size.usize;
+use std.sync.atomic;
+use std.sync.mutex;
+use std.sync.thread;
+use std.system.os;
+
+pub rec Condition {
+    generation: i64;
+    waiters:    i64;
+}
+
+# conditions are unfair and callers must always wait in a predicate loop
+# target waits may wake spuriously and signal may be observed by any waiter
+# predicate access and notification must use the same caller-owned mutex
+# failure while holding the paired mutex does not poison the condition
+# conditions own no target handle and may be discarded only without waiters
+pub fun make() Condition {
+    ret Condition{generation: 0, waiters: 0};
+}
+
+# generation closes the race between releasing the mutex and sleeping
+pub fun wait(c: *Condition, m: *mutex.Mutex) {
+    val observed: i64 = atomic.load(?c.generation);
+    atomic.fetch_add(?c.waiters, 1);
+    mutex.unlock(m);
+    os.thread_wait(?c.generation, observed);
+    atomic.fetch_sub(?c.waiters, 1);
+    mutex.lock(m);
+}
+
+pub fun signal(c: *Condition) {
+    atomic.fetch_add(?c.generation, 1);
+    if (atomic.load(?c.waiters) > 0) {
+        os.thread_wake(?c.generation);
+    }
+}
+
+pub fun broadcast(c: *Condition) {
+    val count: i64 = atomic.load(?c.waiters);
+    atomic.fetch_add(?c.generation, 1);
+    var i: i64 = 0;
+    for (i < count) {
+        os.thread_wake(?c.generation);
+        i = i + 1;
+    }
+}
+
+# this diagnostic result is stale as soon as it is returned
+pub fun waiter_count(c: *Condition) i64 {
+    ret atomic.load(?c.waiters);
+}
+
+rec WaitContext {
+    mutex:    *mutex.Mutex;
+    cond:     *Condition;
+    ready:    *i64;
+    observed: *i64;
+}
+
+fun predicate_worker(arg: *u8) {
+    val ctx: *WaitContext = arg::*WaitContext;
+    mutex.lock(ctx.mutex);
+    for (atomic.load(ctx.ready) == 0) {
+        wait(ctx.cond, ctx.mutex);
+    }
+    atomic.fetch_add(ctx.observed, 1);
+    mutex.unlock(ctx.mutex);
+}
+
+test "condition: wait releases and reacquires its mutex" {
+    var m: mutex.Mutex = mutex.make();
+    var c: Condition = make();
+    var ready: i64 = 0;
+    var observed: i64 = 0;
+    var ctx: WaitContext = WaitContext{mutex: ?m, cond: ?c, ready: ?ready, observed: ?observed};
+    var t: thread.Thread;
+
+    thread.spawn_with(predicate_worker, (?ctx)::*u8, ?t);
+    if (t.tid < 0) { ret 1; }
+    for (waiter_count(?c) != 1) { atomic.spin_hint(); }
+
+    mutex.lock(?m);
+    atomic.store(?ready, 1);
+    signal(?c);
+    mutex.unlock(?m);
+
+    thread.join(?t);
+    if (atomic.load(?observed) != 1) { ret 1; }
+    if (waiter_count(?c) != 0) { ret 1; }
+    ret 0;
+}
+
+test "condition: broadcast releases every predicate waiter" {
+    var m: mutex.Mutex = mutex.make();
+    var c: Condition = make();
+    var ready: i64 = 0;
+    var observed: i64 = 0;
+    var ctx: WaitContext = WaitContext{mutex: ?m, cond: ?c, ready: ?ready, observed: ?observed};
+    var threads: [3]thread.Thread;
+    var i: usize = 0;
+
+    for (i < 3) {
+        thread.spawn_with(predicate_worker, (?ctx)::*u8, ?threads[i]);
+        if (threads[i].tid < 0) {
+            mutex.lock(?m);
+            atomic.store(?ready, 1);
+            broadcast(?c);
+            mutex.unlock(?m);
+            var j: usize = 0;
+            for (j < i) { thread.join(?threads[j]); j = j + 1; }
+            ret 1;
+        }
+        i = i + 1;
+    }
+
+    for (waiter_count(?c) != 3) { atomic.spin_hint(); }
+    mutex.lock(?m);
+    atomic.store(?ready, 1);
+    broadcast(?c);
+    mutex.unlock(?m);
+
+    i = 0;
+    for (i < 3) { thread.join(?threads[i]); i = i + 1; }
+    if (atomic.load(?observed) != 3) { ret 1; }
+    if (waiter_count(?c) != 0) { ret 1; }
+    ret 0;
+}

--- a/src/sync/mutex.mach
+++ b/src/sync/mutex.mach
@@ -1,137 +1,142 @@
-# mutual exclusion lock
-#
-# test-and-test-and-set spinlock with exponential backoff using atomic
-# operations. on contention, spins with CPU pause hints for an
-# exponentially increasing number of iterations (32 up to 4096) before
-# retrying the lock. fully target-agnostic, uses only compiler builtin
-# atomics.
-#
-# values: 0 = unlocked, 1 = locked
+# sleeping mutual exclusion lock
 
 use std.types.bool.bool;
 use std.types.bool.true;
+use std.types.size.usize;
 use std.sync.atomic;
+use std.sync.thread;
+use std.system.os;
 
 pub def Mutex: i64;
 
-# create a new unlocked mutex
-# ---
-# ret: an unlocked mutex
+val UNLOCKED:  i64 = 0;
+val LOCKED:    i64 = 1;
+val CONTENDED: i64 = 2;
+
+# mutexes are unfair and may admit a new caller before a woken waiter
+# waits may wake spuriously, so acquisition always rechecks the state
+# mutexes are not poisoned when a protected operation fails
+# mutexes own no target handle and may be discarded only without waiters
 pub fun make() Mutex {
-    ret 0;
+    ret UNLOCKED;
 }
 
-# acquire the mutex, blocking until it is available
-#
-# uses test-and-test-and-set with exponential backoff: reads the state
-# without a bus lock first, then attempts CAS only when the lock appears
-# free. on contention, spins with pause hints for an exponentially
-# increasing number of iterations before retrying, capped at a maximum
-# to bound worst-case latency.
-# ---
-# m: pointer to the mutex
 pub fun lock(m: *Mutex) {
-    val INITIAL_BACKOFF: i64 = 32;
-    val MAX_BACKOFF: i64 = 4096;
-    var backoff: i64 = INITIAL_BACKOFF;
+    var expected: i64 = UNLOCKED;
+    if (atomic.cas(m, ?expected, LOCKED)) { ret; }
 
     for (true) {
-        if (atomic.load(m) == 0) {
-            var expected: i64 = 0;
-            if (atomic.cas(m, ?expected, 1)) { ret; }
-        }
-
-        var i: i64 = 0;
-        for (i < backoff) {
-            atomic.spin_hint();
-            i = i + 1;
-        }
-
-        if (backoff < MAX_BACKOFF) {
-            backoff = backoff + backoff;
-            if (backoff > MAX_BACKOFF) {
-                backoff = MAX_BACKOFF;
-            }
-        }
+        val prior: i64 = atomic.exchange(m, CONTENDED);
+        if (prior == UNLOCKED) { ret; }
+        os.thread_wait(m, CONTENDED);
     }
 }
 
-# release the mutex
-# ---
-# m: pointer to the mutex
 pub fun unlock(m: *Mutex) {
-    atomic.store(m, 0);
+    val prior: i64 = atomic.exchange(m, UNLOCKED);
+    if (prior == CONTENDED) {
+        os.thread_wake(m);
+    }
 }
 
-# try to acquire the mutex without blocking
-# ---
-# m:   pointer to the mutex
-# ret: true if the lock was acquired, false if already held
 pub fun try_lock(m: *Mutex) bool {
-    var expected: i64 = 0;
-    ret atomic.cas(m, ?expected, 1);
+    var expected: i64 = UNLOCKED;
+    ret atomic.cas(m, ?expected, LOCKED);
 }
 
-# check whether the mutex is currently held
-#
-# the result is immediately stale in a concurrent context; use only
-# for diagnostics or assertions, never for synchronization decisions.
-# ---
-# m:   pointer to the mutex
-# ret: true if the mutex is locked
+# this diagnostic result is stale as soon as it is returned
 pub fun is_locked(m: *Mutex) bool {
-    ret atomic.load(m) != 0;
+    ret atomic.load(m) != UNLOCKED;
+}
+
+rec WaitContext {
+    mutex:    *Mutex;
+    started:  *i64;
+    acquired: *i64;
+}
+
+fun wait_worker(arg: *u8) {
+    val ctx: *WaitContext = arg::*WaitContext;
+    atomic.store(ctx.started, 1);
+    lock(ctx.mutex);
+    atomic.store(ctx.acquired, 1);
+    unlock(ctx.mutex);
+}
+
+rec CountContext {
+    mutex: *Mutex;
+    count: *i64;
+    runs:  i64;
+}
+
+fun count_worker(arg: *u8) {
+    val ctx: *CountContext = arg::*CountContext;
+    var i: i64 = 0;
+    for (i < ctx.runs) {
+        lock(ctx.mutex);
+        @ctx.count = @ctx.count + 1;
+        unlock(ctx.mutex);
+        i = i + 1;
+    }
 }
 
 test "mutex: zero-initialized is unlocked" {
     var m: Mutex = make();
-    if (m != 0) { ret 1; }
+    if (m != UNLOCKED) { ret 1; }
     ret 0;
 }
 
-test "mutex: lock then unlock" {
-    var m: Mutex = make();
-    lock(?m);
-    if (m == 0) { ret 1; }
-    unlock(?m);
-    if (m != 0) { ret 1; }
-    ret 0;
-}
-
-test "mutex: try_lock on unlocked succeeds" {
+test "mutex: try lock observes ownership" {
     var m: Mutex = make();
     if (!try_lock(?m)) { ret 1; }
+    if (!is_locked(?m)) { unlock(?m); ret 1; }
+    if (try_lock(?m)) { unlock(?m); ret 1; }
     unlock(?m);
+    if (is_locked(?m)) { ret 1; }
     ret 0;
 }
 
-test "mutex: try_lock on locked fails" {
+test "mutex: contended waiter sleeps and wakes" {
     var m: Mutex = make();
+    var started: i64 = 0;
+    var acquired: i64 = 0;
+    var ctx: WaitContext = WaitContext{mutex: ?m, started: ?started, acquired: ?acquired};
+    var t: thread.Thread;
+
     lock(?m);
-    if (try_lock(?m)) {
-        unlock(?m);
-        ret 1;
+    thread.spawn_with(wait_worker, (?ctx)::*u8, ?t);
+    if (t.tid < 0) { unlock(?m); ret 1; }
+
+    for (atomic.load(?started) == 0) { atomic.spin_hint(); }
+    for (atomic.load(?m) != CONTENDED) { atomic.spin_hint(); }
+    if (atomic.load(?acquired) != 0) { unlock(?m); thread.join(?t); ret 1; }
+
+    unlock(?m);
+    thread.join(?t);
+    if (atomic.load(?acquired) != 1) { ret 1; }
+    ret 0;
+}
+
+test "mutex: oversubscribed writers preserve every update" {
+    var m: Mutex = make();
+    var count: i64 = 0;
+    var contexts: [4]CountContext;
+    var threads: [4]thread.Thread;
+    var i: usize = 0;
+
+    for (i < 4) {
+        contexts[i] = CountContext{mutex: ?m, count: ?count, runs: 1000};
+        thread.spawn_with(count_worker, (?contexts[i])::*u8, ?threads[i]);
+        if (threads[i].tid < 0) {
+            var j: usize = 0;
+            for (j < i) { thread.join(?threads[j]); j = j + 1; }
+            ret 1;
+        }
+        i = i + 1;
     }
-    unlock(?m);
-    ret 0;
-}
 
-test "mutex: is_locked reflects state" {
-    var m: Mutex = make();
-    if (is_locked(?m)) { ret 1; }
-    lock(?m);
-    if (!is_locked(?m)) { ret 1; }
-    unlock(?m);
-    if (is_locked(?m)) { ret 1; }
-    ret 0;
-}
-
-test "mutex: double lock-unlock cycle" {
-    var m: Mutex = make();
-    lock(?m);
-    unlock(?m);
-    lock(?m);
-    unlock(?m);
-    if (m != 0) { ret 1; }
+    i = 0;
+    for (i < 4) { thread.join(?threads[i]); i = i + 1; }
+    if (count != 4000) { ret 1; }
     ret 0;
 }

--- a/src/sync/once.mach
+++ b/src/sync/once.mach
@@ -1,0 +1,166 @@
+# exactly-once initialization with sticky failure
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.sync.atomic;
+use std.sync.thread;
+use std.system.os;
+
+pub val PENDING:  i64 = 0;
+pub val RUNNING:  i64 = 1;
+pub val COMPLETE: i64 = 2;
+pub val FAILED:   i64 = 3;
+
+pub def InitFun: fun(ptr) bool;
+
+pub rec Once {
+    state:   i64;
+    waiters: i64;
+}
+
+# initializer selection is unfair and recursive use of one value deadlocks
+# waits may wake spuriously and always recheck the published state
+# false is a sticky failure and initialization is never retried
+# a panic terminates the process and does not create recoverable poisoning
+# once owns no target handle and may be discarded only without callers
+pub fun make() Once {
+    ret Once{state: PENDING, waiters: 0};
+}
+
+fun wake_all(o: *Once) {
+    val count: i64 = atomic.load(?o.waiters);
+    var i: i64 = 0;
+    for (i < count) {
+        os.thread_wake(?o.state);
+        i = i + 1;
+    }
+}
+
+pub fun run(o: *Once, ctx: ptr, init: InitFun) bool {
+    for (true) {
+        val state: i64 = atomic.load(?o.state);
+        if (state == COMPLETE) { ret true; }
+        if (state == FAILED) { ret false; }
+
+        if (state == PENDING) {
+            var expected: i64 = PENDING;
+            if (atomic.cas(?o.state, ?expected, RUNNING)) {
+                val ok: bool = init(ctx);
+                if (ok) {
+                    atomic.store(?o.state, COMPLETE);
+                } or {
+                    atomic.store(?o.state, FAILED);
+                }
+                wake_all(o);
+                ret ok;
+            }
+            cnt;
+        }
+
+        atomic.fetch_add(?o.waiters, 1);
+        if (atomic.load(?o.state) == RUNNING) {
+            os.thread_wait(?o.state, RUNNING);
+        }
+        atomic.fetch_sub(?o.waiters, 1);
+    }
+    ret false;
+}
+
+pub fun is_complete(o: *Once) bool {
+    ret atomic.load(?o.state) == COMPLETE;
+}
+
+pub fun is_failed(o: *Once) bool {
+    ret atomic.load(?o.state) == FAILED;
+}
+
+rec RunContext {
+    once:      *Once;
+    init:      ptr;
+    value:     *i64;
+    successes: *i64;
+}
+
+rec InitContext {
+    calls:   *i64;
+    entered: *i64;
+    release: *i64;
+    value:   *i64;
+}
+
+fun blocking_succeed(ctx: ptr) bool {
+    val init: *InitContext = ctx::*InitContext;
+    atomic.fetch_add(init.calls, 1);
+    @init.value = 42;
+    atomic.store(init.entered, 1);
+    for (atomic.load(init.release) == 0) {
+        os.thread_wait(init.release, 0);
+    }
+    ret true;
+}
+
+fun fail(ctx: ptr) bool {
+    val calls: *i64 = ctx::*i64;
+    atomic.fetch_add(calls, 1);
+    ret false;
+}
+
+fun run_worker(arg: *u8) {
+    val ctx: *RunContext = arg::*RunContext;
+    if (run(ctx.once, ctx.init, blocking_succeed) && @ctx.value == 42) {
+        atomic.fetch_add(ctx.successes, 1);
+    }
+}
+
+test "once: concurrent callers initialize exactly once" {
+    var o: Once = make();
+    var calls: i64 = 0;
+    var entered: i64 = 0;
+    var release: i64 = 0;
+    var value: i64 = 0;
+    var successes: i64 = 0;
+    var init: InitContext = InitContext{calls: ?calls, entered: ?entered, release: ?release, value: ?value};
+    var ctx: RunContext = RunContext{once: ?o, init: (?init)::ptr, value: ?value, successes: ?successes};
+    var threads: [4]thread.Thread;
+    var i: usize = 0;
+
+    thread.spawn_with(run_worker, (?ctx)::*u8, ?threads[0]);
+    if (threads[0].tid < 0) { ret 1; }
+    for (atomic.load(?entered) == 0) { atomic.spin_hint(); }
+
+    i = 1;
+    for (i < 4) {
+        thread.spawn_with(run_worker, (?ctx)::*u8, ?threads[i]);
+        if (threads[i].tid < 0) {
+            atomic.store(?release, 1);
+            os.thread_wake(?release);
+            var j: usize = 0;
+            for (j < i) { thread.join(?threads[j]); j = j + 1; }
+            ret 1;
+        }
+        i = i + 1;
+    }
+
+    for (atomic.load(?o.waiters) != 3) { atomic.spin_hint(); }
+    atomic.store(?release, 1);
+    os.thread_wake(?release);
+
+    i = 0;
+    for (i < 4) { thread.join(?threads[i]); i = i + 1; }
+    if (atomic.load(?calls) != 1) { ret 1; }
+    if (atomic.load(?successes) != 4 || value != 42) { ret 1; }
+    if (!is_complete(?o) || is_failed(?o)) { ret 1; }
+    ret 0;
+}
+
+test "once: explicit failure is sticky" {
+    var o: Once = make();
+    var calls: i64 = 0;
+    if (run(?o, (?calls)::ptr, fail)) { ret 1; }
+    if (run(?o, (?calls)::ptr, fail)) { ret 1; }
+    if (atomic.load(?calls) != 1) { ret 1; }
+    if (!is_failed(?o) || is_complete(?o)) { ret 1; }
+    ret 0;
+}

--- a/src/sync/semaphore.mach
+++ b/src/sync/semaphore.mach
@@ -1,0 +1,172 @@
+# bounded counting semaphore
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.sync.atomic;
+use std.sync.thread;
+use std.system.os;
+
+pub rec Semaphore {
+    permits:    i64;
+    limit:      i64;
+    generation: i64;
+    waiters:    i64;
+}
+
+# semaphores are unfair and a new caller may acquire before a woken waiter
+# waits may wake spuriously and always retry permit acquisition
+# failed work does not poison permits or change the configured bound
+# initialization must complete before the semaphore is published
+# semaphores own no target handle and may be discarded only without waiters
+pub fun init(s: *Semaphore, initial: i64, limit: i64) bool {
+    s.permits = 0;
+    s.limit = 0;
+    s.generation = 0;
+    s.waiters = 0;
+    if (initial < 0 || limit < 0 || initial > limit) { ret false; }
+    s.permits = initial;
+    s.limit = limit;
+    ret true;
+}
+
+pub fun try_wait(s: *Semaphore) bool {
+    for (true) {
+        val current: i64 = atomic.load(?s.permits);
+        if (current <= 0) { ret false; }
+        var expected: i64 = current;
+        if (atomic.cas(?s.permits, ?expected, current - 1)) { ret true; }
+    }
+    ret false;
+}
+
+pub fun wait(s: *Semaphore) {
+    for (true) {
+        if (try_wait(s)) { ret; }
+
+        val observed: i64 = atomic.load(?s.generation);
+        atomic.fetch_add(?s.waiters, 1);
+        if (try_wait(s)) {
+            atomic.fetch_sub(?s.waiters, 1);
+            ret;
+        }
+
+        os.thread_wait(?s.generation, observed);
+        atomic.fetch_sub(?s.waiters, 1);
+    }
+}
+
+# release returns false on overflow and leaves the count unchanged
+pub fun release(s: *Semaphore) bool {
+    for (true) {
+        val current: i64 = atomic.load(?s.permits);
+        if (current >= s.limit) { ret false; }
+        var expected: i64 = current;
+        if (atomic.cas(?s.permits, ?expected, current + 1)) {
+            atomic.fetch_add(?s.generation, 1);
+            if (atomic.load(?s.waiters) > 0) {
+                os.thread_wake(?s.generation);
+            }
+            ret true;
+        }
+    }
+    ret false;
+}
+
+# this diagnostic result is stale as soon as it is returned
+pub fun available(s: *Semaphore) i64 {
+    ret atomic.load(?s.permits);
+}
+
+# this diagnostic result is stale as soon as it is returned
+pub fun waiter_count(s: *Semaphore) i64 {
+    ret atomic.load(?s.waiters);
+}
+
+rec WaitContext {
+    sem:     *Semaphore;
+    entered: *i64;
+    passed:  *i64;
+}
+
+fun permit_worker(arg: *u8) {
+    val ctx: *WaitContext = arg::*WaitContext;
+    atomic.fetch_add(ctx.entered, 1);
+    wait(ctx.sem);
+    atomic.fetch_add(ctx.passed, 1);
+}
+
+test "semaphore: init rejects invalid bounds" {
+    var s: Semaphore;
+    if (init(?s, -1, 1)) { ret 1; }
+    if (init(?s, 2, 1)) { ret 1; }
+    if (!init(?s, 0, 0)) { ret 1; }
+    ret 0;
+}
+
+test "semaphore: release reports overflow without mutation" {
+    var s: Semaphore;
+    if (!init(?s, 1, 2)) { ret 1; }
+    if (!release(?s)) { ret 1; }
+    if (available(?s) != 2) { ret 1; }
+    if (release(?s)) { ret 1; }
+    if (available(?s) != 2) { ret 1; }
+    if (!try_wait(?s) || !try_wait(?s) || try_wait(?s)) { ret 1; }
+    ret 0;
+}
+
+test "semaphore: blocked waiter receives a released permit" {
+    var s: Semaphore;
+    if (!init(?s, 0, 1)) { ret 1; }
+    var entered: i64 = 0;
+    var passed: i64 = 0;
+    var ctx: WaitContext = WaitContext{sem: ?s, entered: ?entered, passed: ?passed};
+    var t: thread.Thread;
+
+    thread.spawn_with(permit_worker, (?ctx)::*u8, ?t);
+    if (t.tid < 0) { ret 1; }
+    for (waiter_count(?s) != 1) { atomic.spin_hint(); }
+    if (atomic.load(?passed) != 0) { release(?s); thread.join(?t); ret 1; }
+
+    if (!release(?s)) { ret 1; }
+    thread.join(?t);
+    if (atomic.load(?entered) != 1 || atomic.load(?passed) != 1) { ret 1; }
+    if (available(?s) != 0 || waiter_count(?s) != 0) { ret 1; }
+    ret 0;
+}
+
+test "semaphore: releases settle multiple waiters" {
+    var s: Semaphore;
+    if (!init(?s, 0, 3)) { ret 1; }
+    var entered: i64 = 0;
+    var passed: i64 = 0;
+    var ctx: WaitContext = WaitContext{sem: ?s, entered: ?entered, passed: ?passed};
+    var threads: [3]thread.Thread;
+    var i: usize = 0;
+
+    for (i < 3) {
+        thread.spawn_with(permit_worker, (?ctx)::*u8, ?threads[i]);
+        if (threads[i].tid < 0) {
+            var k: usize = 0;
+            for (k < i) { release(?s); k = k + 1; }
+            k = 0;
+            for (k < i) { thread.join(?threads[k]); k = k + 1; }
+            ret 1;
+        }
+        i = i + 1;
+    }
+
+    for (waiter_count(?s) != 3) { atomic.spin_hint(); }
+    i = 0;
+    for (i < 3) {
+        if (!release(?s)) { ret 1; }
+        i = i + 1;
+    }
+
+    i = 0;
+    for (i < 3) { thread.join(?threads[i]); i = i + 1; }
+    if (atomic.load(?entered) != 3 || atomic.load(?passed) != 3) { ret 1; }
+    if (available(?s) != 0 || waiter_count(?s) != 0) { ret 1; }
+    ret 0;
+}


### PR DESCRIPTION
## Summary

- replace the spin-only mutex with a sleeping three-state mutex
- add condition variables, bounded semaphores, and sticky-failure once initialization
- cover contention, wakeups, overflow, publication, and failure behavior

## Verification

- `mach test .`: 806 passed
- `mach test . -O2`: 806 passed
- `mach build . -O2 --all-targets`: all five declared targets built
- Linux arm64 and riscv64 synchronization tests passed under QEMU
- Windows x86-64 and both Darwin targets compiled through a direct consumer
- 50 repeated focused synchronization runs passed
- 25 additional forced-contention once runs passed

Closes #492
