### PR TITLE
feat(net): make endpoints dual-stack

### DIFF
--- a/src/net/dns.mach
+++ b/src/net/dns.mach
@@ -110,7 +110,7 @@ pub fun query(hostname: str, addr: *ip.IPv4) bool {
     val qlen: usize = build_query(hostname, ?pkt[0], 512, qid);
     if (qlen == 0) { ret false; }
 
-    val ep: ip.Endpoint = ip.Endpoint{addr: ns, port: DNS_PORT};
+    val ep: ip.Endpoint = ip.endpoint_v4(ns, DNS_PORT);
     val sr: Result[udp.Socket, io_error.Error] = udp.create();
     if (is_err[udp.Socket, io_error.Error](sr)) { ret false; }
     var sock: udp.Socket = unwrap_ok[udp.Socket, io_error.Error](sr);

--- a/src/net/ip.mach
+++ b/src/net/ip.mach
@@ -1,8 +1,17 @@
 # IP address types and utilities
 
 use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
 use std.types.string.str_starts_with;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
 
 use std.memory;
 use std.system.os;
@@ -34,11 +43,13 @@ pub rec Addr {
 
 # an IP address and port pair
 # ---
-# addr: IPv4 address
-# port: port number in host byte order
+# addr:  IPv4 or IPv6 address
+# port:  port number in host byte order
+# scope: IPv6 interface scope identifier, or zero
 pub rec Endpoint {
-    addr: IPv4;
-    port: u16;
+    addr:  Addr;
+    port:  u16;
+    scope: u32;
 }
 
 # create an IPv4 address from four octets
@@ -161,23 +172,427 @@ pub fun addr_v6(ip: IPv6) Addr {
 # port: port number in host byte order
 # ret:  the constructed Endpoint
 pub fun endpoint(a: u8, b: u8, c: u8, d: u8, port: u16) Endpoint {
-    ret Endpoint{addr: ipv4(a, b, c, d), port: port};
+    ret endpoint_v4(ipv4(a, b, c, d), port);
+}
+
+pub fun endpoint_v4(addr: IPv4, port: u16) Endpoint {
+    ret Endpoint{addr: addr_v4(addr), port: port, scope: 0};
+}
+
+pub fun endpoint_v6(addr: IPv6, port: u16, scope: u32) Endpoint {
+    ret Endpoint{addr: addr_v6(addr), port: port, scope: scope};
+}
+
+pub fun endpoint_family(ep: Endpoint) i32 {
+    if (ep.addr.is_v6 != 0) { ret os.AF_INET6; }
+    ret os.AF_INET;
+}
+
+pub fun sockaddr_size(ep: Endpoint) usize {
+    if (ep.addr.is_v6 != 0) { ret os.SOCKADDR_IN6_SIZE; }
+    ret os.SOCKADDR_IN_SIZE;
 }
 
 # serialize an Endpoint into a sockaddr_in byte buffer
 # ---
 # ep: the endpoint to serialize
 # sa: pointer to a buffer of at least os.SOCKADDR_IN_SIZE bytes
-pub fun to_sockaddr(ep: Endpoint, sa: *u8) {
-    os.sock_addr_init(sa, ep.port, ?ep.addr.octets[0]);
+pub fun to_sockaddr(ep: Endpoint, sa: *u8) usize {
+    if (ep.addr.is_v6 != 0) {
+        os.sock_addr6_init(sa, ep.port, ?ep.addr.v6.octets[0], ep.scope);
+        ret os.SOCKADDR_IN6_SIZE;
+    }
+    os.sock_addr_init(sa, ep.port, ?ep.addr.v4.octets[0]);
+    ret os.SOCKADDR_IN_SIZE;
 }
 
 # deserialize a sockaddr_in byte buffer into an Endpoint
 # ---
 # sa: pointer to the sockaddr_in buffer
 # ep: pointer to the Endpoint to fill
-pub fun from_sockaddr(sa: *u8, ep: *Endpoint) {
-    os.sock_addr_read(sa, ?ep.port, ?ep.addr.octets[0]);
+pub fun from_sockaddr(sa: *u8, ep: *Endpoint) bool {
+    val family: i32 = os.sock_addr_family(sa);
+    if (family == os.AF_INET) {
+        ep.addr = addr_v4(ipv4_any());
+        ep.scope = 0;
+        os.sock_addr_read(sa, ?ep.port, ?ep.addr.v4.octets[0]);
+        ret true;
+    }
+    if (family == os.AF_INET6) {
+        ep.addr = addr_v6(ipv6_any());
+        os.sock_addr6_read(sa, ?ep.port, ?ep.addr.v6.octets[0], ?ep.scope);
+        ret true;
+    }
+    ret false;
+}
+
+pub fun ipv4_parse(text: str) Result[IPv4, str] {
+    var addr: IPv4;
+    if (!parse_ipv4_span(text, str_len(text), ?addr)) {
+        ret err[IPv4, str]("invalid IPv4 address");
+    }
+    ret ok[IPv4, str](addr);
+}
+
+pub fun ipv6_parse(text: str) Result[IPv6, str] {
+    var addr: IPv6;
+    if (!parse_ipv6_span(text, str_len(text), ?addr)) {
+        ret err[IPv6, str]("invalid IPv6 address");
+    }
+    ret ok[IPv6, str](addr);
+}
+
+# parse a borrowed address string without retaining or allocating it
+pub fun addr_parse(text: str) Result[Addr, str] {
+    val len: usize = str_len(text);
+    var i: usize = 0;
+    for (i < len) {
+        if (text[i] == ':') {
+            val parsed6: Result[IPv6, str] = ipv6_parse(text);
+            if (is_err[IPv6, str](parsed6)) { ret err[Addr, str]("invalid IP address"); }
+            ret ok[Addr, str](addr_v6(unwrap_ok[IPv6, str](parsed6)));
+        }
+        i = i + 1;
+    }
+    val parsed4: Result[IPv4, str] = ipv4_parse(text);
+    if (is_err[IPv4, str](parsed4)) { ret err[Addr, str]("invalid IP address"); }
+    ret ok[Addr, str](addr_v4(unwrap_ok[IPv4, str](parsed4)));
+}
+
+# parse a borrowed endpoint string into a self-contained value
+#
+# IPv6 zones are numeric interface indices. named zones fail explicitly
+# because resolving an interface name belongs to a target network interface API.
+pub fun endpoint_parse(text: str) Result[Endpoint, str] {
+    val len: usize = str_len(text);
+    if (len == 0) { ret err[Endpoint, str]("empty endpoint"); }
+
+    if (text[0] == '[') {
+        var close: usize = 1;
+        for (close < len && text[close] != ']') { close = close + 1; }
+        if (close >= len || close + 2 > len || text[close + 1] != ':') {
+            ret err[Endpoint, str]("invalid bracketed endpoint");
+        }
+
+        var zone: usize = close;
+        var i: usize = 1;
+        for (i < close) {
+            if (text[i] == '%') { zone = i; brk; }
+            i = i + 1;
+        }
+
+        var addr: IPv6;
+        if (!parse_ipv6_span(?(text::*u8)[1], zone - 1, ?addr)) {
+            ret err[Endpoint, str]("invalid IPv6 address");
+        }
+
+        var scope: u32 = 0;
+        if (zone < close) {
+            var raw_scope: u64 = 0;
+            if (!parse_decimal_span(?(text::*u8)[zone + 1], close - zone - 1, 4294967295, ?raw_scope)) {
+                ret err[Endpoint, str]("unsupported IPv6 zone");
+            }
+            scope = raw_scope::u32;
+        }
+
+        var raw_port: u64 = 0;
+        if (!parse_decimal_span(?(text::*u8)[close + 2], len - close - 2, 65535, ?raw_port)) {
+            ret err[Endpoint, str]("invalid port");
+        }
+        ret ok[Endpoint, str](endpoint_v6(addr, raw_port::u16, scope));
+    }
+
+    var colon: usize = len;
+    var i: usize = 0;
+    for (i < len) {
+        if (text[i] == ':') { colon = i; }
+        i = i + 1;
+    }
+    if (colon == 0 || colon >= len - 1) { ret err[Endpoint, str]("invalid IPv4 endpoint"); }
+
+    var addr: IPv4;
+    if (!parse_ipv4_span(text, colon, ?addr)) { ret err[Endpoint, str]("invalid IPv4 address"); }
+    var raw_port: u64 = 0;
+    if (!parse_decimal_span(?(text::*u8)[colon + 1], len - colon - 1, 65535, ?raw_port)) {
+        ret err[Endpoint, str]("invalid port");
+    }
+    ret ok[Endpoint, str](endpoint_v4(addr, raw_port::u16));
+}
+
+pub fun ipv6_format(addr: IPv6, buf: *u8, cap: usize) usize {
+    var groups: [8]u16;
+    var i: usize = 0;
+    for (i < 8) {
+        groups[i] = (addr.octets[i * 2]::u16 << 8) | addr.octets[i * 2 + 1]::u16;
+        i = i + 1;
+    }
+
+    var best_start: usize = 8;
+    var best_len: usize = 0;
+    i = 0;
+    for (i < 8) {
+        if (groups[i] != 0) { i = i + 1; cnt; }
+        val start: usize = i;
+        for (i < 8 && groups[i] == 0) { i = i + 1; }
+        val run: usize = i - start;
+        if (run >= 2 && run > best_len) {
+            best_start = start;
+            best_len = run;
+        }
+    }
+
+    var off: usize = 0;
+    i = 0;
+    for (i < 8) {
+        if (i == best_start) {
+            off = append_char(buf, cap, off, ':');
+            off = append_char(buf, cap, off, ':');
+            i = i + best_len;
+            cnt;
+        }
+        if (i > 0 && i != best_start + best_len) {
+            off = append_char(buf, cap, off, ':');
+        }
+        off = append_hex_u16(buf, cap, off, groups[i]);
+        i = i + 1;
+    }
+    if (off < cap) { buf[off] = 0; }
+    ret off;
+}
+
+# format an address into caller-owned storage without allocating
+pub fun addr_format(addr: Addr, buf: *u8, cap: usize) usize {
+    if (addr.is_v6 != 0) { ret ipv6_format(addr.v6, buf, cap); }
+    ret ipv4_format(addr.v4, buf, cap);
+}
+
+# format an endpoint into caller-owned storage without allocating
+pub fun endpoint_format(ep: Endpoint, buf: *u8, cap: usize) usize {
+    var text: [64]u8;
+    var text_len: usize = 0;
+    var off: usize = 0;
+    if (ep.addr.is_v6 != 0) {
+        off = append_char(buf, cap, off, '[');
+        text_len = ipv6_format(ep.addr.v6, ?text[0], 64);
+        off = append_bytes(buf, cap, off, ?text[0], text_len);
+        if (ep.scope != 0) {
+            off = append_char(buf, cap, off, '%');
+            off = append_decimal(buf, cap, off, ep.scope::u64);
+        }
+        off = append_char(buf, cap, off, ']');
+    }
+    or {
+        text_len = ipv4_format(ep.addr.v4, ?text[0], 64);
+        off = append_bytes(buf, cap, off, ?text[0], text_len);
+    }
+    off = append_char(buf, cap, off, ':');
+    off = append_decimal(buf, cap, off, ep.port::u64);
+    if (off < cap) { buf[off] = 0; }
+    ret off;
+}
+
+pub fun addr_is_unspecified(addr: Addr) bool {
+    if (addr.is_v6 == 0) {
+        ret addr.v4.octets[0] == 0 && addr.v4.octets[1] == 0 && addr.v4.octets[2] == 0 && addr.v4.octets[3] == 0;
+    }
+    var i: usize = 0;
+    for (i < 16) { if (addr.v6.octets[i] != 0) { ret false; } i = i + 1; }
+    ret true;
+}
+
+pub fun addr_is_loopback(addr: Addr) bool {
+    if (addr.is_v6 == 0) { ret addr.v4.octets[0] == 127; }
+    var i: usize = 0;
+    for (i < 15) { if (addr.v6.octets[i] != 0) { ret false; } i = i + 1; }
+    ret addr.v6.octets[15] == 1;
+}
+
+pub fun addr_is_multicast(addr: Addr) bool {
+    if (addr.is_v6 == 0) { ret addr.v4.octets[0] >= 224 && addr.v4.octets[0] <= 239; }
+    ret addr.v6.octets[0] == 255;
+}
+
+pub fun addr_is_v4_mapped(addr: Addr) bool {
+    if (addr.is_v6 == 0) { ret false; }
+    var i: usize = 0;
+    for (i < 10) { if (addr.v6.octets[i] != 0) { ret false; } i = i + 1; }
+    ret addr.v6.octets[10] == 255 && addr.v6.octets[11] == 255;
+}
+
+fun parse_decimal_span(text: *u8, len: usize, max: u64, out: *u64) bool {
+    if (text == nil || out == nil || len == 0) { ret false; }
+    var value: u64 = 0;
+    var i: usize = 0;
+    for (i < len) {
+        val c: u8 = text[i];
+        if (c < '0' || c > '9') { ret false; }
+        val digit: u64 = (c - '0')::u64;
+        if (value > (max - digit) / 10) { ret false; }
+        value = value * 10 + digit;
+        i = i + 1;
+    }
+    @out = value;
+    ret true;
+}
+
+fun parse_ipv4_span(text: *u8, len: usize, out: *IPv4) bool {
+    if (text == nil || out == nil || len == 0) { ret false; }
+    var octets: [4]u8;
+    var part: usize = 0;
+    var start: usize = 0;
+    var i: usize = 0;
+    for (i <= len) {
+        if (i == len || text[i] == '.') {
+            if (part >= 4 || i == start) { ret false; }
+            var value: u64 = 0;
+            if (!parse_decimal_span(?text[start], i - start, 255, ?value)) { ret false; }
+            octets[part] = value::u8;
+            part = part + 1;
+            start = i + 1;
+        }
+        i = i + 1;
+    }
+    if (part != 4) { ret false; }
+    out.octets = octets;
+    ret true;
+}
+
+fun hex_value(c: u8) i32 {
+    if (c >= '0' && c <= '9') { ret (c - '0')::i32; }
+    if (c >= 'a' && c <= 'f') { ret (c - 'a' + 10)::i32; }
+    if (c >= 'A' && c <= 'F') { ret (c - 'A' + 10)::i32; }
+    ret -1;
+}
+
+fun parse_ipv6_span(text: *u8, len: usize, out: *IPv6) bool {
+    if (text == nil || out == nil || len == 0) { ret false; }
+    var groups: [8]u16;
+    var count: usize = 0;
+    var compressed: usize = 9;
+    var i: usize = 0;
+
+    if (len >= 2 && text[0] == ':' && text[1] == ':') {
+        compressed = 0;
+        i = 2;
+        if (i == len) {
+            memory.raw_zero(?out.octets[0], 16);
+            ret true;
+        }
+    }
+
+    for (i < len) {
+        if (count >= 8) { ret false; }
+        val start: usize = i;
+        var has_dot: bool = false;
+        for (i < len && text[i] != ':') {
+            if (text[i] == '.') { has_dot = true; }
+            i = i + 1;
+        }
+        if (i == start) { ret false; }
+
+        if (has_dot) {
+            if (count > 6 || i != len) { ret false; }
+            var v4: IPv4;
+            if (!parse_ipv4_span(?text[start], i - start, ?v4)) { ret false; }
+            groups[count] = (v4.octets[0]::u16 << 8) | v4.octets[1]::u16;
+            groups[count + 1] = (v4.octets[2]::u16 << 8) | v4.octets[3]::u16;
+            count = count + 2;
+            brk;
+        }
+
+        if (i - start > 4) { ret false; }
+        var value: u16 = 0;
+        var j: usize = start;
+        for (j < i) {
+            val digit: i32 = hex_value(text[j]);
+            if (digit < 0) { ret false; }
+            value = (value << 4) | digit::u16;
+            j = j + 1;
+        }
+        groups[count] = value;
+        count = count + 1;
+
+        if (i == len) { brk; }
+        if (i + 1 < len && text[i + 1] == ':') {
+            if (compressed != 9) { ret false; }
+            compressed = count;
+            i = i + 2;
+            if (i == len) { brk; }
+        }
+        or {
+            i = i + 1;
+            if (i == len) { ret false; }
+        }
+    }
+
+    if (compressed == 9) {
+        if (count != 8) { ret false; }
+    }
+    or {
+        if (count >= 8) { ret false; }
+        val zeros: usize = 8 - count;
+        var j: usize = count;
+        for (j > compressed) {
+            j = j - 1;
+            groups[j + zeros] = groups[j];
+        }
+        j = compressed;
+        for (j < compressed + zeros) { groups[j] = 0; j = j + 1; }
+    }
+
+    i = 0;
+    for (i < 8) {
+        out.octets[i * 2] = (groups[i] >> 8)::u8;
+        out.octets[i * 2 + 1] = groups[i]::u8;
+        i = i + 1;
+    }
+    ret true;
+}
+
+fun append_char(buf: *u8, cap: usize, off: usize, c: u8) usize {
+    if (off < cap) { buf[off] = c; }
+    ret off + 1;
+}
+
+fun append_bytes(buf: *u8, cap: usize, off: usize, src: *u8, len: usize) usize {
+    var i: usize = 0;
+    for (i < len) {
+        if (off + i < cap) { buf[off + i] = src[i]; }
+        i = i + 1;
+    }
+    ret off + len;
+}
+
+fun append_decimal(buf: *u8, cap: usize, off: usize, value: u64) usize {
+    var digits: [20]u8;
+    var count: usize = 0;
+    var current: u64 = value;
+    if (current == 0) { digits[0] = '0'; count = 1; }
+    for (current > 0) {
+        digits[count] = (current % 10)::u8 + '0';
+        current = current / 10;
+        count = count + 1;
+    }
+    var result: usize = off;
+    var i: usize = count;
+    for (i > 0) { i = i - 1; result = append_char(buf, cap, result, digits[i]); }
+    ret result;
+}
+
+fun append_hex_u16(buf: *u8, cap: usize, off: usize, value: u16) usize {
+    val digits: str = "0123456789abcdef";
+    var started: bool = false;
+    var result: usize = off;
+    var shift: i32 = 12;
+    for (shift >= 0) {
+        val digit: u8 = ((value >> shift::u8) & 15)::u8;
+        if (digit != 0 || started || shift == 0) {
+            result = append_char(buf, cap, result, digits[digit::usize]);
+            started = true;
+        }
+        shift = shift - 4;
+    }
+    ret result;
 }
 
 fun write_u8_decimal(v: u8, buf: *u8, off: usize, cap: usize) usize {
@@ -282,7 +697,80 @@ test "ip: addr_v6 tag" {
 
 test "ip: endpoint constructor" {
     val ep: Endpoint = endpoint(10, 0, 0, 1, 8080);
-    if (ep.addr.octets[0] != 10) { ret 1; }
+    if (ep.addr.is_v6 != 0) { ret 1; }
+    if (ep.addr.v4.octets[0] != 10) { ret 1; }
     if (ep.port != 8080) { ret 1; }
+    ret 0;
+}
+
+test "ip: IPv4 parsing accepts noncanonical decimal" {
+    val parsed: Result[IPv4, str] = ipv4_parse("192.168.001.7");
+    if (is_err[IPv4, str](parsed)) { ret 1; }
+    val addr: IPv4 = unwrap_ok[IPv4, str](parsed);
+    if (addr.octets[0] != 192 || addr.octets[1] != 168 || addr.octets[2] != 1 || addr.octets[3] != 7) { ret 1; }
+    ret 0;
+}
+
+test "ip: IPv6 canonical formatting compresses longest run" {
+    val parsed: Result[IPv6, str] = ipv6_parse("2001:0db8:0:0:0:ff00:0042:8329");
+    if (is_err[IPv6, str](parsed)) { ret 1; }
+    var buf: [64]u8;
+    val n: usize = ipv6_format(unwrap_ok[IPv6, str](parsed), ?buf[0], 64);
+    if (n != 22) { ret 1; }
+    if (!str_starts_with(?buf[0], "2001:db8::ff00:42:8329")) { ret 1; }
+    ret 0;
+}
+
+test "ip: IPv6 loopback parses and formats" {
+    val parsed: Result[IPv6, str] = ipv6_parse("::1");
+    if (is_err[IPv6, str](parsed)) { ret 1; }
+    var buf: [16]u8;
+    val n: usize = ipv6_format(unwrap_ok[IPv6, str](parsed), ?buf[0], 16);
+    if (n != 3 || !str_starts_with(?buf[0], "::1")) { ret 1; }
+    ret 0;
+}
+
+test "ip: mapped IPv4 address classification" {
+    val parsed: Result[IPv6, str] = ipv6_parse("::ffff:192.0.2.1");
+    if (is_err[IPv6, str](parsed)) { ret 1; }
+    if (!addr_is_v4_mapped(addr_v6(unwrap_ok[IPv6, str](parsed)))) { ret 1; }
+    ret 0;
+}
+
+test "ip: scoped IPv6 endpoint roundtrip" {
+    val parsed: Result[Endpoint, str] = endpoint_parse("[fe80::1%3]:443");
+    if (is_err[Endpoint, str](parsed)) { ret 1; }
+    val ep: Endpoint = unwrap_ok[Endpoint, str](parsed);
+    if (ep.addr.is_v6 == 0 || ep.scope != 3 || ep.port != 443) { ret 1; }
+    var buf: [64]u8;
+    val n: usize = endpoint_format(ep, ?buf[0], 64);
+    if (n != 15 || !str_starts_with(?buf[0], "[fe80::1%3]:443")) { ret 1; }
+    ret 0;
+}
+
+test "ip: sockaddr conversions preserve both families" {
+    var storage: [128]u8;
+    var out: Endpoint;
+    val v4: Endpoint = endpoint(127, 0, 0, 1, 8080);
+    if (to_sockaddr(v4, ?storage[0]) != os.SOCKADDR_IN_SIZE) { ret 1; }
+    if (!from_sockaddr(?storage[0], ?out)) { ret 1; }
+    if (out.addr.is_v6 != 0 || out.addr.v4.octets[0] != 127 || out.port != 8080) { ret 1; }
+
+    val v6: Endpoint = endpoint_v6(ipv6_loopback(), 8443, 9);
+    if (to_sockaddr(v6, ?storage[0]) != os.SOCKADDR_IN6_SIZE) { ret 1; }
+    if (!from_sockaddr(?storage[0], ?out)) { ret 1; }
+    if (out.addr.is_v6 == 0 || out.addr.v6.octets[15] != 1 || out.port != 8443 || out.scope != 9) { ret 1; }
+    ret 0;
+}
+
+test "ip: address classifications cover both families" {
+    if (!addr_is_unspecified(addr_v4(ipv4_any()))) { ret 1; }
+    if (!addr_is_unspecified(addr_v6(ipv6_any()))) { ret 1; }
+    if (!addr_is_loopback(addr_v4(ipv4_loopback()))) { ret 1; }
+    if (!addr_is_loopback(addr_v6(ipv6_loopback()))) { ret 1; }
+    if (!addr_is_multicast(addr_v4(ipv4(239, 1, 2, 3)))) { ret 1; }
+    var multicast6: IPv6 = ipv6_any();
+    multicast6.octets[0] = 255;
+    if (!addr_is_multicast(addr_v6(multicast6))) { ret 1; }
     ret 0;
 }

--- a/src/net/tcp.mach
+++ b/src/net/tcp.mach
@@ -39,7 +39,7 @@ pub rec Stream {
 # ret:     the Listener, or an error message
 pub fun listen(ep: ip.Endpoint, backlog: i32) Result[Listener, io_error.Error] {
     var raw: usize = io_handle.INVALID_VALUE;
-    var code: i64 = os.sock_create(os.AF_INET, os.SOCK_STREAM, 0, ?raw);
+    var code: i64 = os.sock_create(ip.endpoint_family(ep), os.SOCK_STREAM, 0, ?raw);
     if (code < 0) { ret err[Listener, io_error.Error](io_error.from_code(code, io_error.OP_CREATE)); }
 
     var opt: i32 = 1;
@@ -49,10 +49,10 @@ pub fun listen(ep: ip.Endpoint, backlog: i32) Result[Listener, io_error.Error] {
         ret err[Listener, io_error.Error](io_error.from_code(code, io_error.OP_OPTION));
     }
 
-    var sa: [16]u8;
-    ip.to_sockaddr(ep, ?sa[0]);
+    var sa: [128]u8;
+    val sa_len: usize = ip.to_sockaddr(ep, ?sa[0]);
 
-    code = os.sock_bind(raw, ?sa[0], os.SOCKADDR_IN_SIZE);
+    code = os.sock_bind(raw, ?sa[0], sa_len);
     if (code < 0) {
         os.sock_close(raw);
         ret err[Listener, io_error.Error](io_error.from_code(code, io_error.OP_BIND));
@@ -72,8 +72,8 @@ pub fun listen(ep: ip.Endpoint, backlog: i32) Result[Listener, io_error.Error] {
 # ln:  the listener to accept on
 # ret: a connected Stream, or an error message
 pub fun accept(ln: *Listener) Result[Stream, io_error.Error] {
-    var sa: [16]u8;
-    var sa_len: u32 = os.SOCKADDR_IN_SIZE::u32;
+    var sa: [128]u8;
+    var sa_len: u32 = os.SOCKADDR_STORAGE_SIZE::u32;
     var raw: usize = io_handle.INVALID_VALUE;
     val code: i64 = os.sock_accept(ln.handle.value, ?sa[0], ?sa_len, ?raw);
     if (code < 0) { ret err[Stream, io_error.Error](io_error.from_code(code, io_error.OP_ACCEPT)); }
@@ -86,12 +86,15 @@ pub fun accept(ln: *Listener) Result[Stream, io_error.Error] {
 # ep:  pointer to an Endpoint to fill with the remote address
 # ret: a connected Stream, or an error message
 pub fun accept_ep(ln: *Listener, ep: *ip.Endpoint) Result[Stream, io_error.Error] {
-    var sa: [16]u8;
-    var sa_len: u32 = os.SOCKADDR_IN_SIZE::u32;
+    var sa: [128]u8;
+    var sa_len: u32 = os.SOCKADDR_STORAGE_SIZE::u32;
     var raw: usize = io_handle.INVALID_VALUE;
     val code: i64 = os.sock_accept(ln.handle.value, ?sa[0], ?sa_len, ?raw);
     if (code < 0) { ret err[Stream, io_error.Error](io_error.from_code(code, io_error.OP_ACCEPT)); }
-    ip.from_sockaddr(?sa[0], ep);
+    if (!ip.from_sockaddr(?sa[0], ep)) {
+        os.sock_close(raw);
+        ret err[Stream, io_error.Error](io_error.from_code(os.ENOTSUP, io_error.OP_ACCEPT));
+    }
     ret ok[Stream, io_error.Error](Stream{handle: io_handle.SocketHandle{value: raw}});
 }
 
@@ -101,13 +104,13 @@ pub fun accept_ep(ln: *Listener, ep: *ip.Endpoint) Result[Stream, io_error.Error
 # ret: a connected Stream, or an error message
 pub fun connect(ep: ip.Endpoint) Result[Stream, io_error.Error] {
     var raw: usize = io_handle.INVALID_VALUE;
-    var code: i64 = os.sock_create(os.AF_INET, os.SOCK_STREAM, 0, ?raw);
+    var code: i64 = os.sock_create(ip.endpoint_family(ep), os.SOCK_STREAM, 0, ?raw);
     if (code < 0) { ret err[Stream, io_error.Error](io_error.from_code(code, io_error.OP_CREATE)); }
 
-    var sa: [16]u8;
-    ip.to_sockaddr(ep, ?sa[0]);
+    var sa: [128]u8;
+    val sa_len: usize = ip.to_sockaddr(ep, ?sa[0]);
 
-    code = os.sock_connect(raw, ?sa[0], os.SOCKADDR_IN_SIZE);
+    code = os.sock_connect(raw, ?sa[0], sa_len);
     if (code < 0) {
         os.sock_close(raw);
         ret err[Stream, io_error.Error](io_error.from_code(code, io_error.OP_CONNECT));
@@ -203,6 +206,7 @@ $if ($mach.build.os == $mach.os.windows) {
 # pair needs a known port and no getsockname is exposed. SO_REUSEADDR (set by
 # listen) keeps a lingering TIME_WAIT from blocking a re-run.
 val TIMEOUT_TEST_PORT: u16 = 39271;
+val IPV6_TEST_PORT: u16 = 39272;
 
 test "tcp: create and close socket" {
     val ep: ip.Endpoint = ip.endpoint(127, 0, 0, 1, 0);
@@ -231,6 +235,32 @@ test "tcp: duplicate close is normalized" {
     val second: Result[bool, io_error.Error] = listener_close(?ln);
     if (!is_err[bool, io_error.Error](second)) { ret 1; }
     if (unwrap_err[bool, io_error.Error](second).kind != io_error.CLOSED) { ret 1; }
+    ret 0;
+}
+
+test "tcp: IPv6 loopback bind connect and accept" {
+    $if ($mach.build.os == $mach.os.windows) {
+        if (windows.running_under_wine()) { ret 0; }
+    }
+    val ep: ip.Endpoint = ip.endpoint_v6(ip.ipv6_loopback(), IPV6_TEST_PORT, 0);
+    val lr: Result[Listener, io_error.Error] = listen(ep, 1);
+    if (is_err[Listener, io_error.Error](lr)) { ret 1; }
+    var listener: Listener = unwrap_ok[Listener, io_error.Error](lr);
+
+    val cr: Result[Stream, io_error.Error] = connect(ep);
+    if (is_err[Stream, io_error.Error](cr)) { listener_close(?listener); ret 1; }
+    var client: Stream = unwrap_ok[Stream, io_error.Error](cr);
+
+    var peer: ip.Endpoint;
+    val ar: Result[Stream, io_error.Error] = accept_ep(?listener, ?peer);
+    if (is_err[Stream, io_error.Error](ar)) { stream_close(?client); listener_close(?listener); ret 1; }
+    var server: Stream = unwrap_ok[Stream, io_error.Error](ar);
+    val bad: bool = peer.addr.is_v6 == 0 || peer.addr.v6.octets[15] != 1;
+
+    stream_close(?server);
+    stream_close(?client);
+    listener_close(?listener);
+    if (bad) { ret 1; }
     ret 0;
 }
 

--- a/src/net/udp.mach
+++ b/src/net/udp.mach
@@ -19,16 +19,25 @@ use io_handle: std.io.handle;
 # handle: the native-width socket handle
 pub rec Socket {
     handle: io_handle.SocketHandle;
+    family: i32;
 }
 
 # create an unbound UDP socket
 # ---
 # ret: the Socket, or an error message
 pub fun create() Result[Socket, io_error.Error] {
+    ret create_for(os.AF_INET);
+}
+
+pub fun create_v6() Result[Socket, io_error.Error] {
+    ret create_for(os.AF_INET6);
+}
+
+fun create_for(family: i32) Result[Socket, io_error.Error] {
     var raw: usize = io_handle.INVALID_VALUE;
-    val code: i64 = os.sock_create(os.AF_INET, os.SOCK_DGRAM, 0, ?raw);
+    val code: i64 = os.sock_create(family, os.SOCK_DGRAM, 0, ?raw);
     if (code < 0) { ret err[Socket, io_error.Error](io_error.from_code(code, io_error.OP_CREATE)); }
-    ret ok[Socket, io_error.Error](Socket{handle: io_handle.SocketHandle{value: raw}});
+    ret ok[Socket, io_error.Error](Socket{handle: io_handle.SocketHandle{value: raw}, family: family});
 }
 
 # create a UDP socket bound to an endpoint
@@ -37,7 +46,8 @@ pub fun create() Result[Socket, io_error.Error] {
 # ret: the bound Socket, or an error message
 pub fun bind(ep: ip.Endpoint) Result[Socket, io_error.Error] {
     var raw: usize = io_handle.INVALID_VALUE;
-    var code: i64 = os.sock_create(os.AF_INET, os.SOCK_DGRAM, 0, ?raw);
+    val family: i32 = ip.endpoint_family(ep);
+    var code: i64 = os.sock_create(family, os.SOCK_DGRAM, 0, ?raw);
     if (code < 0) { ret err[Socket, io_error.Error](io_error.from_code(code, io_error.OP_CREATE)); }
 
     var opt: i32 = 1;
@@ -47,16 +57,16 @@ pub fun bind(ep: ip.Endpoint) Result[Socket, io_error.Error] {
         ret err[Socket, io_error.Error](io_error.from_code(code, io_error.OP_OPTION));
     }
 
-    var sa: [16]u8;
-    ip.to_sockaddr(ep, ?sa[0]);
+    var sa: [128]u8;
+    val sa_len: usize = ip.to_sockaddr(ep, ?sa[0]);
 
-    code = os.sock_bind(raw, ?sa[0], os.SOCKADDR_IN_SIZE);
+    code = os.sock_bind(raw, ?sa[0], sa_len);
     if (code < 0) {
         os.sock_close(raw);
         ret err[Socket, io_error.Error](io_error.from_code(code, io_error.OP_BIND));
     }
 
-    ret ok[Socket, io_error.Error](Socket{handle: io_handle.SocketHandle{value: raw}});
+    ret ok[Socket, io_error.Error](Socket{handle: io_handle.SocketHandle{value: raw}, family: family});
 }
 
 # send a datagram to a remote endpoint
@@ -67,9 +77,12 @@ pub fun bind(ep: ip.Endpoint) Result[Socket, io_error.Error] {
 # ep:  destination endpoint
 # ret: number of bytes sent, or negative on error
 pub fun send_to(s: *Socket, buf: *u8, len: usize, ep: ip.Endpoint) Result[usize, io_error.Error] {
-    var sa: [16]u8;
-    ip.to_sockaddr(ep, ?sa[0]);
-    val n: i64 = os.sock_sendto(s.handle.value, buf, len, 0, ?sa[0], os.SOCKADDR_IN_SIZE);
+    if (s.family != ip.endpoint_family(ep)) {
+        ret err[usize, io_error.Error](io_error.from_code(os.EINVAL, io_error.OP_SEND));
+    }
+    var sa: [128]u8;
+    val sa_len: usize = ip.to_sockaddr(ep, ?sa[0]);
+    val n: i64 = os.sock_sendto(s.handle.value, buf, len, 0, ?sa[0], sa_len);
     if (n < 0) { ret err[usize, io_error.Error](io_error.from_code(n, io_error.OP_SEND)); }
     ret ok[usize, io_error.Error](n::usize);
 }
@@ -82,11 +95,13 @@ pub fun send_to(s: *Socket, buf: *u8, len: usize, ep: ip.Endpoint) Result[usize,
 # ep:  pointer to an Endpoint to fill with the source address
 # ret: number of bytes received, or negative on error
 pub fun recv_from(s: *Socket, buf: *u8, len: usize, ep: *ip.Endpoint) Result[usize, io_error.Error] {
-    var sa: [16]u8;
-    var sa_len: u32 = os.SOCKADDR_IN_SIZE::u32;
+    var sa: [128]u8;
+    var sa_len: u32 = os.SOCKADDR_STORAGE_SIZE::u32;
     val n: i64 = os.sock_recvfrom(s.handle.value, buf, len, 0, ?sa[0], ?sa_len);
     if (n >= 0 && ep != nil) {
-        ip.from_sockaddr(?sa[0], ep);
+        if (!ip.from_sockaddr(?sa[0], ep)) {
+            ret err[usize, io_error.Error](io_error.from_code(os.ENOTSUP, io_error.OP_RECEIVE));
+        }
     }
     if (n < 0) { ret err[usize, io_error.Error](io_error.from_code(n, io_error.OP_RECEIVE)); }
     ret ok[usize, io_error.Error](n::usize);
@@ -131,5 +146,15 @@ test "udp: duplicate close is normalized" {
     val second: Result[bool, io_error.Error] = socket_close(?s);
     if (!is_err[bool, io_error.Error](second)) { ret 1; }
     if (unwrap_err[bool, io_error.Error](second).kind != io_error.CLOSED) { ret 1; }
+    ret 0;
+}
+
+test "udp: IPv6 loopback bind" {
+    val ep: ip.Endpoint = ip.endpoint_v6(ip.ipv6_loopback(), 0, 0);
+    val r: Result[Socket, io_error.Error] = bind(ep);
+    if (is_err[Socket, io_error.Error](r)) { ret 1; }
+    var s: Socket = unwrap_ok[Socket, io_error.Error](r);
+    if (s.family != os.AF_INET6) { socket_close(?s); ret 1; }
+    socket_close(?s);
     ret 0;
 }

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -182,6 +182,7 @@ fwd impl.stop_signal;
 
 # sockets
 fwd impl.AF_INET;
+fwd impl.AF_INET6;
 fwd impl.SOCK_STREAM;
 fwd impl.SOCK_DGRAM;
 fwd impl.SOL_SOCKET;
@@ -191,8 +192,13 @@ fwd impl.SHUT_RD;
 fwd impl.SHUT_WR;
 fwd impl.SHUT_RDWR;
 fwd impl.SOCKADDR_IN_SIZE;
+fwd impl.SOCKADDR_IN6_SIZE;
+fwd impl.SOCKADDR_STORAGE_SIZE;
 fwd impl.sock_addr_init;
 fwd impl.sock_addr_read;
+fwd impl.sock_addr_family;
+fwd impl.sock_addr6_init;
+fwd impl.sock_addr6_read;
 fwd impl.sock_send;
 fwd impl.sock_recv;
 fwd impl.sock_close;

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -169,6 +169,7 @@ fwd impl.was_continued;
 
 # sockets
 fwd impl.AF_INET;
+fwd platform.AF_INET6;
 fwd impl.SOCK_STREAM;
 fwd impl.SOCK_DGRAM;
 fwd impl.SOL_SOCKET;
@@ -178,6 +179,11 @@ fwd impl.SHUT_RD;
 fwd impl.SHUT_WR;
 fwd impl.SHUT_RDWR;
 fwd impl.SOCKADDR_IN_SIZE;
+fwd platform.SOCKADDR_IN6_SIZE;
+fwd platform.SOCKADDR_STORAGE_SIZE;
+fwd platform.sock_addr_family;
+fwd platform.sock_addr6_init;
+fwd platform.sock_addr6_read;
 fwd impl.sock_addr_init;
 fwd impl.sock_addr_read;
 fwd impl.sock_send;

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -1969,6 +1969,7 @@ test "std.system.os.darwin.libsystem:colliding_wait_addresses_are_both_woken" {
 # sockets
 
 pub val AF_INET:      i32 = 2;
+pub val AF_INET6:     i32 = 30;
 pub val SOCK_STREAM:  i32 = 1;
 pub val SOCK_DGRAM:   i32 = 2;
 pub val SOL_SOCKET:   i32 = 0xFFFF;
@@ -1979,6 +1980,12 @@ pub val SHUT_WR:      i32 = 1;
 pub val SHUT_RDWR:    i32 = 2;
 
 pub val SOCKADDR_IN_SIZE: usize = 16;
+pub val SOCKADDR_IN6_SIZE: usize = 28;
+pub val SOCKADDR_STORAGE_SIZE: usize = 128;
+
+pub fun sock_addr_family(sa: *u8) i32 {
+    ret sa[1]::i32;
+}
 
 pub fun sock_addr_init(sa: *u8, port: u16, addr: *u8) {
     var i: usize = 0;
@@ -1999,6 +2006,28 @@ pub fun sock_addr_read(sa: *u8, port: *u16, addr: *u8) {
     addr[1] = sa[5];
     addr[2] = sa[6];
     addr[3] = sa[7];
+}
+
+pub fun sock_addr6_init(sa: *u8, port: u16, addr: *u8, scope: u32) {
+    var i: usize = 0;
+    for (i < SOCKADDR_IN6_SIZE) { sa[i] = 0; i = i + 1; }
+    sa[0] = SOCKADDR_IN6_SIZE::u8;
+    sa[1] = AF_INET6::u8;
+    sa[2] = (port >> 8)::u8;
+    sa[3] = port::u8;
+    i = 0;
+    for (i < 16) { sa[8 + i] = addr[i]; i = i + 1; }
+    sa[24] = scope::u8;
+    sa[25] = (scope >> 8)::u8;
+    sa[26] = (scope >> 16)::u8;
+    sa[27] = (scope >> 24)::u8;
+}
+
+pub fun sock_addr6_read(sa: *u8, port: *u16, addr: *u8, scope: *u32) {
+    @port = (sa[2]::u16 << 8) | sa[3]::u16;
+    var i: usize = 0;
+    for (i < 16) { addr[i] = sa[8 + i]; i = i + 1; }
+    @scope = sa[24]::u32 | (sa[25]::u32 << 8) | (sa[26]::u32 << 16) | (sa[27]::u32 << 24);
 }
 
 pub fun sock_send(fd: usize, buf: *u8, len: usize) i64 {

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -181,6 +181,7 @@ fwd impl.was_continued;
 
 # sockets
 fwd impl.AF_INET;
+fwd platform.AF_INET6;
 fwd impl.SOCK_STREAM;
 fwd impl.SOCK_DGRAM;
 fwd impl.SOL_SOCKET;
@@ -190,6 +191,11 @@ fwd impl.SHUT_RD;
 fwd impl.SHUT_WR;
 fwd impl.SHUT_RDWR;
 fwd impl.SOCKADDR_IN_SIZE;
+fwd platform.SOCKADDR_IN6_SIZE;
+fwd platform.SOCKADDR_STORAGE_SIZE;
+fwd platform.sock_addr_family;
+fwd platform.sock_addr6_init;
+fwd platform.sock_addr6_read;
 fwd impl.sock_addr_init;
 fwd impl.sock_addr_read;
 fwd impl.sock_send;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -1908,6 +1908,7 @@ pub fun thread_wake(addr: *i64) i64 {
 # sockets
 
 pub val AF_INET:      i32 = 2;
+pub val AF_INET6:     i32 = 10;
 pub val SOCK_STREAM:  i32 = 1;
 pub val SOCK_DGRAM:   i32 = 2;
 pub val SOL_SOCKET:   i32 = 1;
@@ -1918,6 +1919,12 @@ pub val SHUT_WR:      i32 = 1;
 pub val SHUT_RDWR:    i32 = 2;
 
 pub val SOCKADDR_IN_SIZE: usize = 16;
+pub val SOCKADDR_IN6_SIZE: usize = 28;
+pub val SOCKADDR_STORAGE_SIZE: usize = 128;
+
+pub fun sock_addr_family(sa: *u8) i32 {
+    ret sa[0]::i32 | (sa[1]::i32 << 8);
+}
 
 # fill a sockaddr_in buffer with the given port and IPv4 address
 # ---
@@ -1948,6 +1955,28 @@ pub fun sock_addr_read(sa: *u8, port: *u16, addr: *u8) {
     addr[1] = sa[5];
     addr[2] = sa[6];
     addr[3] = sa[7];
+}
+
+pub fun sock_addr6_init(sa: *u8, port: u16, addr: *u8, scope: u32) {
+    var i: usize = 0;
+    for (i < SOCKADDR_IN6_SIZE) { sa[i] = 0; i = i + 1; }
+    sa[0] = AF_INET6::u8;
+    sa[1] = 0;
+    sa[2] = (port >> 8)::u8;
+    sa[3] = port::u8;
+    i = 0;
+    for (i < 16) { sa[8 + i] = addr[i]; i = i + 1; }
+    sa[24] = scope::u8;
+    sa[25] = (scope >> 8)::u8;
+    sa[26] = (scope >> 16)::u8;
+    sa[27] = (scope >> 24)::u8;
+}
+
+pub fun sock_addr6_read(sa: *u8, port: *u16, addr: *u8, scope: *u32) {
+    @port = (sa[2]::u16 << 8) | sa[3]::u16;
+    var i: usize = 0;
+    for (i < 16) { addr[i] = sa[8 + i]; i = i + 1; }
+    @scope = sa[24]::u32 | (sa[25]::u32 << 8) | (sa[26]::u32 << 16) | (sa[27]::u32 << 24);
 }
 
 # send data on a connected socket

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -154,6 +154,7 @@ fwd impl.stop_signal;
 
 # sockets
 fwd impl.AF_INET;
+fwd platform.AF_INET6;
 fwd impl.SOCK_STREAM;
 fwd impl.SOCK_DGRAM;
 fwd impl.SOL_SOCKET;
@@ -163,6 +164,11 @@ fwd impl.SHUT_RD;
 fwd impl.SHUT_WR;
 fwd impl.SHUT_RDWR;
 fwd impl.SOCKADDR_IN_SIZE;
+fwd platform.SOCKADDR_IN6_SIZE;
+fwd platform.SOCKADDR_STORAGE_SIZE;
+fwd platform.sock_addr_family;
+fwd platform.sock_addr6_init;
+fwd platform.sock_addr6_read;
 fwd impl.sock_addr_init;
 fwd impl.sock_addr_read;
 fwd impl.sock_send;

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -2491,6 +2491,7 @@ pub fun running_under_wine() bool {
 # sockets
 
 pub val AF_INET:      i32 = 2;
+pub val AF_INET6:     i32 = 23;
 pub val SOCK_STREAM:  i32 = 1;
 pub val SOCK_DGRAM:   i32 = 2;
 pub val SOL_SOCKET:   i32 = 0xFFFF;
@@ -2501,6 +2502,12 @@ pub val SHUT_WR:      i32 = 1;
 pub val SHUT_RDWR:    i32 = 2;
 
 pub val SOCKADDR_IN_SIZE: usize = 16;
+pub val SOCKADDR_IN6_SIZE: usize = 28;
+pub val SOCKADDR_STORAGE_SIZE: usize = 128;
+
+pub fun sock_addr_family(sa: *u8) i32 {
+    ret sa[0]::i32 | (sa[1]::i32 << 8);
+}
 
 pub fun sock_addr_init(sa: *u8, port: u16, addr: *u8) {
     var i: usize = 0;
@@ -2521,6 +2528,28 @@ pub fun sock_addr_read(sa: *u8, port: *u16, addr: *u8) {
     addr[1] = sa[5];
     addr[2] = sa[6];
     addr[3] = sa[7];
+}
+
+pub fun sock_addr6_init(sa: *u8, port: u16, addr: *u8, scope: u32) {
+    var i: usize = 0;
+    for (i < SOCKADDR_IN6_SIZE) { sa[i] = 0; i = i + 1; }
+    sa[0] = AF_INET6::u8;
+    sa[1] = 0;
+    sa[2] = (port >> 8)::u8;
+    sa[3] = port::u8;
+    i = 0;
+    for (i < 16) { sa[8 + i] = addr[i]; i = i + 1; }
+    sa[24] = scope::u8;
+    sa[25] = (scope >> 8)::u8;
+    sa[26] = (scope >> 16)::u8;
+    sa[27] = (scope >> 24)::u8;
+}
+
+pub fun sock_addr6_read(sa: *u8, port: *u16, addr: *u8, scope: *u32) {
+    @port = (sa[2]::u16 << 8) | sa[3]::u16;
+    var i: usize = 0;
+    for (i < 16) { addr[i] = sa[8 + i]; i = i + 1; }
+    @scope = sa[24]::u32 | (sa[25]::u32 << 8) | (sa[26]::u32 << 16) | (sa[27]::u32 << 24);
 }
 
 pub fun sock_send(fd: usize, buf: *u8, len: usize) i64 {


### PR DESCRIPTION
Closes #485

## Summary

- make endpoints transport-neutral across IPv4 and IPv6
- parse and format canonical addresses, bracketed endpoints, and numeric scope identifiers
- preserve scope identifiers through native sockaddr conversion
- add address classification and mapped-address helpers
- drive TCP and UDP socket creation from endpoint family
- add live IPv6 bind, connect, and accept coverage

## Validation

- `mach test . --target linux-x86_64`
- `mach build . --all-targets`
- `bash test/backends/verify.sh`