### PR TITLE
feat(log): add atomic structured record sinks

### DIFF
--- a/src/log.mach
+++ b/src/log.mach
@@ -1,141 +1,366 @@
-# structured logging with configurable level and output
-#
-# writes leveled log messages to stderr by default, or to a configured
-# writer. each message is prefixed with an RFC 3339 timestamp and the
-# level tag.
+# atomic structured logging with explicit record and sink contracts
 
+use R: std.types.result;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
 use std.types.size.usize;
-use std.types.result.Result;
 use std.types.string.str;
 use std.types.string.str_len;
 use std.io.writer;
 use std.system.os;
 use std.sync.atomic;
+use std.sync.mutex;
 use std.chrono.time;
-use std.chrono.time.Time;
-use std.chrono.date.Datetime;
-use std.chrono.date.datetime_from_time;
-use std.chrono.format.rfc3339;
+use record: std.log.record;
+use sink: std.log.sink;
 
-pub def Level: u8;
-pub val DEBUG: Level = 0;
-pub val INFO:  Level = 1;
-pub val WARN:  Level = 2;
-pub val ERROR: Level = 3;
-pub val OFF:   Level = 4;
+fwd record.MAX_RECORD_BYTES;
+fwd record.MIN_TRUNCATED_BYTES;
+fwd record.ERR_INVALID_RECORD;
+fwd record.ERR_RECORD_TOO_LARGE;
+fwd record.ERR_BUFFER_TOO_SMALL;
+fwd record.ERR_LIMIT_TOO_SMALL;
+fwd record.Level;
+fwd record.DEBUG;
+fwd record.INFO;
+fwd record.WARN;
+fwd record.ERROR;
+fwd record.OFF;
+fwd record.Precision;
+fwd record.PRECISION_SECONDS;
+fwd record.PRECISION_MILLIS;
+fwd record.PRECISION_MICROS;
+fwd record.PRECISION_NANOS;
+fwd record.ClockOwnership;
+fwd record.CLOCK_CONTEXT_NONE;
+fwd record.CLOCK_CONTEXT_BORROWED;
+fwd record.NowFun;
+fwd record.Clock;
+fwd record.FieldKind;
+fwd record.FIELD_I64;
+fwd record.FIELD_U64;
+fwd record.FIELD_BOOL;
+fwd record.FIELD_BYTES;
+fwd record.FIELD_STRING;
+fwd record.FIELD_ERROR;
+fwd record.Bytes;
+fwd record.Field;
+fwd record.Record;
+fwd record.OversizePolicy;
+fwd record.OVERSIZE_REJECT;
+fwd record.OVERSIZE_TRUNCATE;
+fwd record.EncodeStatus;
+fwd record.ENCODED;
+fwd record.ENCODED_TRUNCATED;
+fwd record.ENCODE_REJECTED;
+fwd record.ENCODE_INVALID;
+fwd record.Encoded;
+fwd record.system_clock;
+fwd record.clock;
+fwd record.clock_valid;
+fwd record.clock_now;
+fwd record.record_at;
+fwd record.field_i64;
+fwd record.field_u64;
+fwd record.field_bool;
+fwd record.field_bytes;
+fwd record.field_string;
+fwd record.field_error;
+fwd record.level_name;
+fwd encode_record: record.encode;
 
-var level_val:  i64 = INFO::i64;
-var out_ctx:    ptr = nil;
-var out_fn:     usize = 0;
+fwd sink.WriteStatus;
+fwd sink.WRITE_PERSISTED;
+fwd sink.WRITE_PARTIAL;
+fwd sink.WRITE_FAILED;
+fwd sink.WRITE_REJECTED;
+fwd sink.WRITE_DROPPED;
+fwd sink.WRITE_ENQUEUED;
+fwd sink.WRITE_SUPPRESSED;
+fwd sink.WriteReport;
+fwd sink.Delivery;
+fwd sink.DELIVERY_DIRECT;
+fwd sink.DELIVERY_BOUNDED_QUEUED;
+fwd sink.OverloadPolicy;
+fwd sink.OVERLOAD_REJECT_NEW;
+fwd sink.OVERLOAD_DROP_NEW;
+fwd sink.OVERLOAD_BLOCK;
+fwd sink.AdapterKind;
+fwd sink.ADAPTER_CONSOLE;
+fwd sink.ADAPTER_PIPE;
+fwd sink.ADAPTER_FILE;
+fwd sink.ADAPTER_CUSTOM;
+fwd sink.Contract;
+fwd sink.PublishFun;
+fwd sink.Sink;
+fwd sink.Direct;
+fwd sink.report;
+fwd sink.persisted;
+fwd sink.partial;
+fwd sink.failed;
+fwd sink.suppressed;
+fwd sink.contract_valid;
+fwd sink.queued_contract;
+fwd sink_make: sink.make;
+fwd sink_publish: sink.publish;
+fwd direct_custom: sink.custom;
+fwd direct_writer: sink.from_writer;
+fwd direct_console: sink.console;
+fwd direct_file: sink.file;
+fwd direct_pipe: sink.pipe;
+fwd sink.pipe_target_atomic_limit;
+
+pub val ERR_INVALID_LOGGER: str = "ERR_INVALID_LOGGER";
+
+# the sink and borrowed clock context must outlive the logger
+pub rec Logger {
+    output:    *sink.Sink;
+    clock:     record.Clock;
+    min_level: i64;
+}
+
+pub fun logger(output: *sink.Sink, clock: record.Clock, min_level: record.Level) R.Result[Logger, str] {
+    if (output == nil || !sink.contract_valid(output.contract) || !record.clock_valid(?clock) || min_level > record.OFF) {
+        ret R.err[Logger, str](ERR_INVALID_LOGGER);
+    }
+    ret R.ok[Logger, str](Logger{output: output, clock: clock, min_level: min_level::i64});
+}
+
+pub fun logger_set_level(log: *Logger, level: record.Level) {
+    if (log == nil || level > record.OFF) { ret; }
+    atomic.store(?log.min_level, level::i64);
+}
+
+pub fun emit(log: *Logger, entry: *record.Record) sink.WriteReport {
+    if (log == nil || log.output == nil || entry == nil || !sink.contract_valid(log.output.contract)) {
+        ret sink.failed(0, 0, ERR_INVALID_LOGGER);
+    }
+    if (entry.level::i64 < atomic.load(?log.min_level)) { ret sink.suppressed(); }
+
+    var data: [record.MAX_RECORD_BYTES]u8;
+    val encoded: record.Encoded = record.encode(
+        entry,
+        (?data)::*u8,
+        record.MAX_RECORD_BYTES,
+        log.output.contract.max_record,
+        log.output.contract.oversize,
+    );
+    if (encoded.status == record.ENCODE_REJECTED) {
+        ret sink.report(sink.WRITE_REJECTED, encoded.required, 0, false, encoded.error);
+    }
+    if (encoded.status == record.ENCODE_INVALID) {
+        ret sink.failed(encoded.required, 0, encoded.error);
+    }
+
+    val published: sink.WriteReport = sink.publish(log.output, (?data)::*u8, encoded.len);
+    ret sink.report(
+        published.status,
+        encoded.required,
+        published.persisted,
+        encoded.status == record.ENCODED_TRUNCATED,
+        published.error,
+    );
+}
+
+pub fun write_at(log: *Logger, timestamp: time.Time, level: record.Level, message: str, fields: *record.Field, field_count: usize) sink.WriteReport {
+    if (log == nil) { ret sink.failed(0, 0, ERR_INVALID_LOGGER); }
+    var entry: record.Record = record.record_at(timestamp, log.clock.precision, level, message, fields, field_count);
+    ret emit(log, ?entry);
+}
+
+pub fun write(log: *Logger, level: record.Level, message: str, fields: *record.Field, field_count: usize) sink.WriteReport {
+    if (log == nil) { ret sink.failed(0, 0, ERR_INVALID_LOGGER); }
+    if (level::i64 < atomic.load(?log.min_level)) { ret sink.suppressed(); }
+    val timestamp: time.Time = record.clock_now(?log.clock);
+    ret write_at(log, timestamp, level, message, fields, field_count);
+}
+
+var level_val: i64 = record.INFO::i64;
+var out_ctx: ptr = nil;
+var out_fn: usize = 0;
 var writer_set: i64 = 0;
+var out_lock: mutex.Mutex = 0;
 
-# set the minimum log level
-#
-# messages below this level are silently discarded. safe to call from
-# any thread; takes effect immediately for subsequent log calls.
-# ---
-# level: minimum level to emit (DEBUG, INFO, WARN, ERROR, OFF)
-pub fun set_level(level: Level) {
+# messages below this level are suppressed before timestamp sampling
+pub fun set_level(level: record.Level) {
+    if (level > record.OFF) { ret; }
     atomic.store(?level_val, level::i64);
 }
 
-# set the output writer for log messages
-#
-# when set, all output goes through this writer instead of stderr.
-# must be called before spawning threads that log.
-# ---
-# w: writer to use for output
-pub fun set_writer(w: *writer.Writer) {
-    out_ctx = w.ctx;
-    out_fn = w.f_write::usize;
+# the borrowed writer must be configured before concurrent logging starts
+pub fun set_writer(output: *writer.Writer) {
+    if (output == nil) { ret; }
+    out_ctx = output.ctx;
+    out_fn = output.f_write::usize;
     atomic.store(?writer_set, 1);
 }
 
-fun write_stderr(buf: *u8, len: usize) {
-    os.write(os.STDERR_FD, buf, len);
-}
-
-fun write_piece(buf: *u8, len: usize) {
+fun global_publish(data: *u8, len: usize) sink.WriteReport {
+    mutex.lock(?out_lock);
+    var result: sink.WriteReport;
     if (atomic.load(?writer_set) != 0) {
-        val f: fun(ptr, *u8, usize) Result[usize, str] = out_fn::fun(ptr, *u8, usize) Result[usize, str];
-        f(out_ctx, buf, len);
+        val f: writer.WriteFun = out_fn::writer.WriteFun;
+        val written: R.Result[usize, str] = f(out_ctx, data, len);
+        if (R.is_err[usize, str](written)) {
+            result = sink.failed(len, 0, R.unwrap_err[usize, str](written));
+        }
+        or {
+            val count: usize = R.unwrap_ok[usize, str](written);
+            if (count > len) { result = sink.failed(len, 0, sink.ERR_INVALID_REPORT); }
+            or (count < len) { result = sink.partial(len, count, writer.ERR_SHORT_WRITE); }
+            or { result = sink.persisted(len); }
+        }
     }
     or {
-        write_stderr(buf, len);
+        val count: i64 = os.write(os.STDERR_FD, data, len);
+        if (count < 0) { result = sink.failed(len, 0, os.message(count)); }
+        or (count::usize < len) { result = sink.partial(len, count::usize, writer.ERR_SHORT_WRITE); }
+        or { result = sink.persisted(len); }
     }
+    mutex.unlock(?out_lock);
+    ret result;
 }
 
-fun log_msg(level: Level, prefix: str, msg: str) {
-    if (level::i64 < atomic.load(?level_val)) { ret; }
-    var ts: [64]u8;
-    val dt: Datetime = datetime_from_time(time.now());
-    val n: usize = rfc3339(dt, (?ts)::*u8, 64);
-    if (n != 0) {
-        write_piece((?ts)::*u8, n);
-        write_piece(" ", 1);
+fun log_msg(level: record.Level, message: str) sink.WriteReport {
+    if (level::i64 < atomic.load(?level_val)) { ret sink.suppressed(); }
+    var entry: record.Record = record.record_at(time.now(), record.PRECISION_NANOS, level, message, nil, 0);
+    var data: [record.MAX_RECORD_BYTES]u8;
+    val encoded: record.Encoded = record.encode(
+        ?entry,
+        (?data)::*u8,
+        record.MAX_RECORD_BYTES,
+        record.MAX_RECORD_BYTES,
+        record.OVERSIZE_REJECT,
+    );
+    if (encoded.status == record.ENCODE_REJECTED) {
+        ret sink.report(sink.WRITE_REJECTED, encoded.required, 0, false, encoded.error);
     }
-    write_piece(prefix, str_len(prefix));
-    write_piece(" ", 1);
-    if (msg != nil) {
-        write_piece(msg, str_len(msg));
+    if (encoded.status != record.ENCODED) {
+        ret sink.failed(encoded.required, 0, encoded.error);
     }
-    write_piece("\n", 1);
+    ret global_publish((?data)::*u8, encoded.len);
 }
 
-# log a message at DEBUG level
-# ---
-# msg: message to log
-pub fun debug(msg: str) {
-    log_msg(DEBUG, "DEBUG", msg);
+pub fun debug_report(message: str) sink.WriteReport { ret log_msg(record.DEBUG, message); }
+pub fun info_report(message: str) sink.WriteReport  { ret log_msg(record.INFO, message); }
+pub fun warn_report(message: str) sink.WriteReport  { ret log_msg(record.WARN, message); }
+pub fun error_report(message: str) sink.WriteReport { ret log_msg(record.ERROR, message); }
+
+pub fun debug(message: str) { debug_report(message); }
+pub fun info(message: str)  { info_report(message); }
+pub fun warn(message: str)  { warn_report(message); }
+pub fun error(message: str) { error_report(message); }
+
+rec Capture {
+    data:  [512]u8;
+    len:   usize;
+    calls: usize;
 }
 
-# log a message at INFO level
-# ---
-# msg: message to log
-pub fun info(msg: str) {
-    log_msg(INFO, "INFO", msg);
+fun capture_write(ctx: ptr, data: *u8, len: usize) sink.WriteReport {
+    val capture: *Capture = ctx::*Capture;
+    if (len > 512 - capture.len) { ret sink.failed(len, 0, "capture full"); }
+    var i: usize = 0;
+    for (i < len) {
+        capture.data[capture.len + i] = data[i];
+        i = i + 1;
+    }
+    capture.len = capture.len + len;
+    capture.calls = capture.calls + 1;
+    ret sink.persisted(len);
 }
 
-# log a message at WARN level
-# ---
-# msg: message to log
-pub fun warn(msg: str) {
-    log_msg(WARN, "WARN", msg);
+rec TestClock {
+    calls: usize;
+    value: time.Time;
 }
 
-# log a message at ERROR level
-# ---
-# msg: message to log
-pub fun error(msg: str) {
-    log_msg(ERROR, "ERROR", msg);
+fun fixed_now(ctx: ptr) time.Time {
+    val source: *TestClock = ctx::*TestClock;
+    source.calls = source.calls + 1;
+    ret source.value;
 }
 
-test "set_level: OFF suppresses all" {
-    set_level(OFF);
-    debug("should not crash");
-    info("should not crash");
-    warn("should not crash");
-    error("should not crash");
-    set_level(INFO);
+fun bytes_equal(data: *u8, len: usize, expected: str) bool {
+    if (str_len(expected) != len) { ret false; }
+    var i: usize = 0;
+    for (i < len) {
+        if (data[i] != expected[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+test "log: logger serializes and publishes one structured record" {
+    var capture: Capture;
+    capture.len = 0;
+    capture.calls = 0;
+    var direct: sink.Direct;
+    val sr: R.Result[sink.Sink, str] = sink.custom(?direct, ?capture, capture_write, 512, record.OVERSIZE_REJECT, 0);
+    if (R.is_err[sink.Sink, str](sr)) { ret 1; }
+    var output: sink.Sink = R.unwrap_ok[sink.Sink, str](sr);
+    var source: TestClock = TestClock{calls: 0, value: time.unix(0, 999999999)};
+    val lr: R.Result[Logger, str] = logger(?output, record.clock(?source, fixed_now, record.PRECISION_SECONDS), record.DEBUG);
+    if (R.is_err[Logger, str](lr)) { ret 2; }
+    var log: Logger = R.unwrap_ok[Logger, str](lr);
+    var fields: [1]record.Field;
+    fields[0] = record.field_bool("ready", true);
+    val result: sink.WriteReport = write(?log, record.INFO, "service started", ?fields[0], 1);
+    if (result.status != sink.WRITE_PERSISTED || result.truncated || capture.calls != 1 || source.calls != 1) { ret 3; }
+    val expected: str = "timestamp=1970-01-01T00:00:00Z level=INFO message=\"service started\" ready=true\n";
+    if (!bytes_equal((?capture.data)::*u8, capture.len, expected)) { ret 4; }
     ret 0;
 }
 
-test "set_level: DEBUG enables all" {
-    set_level(DEBUG);
-    debug("debug msg");
-    info("info msg");
-    warn("warn msg");
-    error("error msg");
-    set_level(INFO);
+test "log: logger reports rejected and truncated records" {
+    var capture: Capture;
+    capture.len = 0;
+    capture.calls = 0;
+    var direct: sink.Direct;
+    var source: TestClock = TestClock{calls: 0, value: time.unix(0, 0)};
+
+    val reject_sr: R.Result[sink.Sink, str] = sink.custom(?direct, ?capture, capture_write, 64, record.OVERSIZE_REJECT, 0);
+    if (R.is_err[sink.Sink, str](reject_sr)) { ret 1; }
+    var reject_sink: sink.Sink = R.unwrap_ok[sink.Sink, str](reject_sr);
+    val reject_lr: R.Result[Logger, str] = logger(?reject_sink, record.clock(?source, fixed_now, record.PRECISION_SECONDS), record.DEBUG);
+    if (R.is_err[Logger, str](reject_lr)) { ret 2; }
+    var reject_log: Logger = R.unwrap_ok[Logger, str](reject_lr);
+    val rejected: sink.WriteReport = write(?reject_log, record.INFO, "this message cannot fit in sixty four bytes", nil, 0);
+    if (rejected.status != sink.WRITE_REJECTED || rejected.persisted != 0 || capture.calls != 0) { ret 3; }
+
+    val truncate_sr: R.Result[sink.Sink, str] = sink.custom(?direct, ?capture, capture_write, 64, record.OVERSIZE_TRUNCATE, 0);
+    if (R.is_err[sink.Sink, str](truncate_sr)) { ret 4; }
+    var truncate_sink: sink.Sink = R.unwrap_ok[sink.Sink, str](truncate_sr);
+    val truncate_lr: R.Result[Logger, str] = logger(?truncate_sink, record.clock(?source, fixed_now, record.PRECISION_SECONDS), record.DEBUG);
+    if (R.is_err[Logger, str](truncate_lr)) { ret 5; }
+    var truncate_log: Logger = R.unwrap_ok[Logger, str](truncate_lr);
+    val truncated: sink.WriteReport = write(?truncate_log, record.INFO, "this message cannot fit in sixty four bytes", nil, 0);
+    if (truncated.status != sink.WRITE_PERSISTED || !truncated.truncated || truncated.persisted > 64 || capture.calls != 1) { ret 6; }
     ret 0;
 }
 
-test "log: nil message does not crash" {
-    set_level(DEBUG);
-    debug(nil);
-    info(nil);
-    warn(nil);
-    error(nil);
-    set_level(INFO);
+test "log: level suppression samples no timestamp and publishes nothing" {
+    var capture: Capture;
+    capture.len = 0;
+    capture.calls = 0;
+    var direct: sink.Direct;
+    val sr: R.Result[sink.Sink, str] = sink.custom(?direct, ?capture, capture_write, 128, record.OVERSIZE_REJECT, 0);
+    if (R.is_err[sink.Sink, str](sr)) { ret 1; }
+    var output: sink.Sink = R.unwrap_ok[sink.Sink, str](sr);
+    var source: TestClock = TestClock{calls: 0, value: time.unix(0, 0)};
+    val lr: R.Result[Logger, str] = logger(?output, record.clock(?source, fixed_now, record.PRECISION_SECONDS), record.WARN);
+    if (R.is_err[Logger, str](lr)) { ret 2; }
+    var log: Logger = R.unwrap_ok[Logger, str](lr);
+    val result: sink.WriteReport = write(?log, record.INFO, "suppressed", nil, 0);
+    if (result.status != sink.WRITE_SUPPRESSED || source.calls != 0 || capture.calls != 0) { ret 3; }
+    ret 0;
+}
+
+test "log: compatibility level controls remain stable" {
+    set_level(record.OFF);
+    if (debug_report("suppressed").status != sink.WRITE_SUPPRESSED) { set_level(record.INFO); ret 1; }
+    if (error_report("suppressed").status != sink.WRITE_SUPPRESSED) { set_level(record.INFO); ret 2; }
+    set_level(record.INFO);
     ret 0;
 }

--- a/src/log.mach
+++ b/src/log.mach
@@ -12,8 +12,8 @@ use std.system.os;
 use std.sync.atomic;
 use std.sync.mutex;
 use std.chrono.time;
-use record: std.log.record;
-use sink: std.log.sink;
+use std.log.record;
+use std.log.sink;
 
 fwd record.MAX_RECORD_BYTES;
 fwd record.MIN_TRUNCATED_BYTES;
@@ -188,7 +188,8 @@ pub fun set_level(level: record.Level) {
     atomic.store(?level_val, level::i64);
 }
 
-# the borrowed writer must be configured before concurrent logging starts
+# the writer ctx is borrowed and must outlive every subsequent global log call
+# configure the writer before concurrent logging starts
 pub fun set_writer(output: *writer.Writer) {
     if (output == nil) { ret; }
     out_ctx = output.ctx;
@@ -208,14 +209,14 @@ fun global_publish(data: *u8, len: usize) sink.WriteReport {
         or {
             val count: usize = R.unwrap_ok[usize, str](written);
             if (count > len) { result = sink.failed(len, 0, sink.ERR_INVALID_REPORT); }
-            or (count < len) { result = sink.partial(len, count, writer.ERR_SHORT_WRITE); }
+            or (count < len) { result = sink.partial(len, 0, writer.ERR_SHORT_WRITE); }
             or { result = sink.persisted(len); }
         }
     }
     or {
         val count: i64 = os.write(os.STDERR_FD, data, len);
         if (count < 0) { result = sink.failed(len, 0, os.message(count)); }
-        or (count::usize < len) { result = sink.partial(len, count::usize, writer.ERR_SHORT_WRITE); }
+        or (count::usize < len) { result = sink.partial(len, 0, writer.ERR_SHORT_WRITE); }
         or { result = sink.persisted(len); }
     }
     mutex.unlock(?out_lock);

--- a/src/log.mach
+++ b/src/log.mach
@@ -209,14 +209,16 @@ fun global_publish(data: *u8, len: usize) sink.WriteReport {
         or {
             val count: usize = R.unwrap_ok[usize, str](written);
             if (count > len) { result = sink.failed(len, 0, sink.ERR_INVALID_REPORT); }
-            or (count < len) { result = sink.partial(len, 0, writer.ERR_SHORT_WRITE); }
+            or (count == 0 && len > 0) { result = sink.failed(len, 0, writer.ERR_SHORT_WRITE); }
+            or (count < len) { result = sink.partial(len, count, writer.ERR_SHORT_WRITE); }
             or { result = sink.persisted(len); }
         }
     }
     or {
         val count: i64 = os.write(os.STDERR_FD, data, len);
         if (count < 0) { result = sink.failed(len, 0, os.message(count)); }
-        or (count::usize < len) { result = sink.partial(len, 0, writer.ERR_SHORT_WRITE); }
+        or (count == 0 && len > 0) { result = sink.failed(len, 0, writer.ERR_SHORT_WRITE); }
+        or (count::usize < len) { result = sink.partial(len, count::usize, writer.ERR_SHORT_WRITE); }
         or { result = sink.persisted(len); }
     }
     mutex.unlock(?out_lock);

--- a/src/log/record.mach
+++ b/src/log/record.mach
@@ -1,0 +1,604 @@
+# typed structured log records and deterministic logfmt encoding
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.types.string.str_equals;
+use std.chrono.time;
+use std.chrono.time.Time;
+use std.chrono.date.Datetime;
+use std.chrono.date.datetime_from_time;
+use std.chrono.format.rfc3339;
+use io_error: std.io.error;
+
+pub val MAX_RECORD_BYTES: usize = 8192;
+pub val MIN_TRUNCATED_BYTES: usize = 15;
+
+pub val ERR_INVALID_RECORD: str = "ERR_INVALID_RECORD";
+pub val ERR_RECORD_TOO_LARGE: str = "ERR_RECORD_TOO_LARGE";
+pub val ERR_BUFFER_TOO_SMALL: str = "ERR_BUFFER_TOO_SMALL";
+pub val ERR_LIMIT_TOO_SMALL: str = "ERR_LIMIT_TOO_SMALL";
+
+pub def Level: u8;
+pub val DEBUG: Level = 0;
+pub val INFO:  Level = 1;
+pub val WARN:  Level = 2;
+pub val ERROR: Level = 3;
+pub val OFF:   Level = 4;
+
+pub def Precision: u8;
+pub val PRECISION_SECONDS: Precision = 0;
+pub val PRECISION_MILLIS:  Precision = 1;
+pub val PRECISION_MICROS:  Precision = 2;
+pub val PRECISION_NANOS:   Precision = 3;
+
+pub def ClockOwnership: u8;
+pub val CLOCK_CONTEXT_NONE:     ClockOwnership = 0;
+pub val CLOCK_CONTEXT_BORROWED: ClockOwnership = 1;
+
+pub def NowFun: fun(ptr) Time;
+
+# the clock context is borrowed and must outlive every logger using it
+pub rec Clock {
+    ctx:       ptr;
+    f_now:     NowFun;
+    precision: Precision;
+    ownership: ClockOwnership;
+}
+
+pub def FieldKind: u8;
+pub val FIELD_I64:    FieldKind = 0;
+pub val FIELD_U64:    FieldKind = 1;
+pub val FIELD_BOOL:   FieldKind = 2;
+pub val FIELD_BYTES:  FieldKind = 3;
+pub val FIELD_STRING: FieldKind = 4;
+pub val FIELD_ERROR:  FieldKind = 5;
+
+pub rec Bytes {
+    data: *u8;
+    len:  usize;
+}
+
+# keys and borrowed string or byte values must outlive record encoding
+pub rec Field {
+    key:  str;
+    kind: FieldKind;
+    value: uni {
+        i64_value:    i64;
+        u64_value:    u64;
+        bool_value:   bool;
+        bytes_value:  Bytes;
+        string_value: str;
+        error_value:  io_error.Error;
+    };
+}
+
+# the timestamp is owned by value while message and fields are borrowed
+pub rec Record {
+    timestamp:   Time;
+    precision:   Precision;
+    level:       Level;
+    message:     str;
+    fields:      *Field;
+    field_count: usize;
+}
+
+pub def OversizePolicy: u8;
+pub val OVERSIZE_REJECT:   OversizePolicy = 0;
+pub val OVERSIZE_TRUNCATE: OversizePolicy = 1;
+
+pub def EncodeStatus: u8;
+pub val ENCODED:          EncodeStatus = 0;
+pub val ENCODED_TRUNCATED: EncodeStatus = 1;
+pub val ENCODE_REJECTED:  EncodeStatus = 2;
+pub val ENCODE_INVALID:   EncodeStatus = 3;
+
+pub rec Encoded {
+    status:   EncodeStatus;
+    len:      usize;
+    required: usize;
+    error:    str;
+}
+
+rec Cursor {
+    data:    *u8;
+    len:     usize;
+    cap:     usize;
+    written: usize;
+    valid:   bool;
+}
+
+fun system_now(ctx: ptr) Time {
+    ret time.now();
+}
+
+pub fun system_clock(precision: Precision) Clock {
+    ret Clock{
+        ctx: nil,
+        f_now: system_now,
+        precision: precision,
+        ownership: CLOCK_CONTEXT_NONE,
+    };
+}
+
+pub fun clock(ctx: ptr, f_now: NowFun, precision: Precision) Clock {
+    ret Clock{
+        ctx: ctx,
+        f_now: f_now,
+        precision: precision,
+        ownership: CLOCK_CONTEXT_BORROWED,
+    };
+}
+
+pub fun clock_valid(c: *Clock) bool {
+    if (c == nil || c.f_now::usize == 0) { ret false; }
+    if (!precision_valid(c.precision)) { ret false; }
+    if (c.ownership == CLOCK_CONTEXT_NONE) { ret c.ctx == nil; }
+    ret c.ownership == CLOCK_CONTEXT_BORROWED;
+}
+
+pub fun clock_now(c: *Clock) Time {
+    if (!clock_valid(c)) { ret Time{sec: 0, nsec: 0}; }
+    ret normalize_time(c.f_now(c.ctx), c.precision);
+}
+
+pub fun record_at(timestamp: Time, precision: Precision, level: Level, message: str, fields: *Field, field_count: usize) Record {
+    ret Record{
+        timestamp: normalize_time(timestamp, precision),
+        precision: precision,
+        level: level,
+        message: message,
+        fields: fields,
+        field_count: field_count,
+    };
+}
+
+pub fun field_i64(key: str, value: i64) Field {
+    var field: Field;
+    field.key = key;
+    field.kind = FIELD_I64;
+    field.value.i64_value = value;
+    ret field;
+}
+
+pub fun field_u64(key: str, value: u64) Field {
+    var field: Field;
+    field.key = key;
+    field.kind = FIELD_U64;
+    field.value.u64_value = value;
+    ret field;
+}
+
+pub fun field_bool(key: str, value: bool) Field {
+    var field: Field;
+    field.key = key;
+    field.kind = FIELD_BOOL;
+    field.value.bool_value = value;
+    ret field;
+}
+
+pub fun field_bytes(key: str, data: *u8, len: usize) Field {
+    var field: Field;
+    field.key = key;
+    field.kind = FIELD_BYTES;
+    field.value.bytes_value = Bytes{data: data, len: len};
+    ret field;
+}
+
+pub fun field_string(key: str, value: str) Field {
+    var field: Field;
+    field.key = key;
+    field.kind = FIELD_STRING;
+    field.value.string_value = value;
+    ret field;
+}
+
+pub fun field_error(key: str, value: io_error.Error) Field {
+    var field: Field;
+    field.key = key;
+    field.kind = FIELD_ERROR;
+    field.value.error_value = value;
+    ret field;
+}
+
+pub fun level_name(level: Level) str {
+    if (level == DEBUG) { ret "DEBUG"; }
+    if (level == INFO)  { ret "INFO"; }
+    if (level == WARN)  { ret "WARN"; }
+    if (level == ERROR) { ret "ERROR"; }
+    if (level == OFF)   { ret "OFF"; }
+    ret "INVALID";
+}
+
+fun precision_valid(precision: Precision) bool {
+    ret precision <= PRECISION_NANOS;
+}
+
+fun normalize_time(value: Time, precision: Precision) Time {
+    var normalized: Time = time.unix(value.sec, value.nsec);
+    if (precision == PRECISION_SECONDS) {
+        normalized.nsec = 0;
+    }
+    or (precision == PRECISION_MILLIS) {
+        normalized.nsec = normalized.nsec / 1000000 * 1000000;
+    }
+    or (precision == PRECISION_MICROS) {
+        normalized.nsec = normalized.nsec / 1000 * 1000;
+    }
+    ret normalized;
+}
+
+fun cursor(data: *u8, cap: usize) Cursor {
+    ret Cursor{data: data, len: 0, cap: cap, written: 0, valid: true};
+}
+
+fun put(c: *Cursor, data: *u8, len: usize) {
+    if (!c.valid) { ret; }
+    if (len > 0 && data == nil) { c.valid = false; ret; }
+    if (len > (0 - 1) - c.len) { c.valid = false; ret; }
+
+    if (c.data != nil) {
+        if (c.written > c.cap || len > c.cap - c.written) {
+            c.valid = false;
+            ret;
+        }
+        var i: usize = 0;
+        for (i < len) {
+            c.data[c.written + i] = data[i];
+            i = i + 1;
+        }
+        c.written = c.written + len;
+    }
+    c.len = c.len + len;
+}
+
+fun put_str(c: *Cursor, value: str) {
+    if (value == nil) { ret; }
+    put(c, value, str_len(value));
+}
+
+fun put_byte(c: *Cursor, value: u8) {
+    val byte: u8 = value;
+    put(c, ?byte, 1);
+}
+
+fun put_u64(c: *Cursor, value: u64) {
+    var digits: [20]u8;
+    var index: usize = 20;
+    var n: u64 = value;
+    if (n == 0) {
+        index = index - 1;
+        digits[index] = '0';
+    }
+    or {
+        for (n > 0) {
+            index = index - 1;
+            digits[index] = (n % 10)::u8 + '0';
+            n = n / 10;
+        }
+    }
+    put(c, ?digits[index], 20 - index);
+}
+
+fun put_i64(c: *Cursor, value: i64) {
+    if (value >= 0) { put_u64(c, value::u64); ret; }
+    if (value == -9223372036854775808) {
+        put_str(c, "-9223372036854775808");
+        ret;
+    }
+    put_byte(c, '-');
+    put_u64(c, (0 - value)::u64);
+}
+
+fun put_hex_byte(c: *Cursor, value: u8) {
+    val hex: str = "0123456789abcdef";
+    put_byte(c, hex[(value >> 4)::usize]);
+    put_byte(c, hex[(value & 15)::usize]);
+}
+
+fun put_quoted(c: *Cursor, value: str) {
+    put_byte(c, '"');
+    if (value != nil) {
+        val len: usize = str_len(value);
+        var i: usize = 0;
+        for (i < len) {
+            val byte: u8 = value[i];
+            if (byte == '"') { put_str(c, "\\\""); }
+            or (byte == '\\') { put_str(c, "\\\\"); }
+            or (byte == '\n') { put_str(c, "\\n"); }
+            or (byte == '\r') { put_str(c, "\\r"); }
+            or (byte == '\t') { put_str(c, "\\t"); }
+            or (byte < 0x20 || byte == 0x7f) {
+                put_str(c, "\\x");
+                put_hex_byte(c, byte);
+            }
+            or { put_byte(c, byte); }
+            i = i + 1;
+        }
+    }
+    put_byte(c, '"');
+}
+
+fun key_valid(key: str) bool {
+    if (key == nil || key[0] == 0) { ret false; }
+    if (str_equals(key, "timestamp") || str_equals(key, "level") || str_equals(key, "message") || str_equals(key, "truncated")) {
+        ret false;
+    }
+    var i: usize = 0;
+    for (key[i] != 0) {
+        val c: u8 = key[i];
+        val alpha: bool = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
+        val digit: bool = c >= '0' && c <= '9';
+        if (!alpha && !digit && c != '_' && c != '.' && c != '-') { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+fun record_valid(record: *Record) bool {
+    if (record == nil) { ret false; }
+    if (!precision_valid(record.precision)) { ret false; }
+    if (record.level > OFF) { ret false; }
+    if (record.field_count > 0 && record.fields == nil) { ret false; }
+
+    var i: usize = 0;
+    for (i < record.field_count) {
+        val field: *Field = ?record.fields[i];
+        if (!key_valid(field.key) || field.kind > FIELD_ERROR) { ret false; }
+        if (field.kind == FIELD_BYTES && field.value.bytes_value.len > 0 && field.value.bytes_value.data == nil) {
+            ret false;
+        }
+        i = i + 1;
+    }
+    ret true;
+}
+
+fun token_prefix(c: *Cursor, first: bool) {
+    if (!first) { put_byte(c, ' '); }
+}
+
+fun timestamp_token(c: *Cursor, record: *Record, first: bool) {
+    token_prefix(c, first);
+    put_str(c, "timestamp=");
+    var timestamp: [64]u8;
+    val normalized: Time = normalize_time(record.timestamp, record.precision);
+    val datetime: Datetime = datetime_from_time(normalized);
+    val len: usize = rfc3339(datetime, (?timestamp)::*u8, 64);
+    if (len == 0) { c.valid = false; ret; }
+    put(c, (?timestamp)::*u8, len);
+}
+
+fun level_token(c: *Cursor, record: *Record, first: bool) {
+    token_prefix(c, first);
+    put_str(c, "level=");
+    put_str(c, level_name(record.level));
+}
+
+fun message_token(c: *Cursor, record: *Record, first: bool) {
+    token_prefix(c, first);
+    put_str(c, "message=");
+    put_quoted(c, record.message);
+}
+
+fun field_token(c: *Cursor, field: *Field, first: bool) {
+    token_prefix(c, first);
+    put_str(c, field.key);
+    put_byte(c, '=');
+
+    if (field.kind == FIELD_I64) { put_i64(c, field.value.i64_value); }
+    or (field.kind == FIELD_U64) { put_u64(c, field.value.u64_value); }
+    or (field.kind == FIELD_BOOL) {
+        if (field.value.bool_value) { put_str(c, "true"); }
+        or { put_str(c, "false"); }
+    }
+    or (field.kind == FIELD_BYTES) {
+        put_str(c, "0x");
+        var i: usize = 0;
+        for (i < field.value.bytes_value.len) {
+            put_hex_byte(c, field.value.bytes_value.data[i]);
+            i = i + 1;
+        }
+    }
+    or (field.kind == FIELD_STRING) { put_quoted(c, field.value.string_value); }
+    or (field.kind == FIELD_ERROR) {
+        val error: io_error.Error = field.value.error_value;
+        put_str(c, "error(kind=");
+        put_u64(c, error.kind::u64);
+        put_str(c, ",code=");
+        put_i64(c, error.code);
+        put_str(c, ",operation=");
+        put_u64(c, error.operation::u64);
+        put_str(c, ",message=");
+        put_quoted(c, io_error.message(error));
+        put_byte(c, ')');
+    }
+}
+
+fun full_record(c: *Cursor, record: *Record) {
+    timestamp_token(c, record, true);
+    level_token(c, record, false);
+    message_token(c, record, false);
+    var i: usize = 0;
+    for (i < record.field_count) {
+        field_token(c, ?record.fields[i], false);
+        i = i + 1;
+    }
+    put_byte(c, '\n');
+}
+
+fun token_size(record: *Record, kind: u8, index: usize, first: bool) usize {
+    var size: Cursor = cursor(nil, 0);
+    if (kind == 0) { timestamp_token(?size, record, first); }
+    or (kind == 1) { level_token(?size, record, first); }
+    or (kind == 2) { message_token(?size, record, first); }
+    or { field_token(?size, ?record.fields[index], first); }
+    if (!size.valid) { ret 0 - 1; }
+    ret size.len;
+}
+
+fun write_token(c: *Cursor, record: *Record, kind: u8, index: usize, first: bool) {
+    if (kind == 0) { timestamp_token(c, record, first); }
+    or (kind == 1) { level_token(c, record, first); }
+    or (kind == 2) { message_token(c, record, first); }
+    or { field_token(c, ?record.fields[index], first); }
+}
+
+fun encoded(status: EncodeStatus, len: usize, required: usize, error: str) Encoded {
+    ret Encoded{status: status, len: len, required: required, error: error};
+}
+
+# encode one record into caller-owned storage
+#
+# reject emits no bytes. truncate retains whole leading tokens and appends
+# truncated=true, so the result remains a complete logfmt line.
+pub fun encode(record: *Record, data: *u8, cap: usize, limit: usize, policy: OversizePolicy) Encoded {
+    if (!record_valid(record) || policy > OVERSIZE_TRUNCATE) {
+        ret encoded(ENCODE_INVALID, 0, 0, ERR_INVALID_RECORD);
+    }
+    if (limit == 0 || limit > MAX_RECORD_BYTES) {
+        ret encoded(ENCODE_INVALID, 0, 0, ERR_INVALID_RECORD);
+    }
+    if (cap > 0 && data == nil) {
+        ret encoded(ENCODE_INVALID, 0, 0, ERR_INVALID_RECORD);
+    }
+
+    var sizing: Cursor = cursor(nil, 0);
+    full_record(?sizing, record);
+    if (!sizing.valid) { ret encoded(ENCODE_INVALID, 0, 0, ERR_INVALID_RECORD); }
+    val required: usize = sizing.len;
+
+    if (required <= limit) {
+        if (required > cap) { ret encoded(ENCODE_INVALID, 0, required, ERR_BUFFER_TOO_SMALL); }
+        var output: Cursor = cursor(data, cap);
+        full_record(?output, record);
+        if (!output.valid) { ret encoded(ENCODE_INVALID, 0, required, ERR_BUFFER_TOO_SMALL); }
+        ret encoded(ENCODED, output.written, required, nil);
+    }
+
+    if (policy == OVERSIZE_REJECT) {
+        ret encoded(ENCODE_REJECTED, 0, required, ERR_RECORD_TOO_LARGE);
+    }
+    if (limit < MIN_TRUNCATED_BYTES) {
+        ret encoded(ENCODE_INVALID, 0, required, ERR_LIMIT_TOO_SMALL);
+    }
+    if (limit > cap) {
+        ret encoded(ENCODE_INVALID, 0, required, ERR_BUFFER_TOO_SMALL);
+    }
+
+    var output: Cursor = cursor(data, cap);
+    var first: bool = true;
+    var stopped: bool = false;
+    var kind: u8 = 0;
+    for (kind < 3 && !stopped) {
+        val size: usize = token_size(record, kind, 0, first);
+        val suffix: usize = 16;
+        if (limit < suffix || size == 0 - 1 || size > limit - suffix || output.len > limit - suffix - size) {
+            stopped = true;
+        }
+        or {
+            write_token(?output, record, kind, 0, first);
+            first = false;
+        }
+        kind = kind + 1;
+    }
+
+    var i: usize = 0;
+    for (i < record.field_count && !stopped) {
+        val size: usize = token_size(record, 3, i, first);
+        val suffix: usize = 16;
+        if (limit < suffix || size == 0 - 1 || size > limit - suffix || output.len > limit - suffix - size) {
+            stopped = true;
+        }
+        or {
+            write_token(?output, record, 3, i, first);
+            first = false;
+        }
+        i = i + 1;
+    }
+
+    if (first) { put_str(?output, "truncated=true\n"); }
+    or { put_str(?output, " truncated=true\n"); }
+    if (!output.valid || output.written > limit) {
+        ret encoded(ENCODE_INVALID, 0, required, ERR_BUFFER_TOO_SMALL);
+    }
+    ret encoded(ENCODED_TRUNCATED, output.written, required, nil);
+}
+
+fun bytes_equal(data: *u8, len: usize, expected: str) bool {
+    if (str_len(expected) != len) { ret false; }
+    var i: usize = 0;
+    for (i < len) {
+        if (data[i] != expected[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+test "log.record: typed fields encode after timestamp capture" {
+    var raw: [3]u8;
+    raw[0] = 0x00;
+    raw[1] = 0xab;
+    raw[2] = 0xff;
+    var fields: [6]Field;
+    fields[0] = field_i64("signed", -7);
+    fields[1] = field_u64("unsigned", 9);
+    fields[2] = field_bool("ready", true);
+    fields[3] = field_bytes("body", (?raw)::*u8, 3);
+    fields[4] = field_string("name", "a\"b");
+    fields[5] = field_error("cause", io_error.Error{kind: io_error.INVALID, code: -22, operation: io_error.OP_WRITE});
+
+    var record: Record = record_at(time.unix(0, 123456789), PRECISION_MILLIS, INFO, "hello\nworld", ?fields[0], 6);
+    var output: [512]u8;
+    val result: Encoded = encode(?record, (?output)::*u8, 512, 512, OVERSIZE_REJECT);
+    if (result.status != ENCODED) { ret 1; }
+    val expected: str = "timestamp=1970-01-01T00:00:00.123000000Z level=INFO message=\"hello\\nworld\" signed=-7 unsigned=9 ready=true body=0x00abff name=\"a\\\"b\" cause=error(kind=12,code=-22,operation=4,message=\"invalid argument\")\n";
+    if (!bytes_equal((?output)::*u8, result.len, expected)) { ret 2; }
+
+    var reserved: [1]Field;
+    reserved[0] = field_bool("truncated", false);
+    var invalid: Record = record_at(time.unix(0, 0), PRECISION_SECONDS, INFO, "reserved", ?reserved[0], 1);
+    if (encode(?invalid, (?output)::*u8, 512, 512, OVERSIZE_REJECT).status != ENCODE_INVALID) { ret 3; }
+    ret 0;
+}
+
+test "log.record: reject and truncate policies are deterministic" {
+    var record: Record = record_at(time.unix(0, 0), PRECISION_SECONDS, WARN, "a message too large for the configured record budget", nil, 0);
+    var output: [128]u8;
+
+    val rejected: Encoded = encode(?record, (?output)::*u8, 128, 64, OVERSIZE_REJECT);
+    if (rejected.status != ENCODE_REJECTED || rejected.len != 0 || rejected.required <= 64) { ret 1; }
+
+    val truncated: Encoded = encode(?record, (?output)::*u8, 128, 64, OVERSIZE_TRUNCATE);
+    if (truncated.status != ENCODED_TRUNCATED || truncated.len > 64 || truncated.required != rejected.required) { ret 2; }
+    if (!bytes_equal((?output)::*u8, truncated.len, "timestamp=1970-01-01T00:00:00Z level=WARN truncated=true\n")) { ret 3; }
+
+    var minimum: [MIN_TRUNCATED_BYTES]u8;
+    val minimal: Encoded = encode(?record, (?minimum)::*u8, MIN_TRUNCATED_BYTES, MIN_TRUNCATED_BYTES, OVERSIZE_TRUNCATE);
+    if (minimal.status != ENCODED_TRUNCATED || !bytes_equal((?minimum)::*u8, minimal.len, "truncated=true\n")) { ret 4; }
+    ret 0;
+}
+
+rec TestClock {
+    calls: i64;
+    value: Time;
+}
+
+fun test_now(ctx: ptr) Time {
+    val source: *TestClock = ctx::*TestClock;
+    source.calls = source.calls + 1;
+    ret source.value;
+}
+
+test "log.record: clock source precision and ownership are explicit" {
+    var system: Clock = system_clock(PRECISION_NANOS);
+    if (system.ownership != CLOCK_CONTEXT_NONE || !clock_valid(?system)) { ret 1; }
+    var source: TestClock = TestClock{calls: 0, value: time.unix(10, 987654321)};
+    var c: Clock = clock(?source, test_now, PRECISION_MICROS);
+    if (c.ownership != CLOCK_CONTEXT_BORROWED || !clock_valid(?c)) { ret 2; }
+    val sampled: Time = clock_now(?c);
+    if (source.calls != 1 || sampled.sec != 10 || sampled.nsec != 987654000) { ret 3; }
+    ret 0;
+}

--- a/src/log/sink.mach
+++ b/src/log/sink.mach
@@ -15,7 +15,7 @@ use std.system.os;
 use std.sync.atomic;
 use std.sync.mutex;
 use std.sync.thread;
-use record: std.log.record;
+use std.log.record;
 
 pub val ERR_INVALID_SINK: str = "ERR_INVALID_SINK";
 pub val ERR_INVALID_REPORT: str = "ERR_INVALID_REPORT";
@@ -69,6 +69,7 @@ pub rec Contract {
 
 pub def PublishFun: fun(ptr, *u8, usize) WriteReport;
 
+# sink ctx is borrowed and must outlive every publish
 # publish callbacks must consume or copy the borrowed bytes before returning
 pub rec Sink {
     ctx:       ptr;
@@ -172,20 +173,21 @@ pub fun publish(sink: *Sink, data: *u8, len: usize) WriteReport {
     if (result.status > WRITE_SUPPRESSED || result.offered != len || result.persisted > len) {
         ret failed(len, 0, ERR_INVALID_REPORT);
     }
+    if (sink.contract.delivery == DELIVERY_DIRECT) { ret normalize_direct(result, len); }
     ret result;
 }
 
+# direct publication confirms the complete record or exposes no persisted bytes
 fun normalize_direct(result: WriteReport, len: usize) WriteReport {
-    if (result.status > WRITE_FAILED || result.persisted > len) {
+    if (result.status == WRITE_PERSISTED) {
+        if (result.persisted != len) { ret failed(len, 0, ERR_INVALID_REPORT); }
+        ret report(WRITE_PERSISTED, len, len, result.truncated, result.error);
+    }
+    if (result.status == WRITE_ENQUEUED || result.status == WRITE_SUPPRESSED) {
         ret failed(len, 0, ERR_INVALID_REPORT);
     }
-    if (result.status == WRITE_PERSISTED && result.persisted != len) {
-        ret partial(len, result.persisted, result.error);
-    }
-    if (result.status == WRITE_PARTIAL && result.persisted == len) {
-        ret persisted(len);
-    }
-    ret report(result.status, len, result.persisted, result.truncated, result.error);
+    if (len > 0 && result.persisted == len) { ret failed(len, 0, ERR_INVALID_REPORT); }
+    ret report(result.status, len, 0, result.truncated, result.error);
 }
 
 fun direct_publish(ctx: ptr, data: *u8, len: usize) WriteReport {
@@ -197,7 +199,7 @@ fun direct_publish(ctx: ptr, data: *u8, len: usize) WriteReport {
     mutex.lock(?direct.lock);
     val result: WriteReport = direct.f_write(direct.adapter_ctx, data, len);
     mutex.unlock(?direct.lock);
-    ret normalize_direct(result, len);
+    ret result;
 }
 
 fun writer_publish(ctx: ptr, data: *u8, len: usize) WriteReport {
@@ -231,6 +233,7 @@ fun direct_sink(direct: *Direct, contract: Contract) R.Result[Sink, str] {
     ret make(direct::ptr, direct_publish, contract);
 }
 
+# ctx is borrowed and must outlive direct and every sink created from it
 # the custom callback is serialized by direct before each invocation
 pub fun custom(direct: *Direct, ctx: ptr, f_write: PublishFun, max_record: usize, oversize: record.OversizePolicy, target_atomic_limit: usize) R.Result[Sink, str] {
     if (direct == nil || f_write::usize == 0) { ret R.err[Sink, str](ERR_INVALID_SINK); }
@@ -240,6 +243,7 @@ pub fun custom(direct: *Direct, ctx: ptr, f_write: PublishFun, max_record: usize
     ret direct_sink(direct, R.unwrap_ok[Contract, str](cr));
 }
 
+# the writer value is copied while its ctx remains borrowed for every sink created from direct
 # io writers report a failed call or a partial successful call
 pub fun from_writer(direct: *Direct, output: writer.Writer, max_record: usize, oversize: record.OversizePolicy, target_atomic_limit: usize) R.Result[Sink, str] {
     if (direct == nil) { ret R.err[Sink, str](ERR_INVALID_SINK); }
@@ -260,6 +264,7 @@ pub fun console(direct: *Direct, stderr: bool, max_record: usize, oversize: reco
     ret direct_sink(direct, R.unwrap_ok[Contract, str](cr));
 }
 
+# the caller owns the file handle and closes it only after sink use stops
 # regular files guarantee one in-process callback but no cross-process limit
 pub fun file(direct: *Direct, output: filesystem.File, max_record: usize, oversize: record.OversizePolicy) R.Result[Sink, str] {
     if (direct == nil) { ret R.err[Sink, str](ERR_INVALID_SINK); }
@@ -278,6 +283,7 @@ pub fun pipe_target_atomic_limit() usize {
 # linux pipe writes through 4096 bytes are cross-process atomic
 # darwin exposes the posix minimum of 512 bytes through this contract
 # windows anonymous byte pipes publish once but expose no portable byte limit
+# the caller owns the pipe handle and closes it only after sink use stops
 pub fun pipe(direct: *Direct, output: filesystem.File, max_record: usize, oversize: record.OversizePolicy) R.Result[Sink, str] {
     if (direct == nil) { ret R.err[Sink, str](ERR_INVALID_SINK); }
     val cr: R.Result[Contract, str] = direct_contract(max_record, oversize, ADAPTER_PIPE, pipe_target_atomic_limit());
@@ -343,8 +349,63 @@ test "log.sink: custom adapter reports partial writes and recovers after failure
 
     capture.partial_at = 2;
     val third: WriteReport = publish(?sink, "third", 5);
-    if (third.status != WRITE_PARTIAL || third.offered != 5 || third.persisted != 2) { ret 4; }
+    if (third.status != WRITE_PARTIAL || third.offered != 5 || third.persisted != 0) { ret 4; }
     if (capture.calls != 3 || !bytes_equal((?capture.data)::*u8, capture.len, "secondth")) { ret 5; }
+    ret 0;
+}
+
+rec MalformedCapture {
+    result: WriteReport;
+}
+
+fun malformed_write(ctx: ptr, data: *u8, len: usize) WriteReport {
+    val capture: *MalformedCapture = ctx::*MalformedCapture;
+    ret capture.result;
+}
+
+test "log.sink: direct publication rejects contradictory adapter reports" {
+    val cr: R.Result[Contract, str] = direct_contract(128, record.OVERSIZE_REJECT, ADAPTER_CUSTOM, 0);
+    if (R.is_err[Contract, str](cr)) { ret 1; }
+    var capture: MalformedCapture;
+    val sr: R.Result[Sink, str] = make(?capture, malformed_write, R.unwrap_ok[Contract, str](cr));
+    if (R.is_err[Sink, str](sr)) { ret 2; }
+    var sink: Sink = R.unwrap_ok[Sink, str](sr);
+
+    capture.result = report(WRITE_PERSISTED, 4, 3, false, nil);
+    val short_ok: WriteReport = publish(?sink, "test", 4);
+    if (short_ok.status != WRITE_FAILED || short_ok.persisted != 0 || short_ok.error != ERR_INVALID_REPORT) { ret 3; }
+
+    capture.result = report(WRITE_FAILED, 4, 4, false, ERR_DIRECT_WRITE_FAILED);
+    val failed_full: WriteReport = publish(?sink, "test", 4);
+    if (failed_full.status != WRITE_FAILED || failed_full.persisted != 0 || failed_full.error != ERR_INVALID_REPORT) { ret 4; }
+
+    capture.result = report(WRITE_REJECTED, 4, 4, false, ERR_DIRECT_WRITE_FAILED);
+    val rejected_full: WriteReport = publish(?sink, "test", 4);
+    if (rejected_full.status != WRITE_FAILED || rejected_full.persisted != 0 || rejected_full.error != ERR_INVALID_REPORT) { ret 5; }
+
+    capture.result = report(WRITE_PERSISTED, 4, 5, false, nil);
+    val oversized: WriteReport = publish(?sink, "test", 4);
+    if (oversized.status != WRITE_FAILED || oversized.persisted != 0 || oversized.error != ERR_INVALID_REPORT) { ret 6; }
+    ret 0;
+}
+
+test "log.sink: direct publication exposes no partial persistence" {
+    val cr: R.Result[Contract, str] = direct_contract(128, record.OVERSIZE_REJECT, ADAPTER_CUSTOM, 0);
+    if (R.is_err[Contract, str](cr)) { ret 1; }
+    var capture: MalformedCapture;
+    val sr: R.Result[Sink, str] = make(?capture, malformed_write, R.unwrap_ok[Contract, str](cr));
+    if (R.is_err[Sink, str](sr)) { ret 2; }
+    var sink: Sink = R.unwrap_ok[Sink, str](sr);
+
+    capture.result = report(WRITE_PARTIAL, 4, 2, false, writer.ERR_SHORT_WRITE);
+    val partial_result: WriteReport = publish(?sink, "test", 4);
+    if (partial_result.status != WRITE_PARTIAL || partial_result.persisted != 0
+     || partial_result.error != writer.ERR_SHORT_WRITE) { ret 3; }
+
+    capture.result = report(WRITE_FAILED, 4, 2, false, ERR_DIRECT_WRITE_FAILED);
+    val failed_result: WriteReport = publish(?sink, "test", 4);
+    if (failed_result.status != WRITE_FAILED || failed_result.persisted != 0
+     || failed_result.error != ERR_DIRECT_WRITE_FAILED) { ret 4; }
     ret 0;
 }
 

--- a/src/log/sink.mach
+++ b/src/log/sink.mach
@@ -1,0 +1,474 @@
+# serialized record sinks with direct atomic publication
+
+use R: std.types.result;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.io.writer;
+use io_error: std.io.error;
+use io_handle: std.io.handle;
+use std.filesystem;
+use std.system.os;
+use std.sync.atomic;
+use std.sync.mutex;
+use std.sync.thread;
+use record: std.log.record;
+
+pub val ERR_INVALID_SINK: str = "ERR_INVALID_SINK";
+pub val ERR_INVALID_REPORT: str = "ERR_INVALID_REPORT";
+val ERR_DIRECT_WRITE_FAILED: str = "ERR_DIRECT_WRITE_FAILED";
+
+pub def WriteStatus: u8;
+pub val WRITE_PERSISTED:  WriteStatus = 0;
+pub val WRITE_PARTIAL:    WriteStatus = 1;
+pub val WRITE_FAILED:     WriteStatus = 2;
+pub val WRITE_REJECTED:   WriteStatus = 3;
+pub val WRITE_DROPPED:    WriteStatus = 4;
+pub val WRITE_ENQUEUED:   WriteStatus = 5;
+pub val WRITE_SUPPRESSED: WriteStatus = 6;
+
+# offered is the full logical size before truncation
+# persisted is the byte count confirmed by the adapter
+pub rec WriteReport {
+    status:    WriteStatus;
+    offered:   usize;
+    persisted: usize;
+    truncated: bool;
+    error:     str;
+}
+
+pub def Delivery: u8;
+pub val DELIVERY_DIRECT:         Delivery = 0;
+pub val DELIVERY_BOUNDED_QUEUED: Delivery = 1;
+
+pub def OverloadPolicy: u8;
+pub val OVERLOAD_REJECT_NEW: OverloadPolicy = 0;
+pub val OVERLOAD_DROP_NEW:   OverloadPolicy = 1;
+pub val OVERLOAD_BLOCK:      OverloadPolicy = 2;
+
+pub def AdapterKind: u8;
+pub val ADAPTER_CONSOLE: AdapterKind = 0;
+pub val ADAPTER_PIPE:    AdapterKind = 1;
+pub val ADAPTER_FILE:    AdapterKind = 2;
+pub val ADAPTER_CUSTOM:  AdapterKind = 3;
+
+# target_atomic_limit is zero when the target offers no cross-process limit
+# every direct adapter still serializes callbacks within this process
+pub rec Contract {
+    delivery:            Delivery;
+    max_record:          usize;
+    oversize:            record.OversizePolicy;
+    adapter:             AdapterKind;
+    target_atomic_limit: usize;
+    queue_capacity:      usize;
+    overload:            OverloadPolicy;
+}
+
+pub def PublishFun: fun(ptr, *u8, usize) WriteReport;
+
+# publish callbacks must consume or copy the borrowed bytes before returning
+pub rec Sink {
+    ctx:       ptr;
+    f_publish: PublishFun;
+    contract:  Contract;
+}
+
+# direct sinks must remain at a stable address and must not be copied in use
+pub rec Direct {
+    lock:        mutex.Mutex;
+    adapter_ctx: ptr;
+    f_write:     PublishFun;
+    writer:      writer.Writer;
+    initialized: bool;
+}
+
+pub fun report(status: WriteStatus, offered: usize, persisted: usize, truncated: bool, error: str) WriteReport {
+    ret WriteReport{
+        status: status,
+        offered: offered,
+        persisted: persisted,
+        truncated: truncated,
+        error: error,
+    };
+}
+
+pub fun persisted(bytes: usize) WriteReport {
+    ret report(WRITE_PERSISTED, bytes, bytes, false, nil);
+}
+
+pub fun partial(offered: usize, persisted_bytes: usize, error: str) WriteReport {
+    ret report(WRITE_PARTIAL, offered, persisted_bytes, false, error);
+}
+
+pub fun failed(offered: usize, persisted_bytes: usize, error: str) WriteReport {
+    ret report(WRITE_FAILED, offered, persisted_bytes, false, error);
+}
+
+pub fun suppressed() WriteReport {
+    ret report(WRITE_SUPPRESSED, 0, 0, false, nil);
+}
+
+pub fun contract_valid(contract: Contract) bool {
+    if (contract.delivery > DELIVERY_BOUNDED_QUEUED) { ret false; }
+    if (contract.max_record == 0 || contract.max_record > record.MAX_RECORD_BYTES) { ret false; }
+    if (contract.oversize > record.OVERSIZE_TRUNCATE) { ret false; }
+    if (contract.oversize == record.OVERSIZE_TRUNCATE && contract.max_record < record.MIN_TRUNCATED_BYTES) { ret false; }
+    if (contract.adapter > ADAPTER_CUSTOM) { ret false; }
+    if (contract.overload > OVERLOAD_BLOCK) { ret false; }
+    if (contract.delivery == DELIVERY_DIRECT && contract.queue_capacity != 0) { ret false; }
+    if (contract.delivery == DELIVERY_BOUNDED_QUEUED && contract.queue_capacity == 0) { ret false; }
+    ret true;
+}
+
+fun direct_contract(max_record: usize, oversize: record.OversizePolicy, adapter: AdapterKind, target_atomic_limit: usize) R.Result[Contract, str] {
+    val contract: Contract = Contract{
+        delivery: DELIVERY_DIRECT,
+        max_record: max_record,
+        oversize: oversize,
+        adapter: adapter,
+        target_atomic_limit: target_atomic_limit,
+        queue_capacity: 0,
+        overload: OVERLOAD_REJECT_NEW,
+    };
+    if (!contract_valid(contract)) { ret R.err[Contract, str](ERR_INVALID_SINK); }
+    ret R.ok[Contract, str](contract);
+}
+
+# this is the extension contract for issue 493, not a queue implementation
+pub fun queued_contract(max_record: usize, oversize: record.OversizePolicy, capacity: usize, overload: OverloadPolicy, adapter: AdapterKind, target_atomic_limit: usize) R.Result[Contract, str] {
+    val contract: Contract = Contract{
+        delivery: DELIVERY_BOUNDED_QUEUED,
+        max_record: max_record,
+        oversize: oversize,
+        adapter: adapter,
+        target_atomic_limit: target_atomic_limit,
+        queue_capacity: capacity,
+        overload: overload,
+    };
+    if (!contract_valid(contract)) { ret R.err[Contract, str](ERR_INVALID_SINK); }
+    ret R.ok[Contract, str](contract);
+}
+
+# construct a sink from an implementation and a validated contract
+pub fun make(ctx: ptr, f_publish: PublishFun, contract: Contract) R.Result[Sink, str] {
+    if (f_publish::usize == 0 || !contract_valid(contract)) {
+        ret R.err[Sink, str](ERR_INVALID_SINK);
+    }
+    ret R.ok[Sink, str](Sink{ctx: ctx, f_publish: f_publish, contract: contract});
+}
+
+pub fun publish(sink: *Sink, data: *u8, len: usize) WriteReport {
+    if (sink == nil || sink.f_publish::usize == 0 || !contract_valid(sink.contract)) {
+        ret failed(len, 0, ERR_INVALID_SINK);
+    }
+    if (len > 0 && data == nil) { ret failed(len, 0, ERR_INVALID_SINK); }
+    if (len > sink.contract.max_record) {
+        ret report(WRITE_REJECTED, len, 0, false, record.ERR_RECORD_TOO_LARGE);
+    }
+    val result: WriteReport = sink.f_publish(sink.ctx, data, len);
+    if (result.status > WRITE_SUPPRESSED || result.offered != len || result.persisted > len) {
+        ret failed(len, 0, ERR_INVALID_REPORT);
+    }
+    ret result;
+}
+
+fun normalize_direct(result: WriteReport, len: usize) WriteReport {
+    if (result.status > WRITE_FAILED || result.persisted > len) {
+        ret failed(len, 0, ERR_INVALID_REPORT);
+    }
+    if (result.status == WRITE_PERSISTED && result.persisted != len) {
+        ret partial(len, result.persisted, result.error);
+    }
+    if (result.status == WRITE_PARTIAL && result.persisted == len) {
+        ret persisted(len);
+    }
+    ret report(result.status, len, result.persisted, result.truncated, result.error);
+}
+
+fun direct_publish(ctx: ptr, data: *u8, len: usize) WriteReport {
+    val direct: *Direct = ctx::*Direct;
+    if (!direct.initialized || direct.f_write::usize == 0) {
+        ret failed(len, 0, ERR_INVALID_SINK);
+    }
+
+    mutex.lock(?direct.lock);
+    val result: WriteReport = direct.f_write(direct.adapter_ctx, data, len);
+    mutex.unlock(?direct.lock);
+    ret normalize_direct(result, len);
+}
+
+fun writer_publish(ctx: ptr, data: *u8, len: usize) WriteReport {
+    val output: *writer.Writer = ctx::*writer.Writer;
+    val result: R.Result[usize, str] = writer.write(output, data, len);
+    if (R.is_err[usize, str](result)) {
+        ret failed(len, 0, R.unwrap_err[usize, str](result));
+    }
+    val written: usize = R.unwrap_ok[usize, str](result);
+    if (written > len) { ret failed(len, 0, ERR_INVALID_REPORT); }
+    if (written < len) { ret partial(len, written, writer.ERR_SHORT_WRITE); }
+    ret persisted(len);
+}
+
+fun init_custom(direct: *Direct, ctx: ptr, f_write: PublishFun) {
+    direct.lock = mutex.make();
+    direct.adapter_ctx = ctx;
+    direct.f_write = f_write;
+    direct.initialized = true;
+}
+
+fun init_writer(direct: *Direct, output: writer.Writer) {
+    direct.writer = output;
+    init_custom(direct, (?direct.writer)::ptr, writer_publish);
+}
+
+fun direct_sink(direct: *Direct, contract: Contract) R.Result[Sink, str] {
+    if (direct == nil || !direct.initialized || contract.delivery != DELIVERY_DIRECT) {
+        ret R.err[Sink, str](ERR_INVALID_SINK);
+    }
+    ret make(direct::ptr, direct_publish, contract);
+}
+
+# the custom callback is serialized by direct before each invocation
+pub fun custom(direct: *Direct, ctx: ptr, f_write: PublishFun, max_record: usize, oversize: record.OversizePolicy, target_atomic_limit: usize) R.Result[Sink, str] {
+    if (direct == nil || f_write::usize == 0) { ret R.err[Sink, str](ERR_INVALID_SINK); }
+    val cr: R.Result[Contract, str] = direct_contract(max_record, oversize, ADAPTER_CUSTOM, target_atomic_limit);
+    if (R.is_err[Contract, str](cr)) { ret R.err[Sink, str](R.unwrap_err[Contract, str](cr)); }
+    init_custom(direct, ctx, f_write);
+    ret direct_sink(direct, R.unwrap_ok[Contract, str](cr));
+}
+
+# io writers report a failed call or a partial successful call
+pub fun from_writer(direct: *Direct, output: writer.Writer, max_record: usize, oversize: record.OversizePolicy, target_atomic_limit: usize) R.Result[Sink, str] {
+    if (direct == nil) { ret R.err[Sink, str](ERR_INVALID_SINK); }
+    val cr: R.Result[Contract, str] = direct_contract(max_record, oversize, ADAPTER_CUSTOM, target_atomic_limit);
+    if (R.is_err[Contract, str](cr)) { ret R.err[Sink, str](R.unwrap_err[Contract, str](cr)); }
+    init_writer(direct, output);
+    ret direct_sink(direct, R.unwrap_ok[Contract, str](cr));
+}
+
+# consoles guarantee one in-process callback but no cross-process byte limit
+pub fun console(direct: *Direct, stderr: bool, max_record: usize, oversize: record.OversizePolicy) R.Result[Sink, str] {
+    if (direct == nil) { ret R.err[Sink, str](ERR_INVALID_SINK); }
+    var file: filesystem.File = filesystem.STDOUT;
+    if (stderr) { file = filesystem.STDERR; }
+    val cr: R.Result[Contract, str] = direct_contract(max_record, oversize, ADAPTER_CONSOLE, 0);
+    if (R.is_err[Contract, str](cr)) { ret R.err[Sink, str](R.unwrap_err[Contract, str](cr)); }
+    init_writer(direct, filesystem.writer(file));
+    ret direct_sink(direct, R.unwrap_ok[Contract, str](cr));
+}
+
+# regular files guarantee one in-process callback but no cross-process limit
+pub fun file(direct: *Direct, output: filesystem.File, max_record: usize, oversize: record.OversizePolicy) R.Result[Sink, str] {
+    if (direct == nil) { ret R.err[Sink, str](ERR_INVALID_SINK); }
+    val cr: R.Result[Contract, str] = direct_contract(max_record, oversize, ADAPTER_FILE, 0);
+    if (R.is_err[Contract, str](cr)) { ret R.err[Sink, str](R.unwrap_err[Contract, str](cr)); }
+    init_writer(direct, filesystem.writer(output));
+    ret direct_sink(direct, R.unwrap_ok[Contract, str](cr));
+}
+
+pub fun pipe_target_atomic_limit() usize {
+    $if ($mach.build.os == $mach.os.windows) { ret 0; }
+    $if ($mach.build.os == $mach.os.darwin) { ret 512; }
+    ret 4096;
+}
+
+# linux pipe writes through 4096 bytes are cross-process atomic
+# darwin exposes the posix minimum of 512 bytes through this contract
+# windows anonymous byte pipes publish once but expose no portable byte limit
+pub fun pipe(direct: *Direct, output: filesystem.File, max_record: usize, oversize: record.OversizePolicy) R.Result[Sink, str] {
+    if (direct == nil) { ret R.err[Sink, str](ERR_INVALID_SINK); }
+    val cr: R.Result[Contract, str] = direct_contract(max_record, oversize, ADAPTER_PIPE, pipe_target_atomic_limit());
+    if (R.is_err[Contract, str](cr)) { ret R.err[Sink, str](R.unwrap_err[Contract, str](cr)); }
+    init_writer(direct, filesystem.writer(output));
+    ret direct_sink(direct, R.unwrap_ok[Contract, str](cr));
+}
+
+rec Capture {
+    data:       [256]u8;
+    len:        usize;
+    calls:      usize;
+    fail_calls: usize;
+    partial_at: usize;
+}
+
+fun capture_write(ctx: ptr, data: *u8, len: usize) WriteReport {
+    val capture: *Capture = ctx::*Capture;
+    capture.calls = capture.calls + 1;
+    if (capture.fail_calls > 0) {
+        capture.fail_calls = capture.fail_calls - 1;
+        ret failed(len, 0, ERR_DIRECT_WRITE_FAILED);
+    }
+
+    var count: usize = len;
+    if (capture.partial_at < count) { count = capture.partial_at; }
+    if (count > 256 - capture.len) { count = 256 - capture.len; }
+    var i: usize = 0;
+    for (i < count) {
+        capture.data[capture.len + i] = data[i];
+        i = i + 1;
+    }
+    capture.len = capture.len + count;
+    if (count < len) { ret partial(len, count, writer.ERR_SHORT_WRITE); }
+    ret persisted(len);
+}
+
+fun bytes_equal(data: *u8, len: usize, expected: str) bool {
+    if (str_len(expected) != len) { ret false; }
+    var i: usize = 0;
+    for (i < len) {
+        if (data[i] != expected[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+test "log.sink: custom adapter reports partial writes and recovers after failure" {
+    var capture: Capture;
+    capture.len = 0;
+    capture.calls = 0;
+    capture.fail_calls = 1;
+    capture.partial_at = 256;
+    var direct: Direct;
+    val sr: R.Result[Sink, str] = custom(?direct, ?capture, capture_write, 128, record.OVERSIZE_REJECT, 0);
+    if (R.is_err[Sink, str](sr)) { ret 1; }
+    var sink: Sink = R.unwrap_ok[Sink, str](sr);
+
+    val first: WriteReport = publish(?sink, "first", 5);
+    if (first.status != WRITE_FAILED || first.persisted != 0) { ret 2; }
+    val second: WriteReport = publish(?sink, "second", 6);
+    if (second.status != WRITE_PERSISTED || second.persisted != 6) { ret 3; }
+
+    capture.partial_at = 2;
+    val third: WriteReport = publish(?sink, "third", 5);
+    if (third.status != WRITE_PARTIAL || third.offered != 5 || third.persisted != 2) { ret 4; }
+    if (capture.calls != 3 || !bytes_equal((?capture.data)::*u8, capture.len, "secondth")) { ret 5; }
+    ret 0;
+}
+
+rec ConcurrentCapture {
+    active:  i64;
+    overlap: i64;
+    calls:   i64;
+}
+
+fun concurrent_write(ctx: ptr, data: *u8, len: usize) WriteReport {
+    val capture: *ConcurrentCapture = ctx::*ConcurrentCapture;
+    if (atomic.exchange(?capture.active, 1) != 0) { atomic.store(?capture.overlap, 1); }
+    var i: usize = 0;
+    for (i < 1000) { atomic.spin_hint(); i = i + 1; }
+    capture.calls = capture.calls + 1;
+    atomic.store(?capture.active, 0);
+    ret persisted(len);
+}
+
+rec PublishContext {
+    sink: *Sink;
+    runs: usize;
+}
+
+fun publish_worker(arg: *u8) {
+    val context: *PublishContext = arg::*PublishContext;
+    var i: usize = 0;
+    for (i < context.runs) {
+        publish(context.sink, "one-record\n", 11);
+        i = i + 1;
+    }
+}
+
+test "log.sink: concurrent direct publishers never overlap one callback" {
+    var capture: ConcurrentCapture = ConcurrentCapture{active: 0, overlap: 0, calls: 0};
+    var direct: Direct;
+    val sr: R.Result[Sink, str] = custom(?direct, ?capture, concurrent_write, 128, record.OVERSIZE_REJECT, 0);
+    if (R.is_err[Sink, str](sr)) { ret 1; }
+    var sink: Sink = R.unwrap_ok[Sink, str](sr);
+    var contexts: [4]PublishContext;
+    var threads: [4]thread.Thread;
+    var i: usize = 0;
+    for (i < 4) {
+        contexts[i] = PublishContext{sink: ?sink, runs: 25};
+        thread.spawn_with(publish_worker, (?contexts[i])::*u8, ?threads[i]);
+        if (threads[i].tid < 0) {
+            var joined: usize = 0;
+            for (joined < i) { thread.join(?threads[joined]); joined = joined + 1; }
+            ret 2;
+        }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < 4) { thread.join(?threads[i]); i = i + 1; }
+    if (atomic.load(?capture.overlap) != 0 || capture.calls != 100) { ret 3; }
+    ret 0;
+}
+
+test "log.sink: file adapter publishes one complete region" {
+    val path: str = ".mach-log-sink-497.tmp";
+    filesystem.remove_file(path);
+    val created: R.Result[filesystem.File, io_error.Error] = filesystem.create(path, 0o600);
+    if (R.is_err[filesystem.File, io_error.Error](created)) { ret 1; }
+    var output: filesystem.File = R.unwrap_ok[filesystem.File, io_error.Error](created);
+
+    var direct: Direct;
+    val sr: R.Result[Sink, str] = file(?direct, output, 128, record.OVERSIZE_REJECT);
+    if (R.is_err[Sink, str](sr)) { filesystem.close(?output); filesystem.remove_file(path); ret 2; }
+    var sink: Sink = R.unwrap_ok[Sink, str](sr);
+    val result: WriteReport = publish(?sink, "file-record\n", 12);
+    filesystem.close(?output);
+    if (result.status != WRITE_PERSISTED || result.persisted != 12) { filesystem.remove_file(path); ret 3; }
+
+    val opened: R.Result[filesystem.File, io_error.Error] = filesystem.open(path);
+    if (R.is_err[filesystem.File, io_error.Error](opened)) { filesystem.remove_file(path); ret 4; }
+    var input: filesystem.File = R.unwrap_ok[filesystem.File, io_error.Error](opened);
+    var data: [32]u8;
+    val read: R.Result[usize, io_error.Error] = filesystem.read(input, (?data)::*u8, 32);
+    filesystem.close(?input);
+    filesystem.remove_file(path);
+    if (R.is_err[usize, io_error.Error](read)) { ret 5; }
+    val len: usize = R.unwrap_ok[usize, io_error.Error](read);
+    if (!bytes_equal((?data)::*u8, len, "file-record\n")) { ret 6; }
+    ret 0;
+}
+
+test "log.sink: pipe adapter publishes one complete region" {
+    var fds: [2]i32;
+    if (os.pipe(?fds[0]) < 0) { ret 1; }
+    var input: filesystem.File = filesystem.File{handle: io_handle.FileHandle{value: fds[0]::usize}};
+    var output: filesystem.File = filesystem.File{handle: io_handle.FileHandle{value: fds[1]::usize}};
+    var direct: Direct;
+    val sr: R.Result[Sink, str] = pipe(?direct, output, 128, record.OVERSIZE_REJECT);
+    if (R.is_err[Sink, str](sr)) { filesystem.close(?input); filesystem.close(?output); ret 2; }
+    var sink: Sink = R.unwrap_ok[Sink, str](sr);
+    if (sink.contract.target_atomic_limit != pipe_target_atomic_limit()) { filesystem.close(?input); filesystem.close(?output); ret 3; }
+    val result: WriteReport = publish(?sink, "pipe-record\n", 12);
+    filesystem.close(?output);
+    if (result.status != WRITE_PERSISTED) { filesystem.close(?input); ret 4; }
+    var data: [32]u8;
+    val read: R.Result[usize, io_error.Error] = filesystem.read(input, (?data)::*u8, 32);
+    filesystem.close(?input);
+    if (R.is_err[usize, io_error.Error](read)) { ret 5; }
+    val len: usize = R.unwrap_ok[usize, io_error.Error](read);
+    if (!bytes_equal((?data)::*u8, len, "pipe-record\n")) { ret 6; }
+    ret 0;
+}
+
+test "log.sink: console adapter publishes through the native stream" {
+    var direct: Direct;
+    val sr: R.Result[Sink, str] = console(?direct, true, 128, record.OVERSIZE_REJECT);
+    if (R.is_err[Sink, str](sr)) { ret 1; }
+    var sink: Sink = R.unwrap_ok[Sink, str](sr);
+    val result: WriteReport = publish(?sink, "log console adapter ok\n", 23);
+    if (result.status != WRITE_PERSISTED || result.persisted != 23) { ret 2; }
+    ret 0;
+}
+
+test "log.sink: queued extension requires capacity and overload policy" {
+    val invalid: R.Result[Contract, str] = queued_contract(128, record.OVERSIZE_REJECT, 0, OVERLOAD_DROP_NEW, ADAPTER_FILE, 0);
+    if (R.is_ok[Contract, str](invalid)) { ret 1; }
+    val valid: R.Result[Contract, str] = queued_contract(128, record.OVERSIZE_REJECT, 64, OVERLOAD_REJECT_NEW, ADAPTER_FILE, 0);
+    if (R.is_err[Contract, str](valid)) { ret 2; }
+    val contract: Contract = R.unwrap_ok[Contract, str](valid);
+    if (contract.delivery != DELIVERY_BOUNDED_QUEUED || contract.queue_capacity != 64 || contract.overload != OVERLOAD_REJECT_NEW) { ret 3; }
+    ret 0;
+}

--- a/src/log/sink.mach
+++ b/src/log/sink.mach
@@ -78,6 +78,9 @@ pub rec Sink {
 }
 
 # direct sinks must remain at a stable address and must not be copied in use
+# reinitialization requires every current publication to stop first
+# existing sinks retarget to the new adapter but retain their copied contract and must be discarded
+# direct owns no resources and requires no destruction
 pub rec Direct {
     lock:        mutex.Mutex;
     adapter_ctx: ptr;
@@ -170,24 +173,37 @@ pub fun publish(sink: *Sink, data: *u8, len: usize) WriteReport {
         ret report(WRITE_REJECTED, len, 0, false, record.ERR_RECORD_TOO_LARGE);
     }
     val result: WriteReport = sink.f_publish(sink.ctx, data, len);
+    if (sink.contract.delivery == DELIVERY_DIRECT) { ret validate_direct(result, len); }
     if (result.status > WRITE_SUPPRESSED || result.offered != len || result.persisted > len) {
         ret failed(len, 0, ERR_INVALID_REPORT);
     }
-    if (sink.contract.delivery == DELIVERY_DIRECT) { ret normalize_direct(result, len); }
     ret result;
 }
 
-# direct publication confirms the complete record or exposes no persisted bytes
-fun normalize_direct(result: WriteReport, len: usize) WriteReport {
-    if (result.status == WRITE_PERSISTED) {
-        if (result.persisted != len) { ret failed(len, 0, ERR_INVALID_REPORT); }
-        ret report(WRITE_PERSISTED, len, len, result.truncated, result.error);
-    }
-    if (result.status == WRITE_ENQUEUED || result.status == WRITE_SUPPRESSED) {
+# direct atomicity is one callback while confirmed short-write bytes remain observable
+fun validate_direct(result: WriteReport, len: usize) WriteReport {
+    if (result.offered != len || result.persisted > len) {
         ret failed(len, 0, ERR_INVALID_REPORT);
     }
-    if (len > 0 && result.persisted == len) { ret failed(len, 0, ERR_INVALID_REPORT); }
-    ret report(result.status, len, 0, result.truncated, result.error);
+    if (result.status == WRITE_PERSISTED) {
+        if (result.persisted != len || result.error != nil) {
+            ret failed(len, 0, ERR_INVALID_REPORT);
+        }
+        ret result;
+    }
+    if (result.status == WRITE_PARTIAL) {
+        if (result.persisted == 0 || result.persisted == len || result.error == nil) {
+            ret failed(len, 0, ERR_INVALID_REPORT);
+        }
+        ret result;
+    }
+    if (result.status == WRITE_FAILED) {
+        if (result.error == nil || (len > 0 && result.persisted == len)) {
+            ret failed(len, 0, ERR_INVALID_REPORT);
+        }
+        ret result;
+    }
+    ret failed(len, 0, ERR_INVALID_REPORT);
 }
 
 fun direct_publish(ctx: ptr, data: *u8, len: usize) WriteReport {
@@ -210,6 +226,7 @@ fun writer_publish(ctx: ptr, data: *u8, len: usize) WriteReport {
     }
     val written: usize = R.unwrap_ok[usize, str](result);
     if (written > len) { ret failed(len, 0, ERR_INVALID_REPORT); }
+    if (written == 0 && len > 0) { ret failed(len, 0, writer.ERR_SHORT_WRITE); }
     if (written < len) { ret partial(len, written, writer.ERR_SHORT_WRITE); }
     ret persisted(len);
 }
@@ -349,9 +366,42 @@ test "log.sink: custom adapter reports partial writes and recovers after failure
 
     capture.partial_at = 2;
     val third: WriteReport = publish(?sink, "third", 5);
-    if (third.status != WRITE_PARTIAL || third.offered != 5 || third.persisted != 0) { ret 4; }
+    if (third.status != WRITE_PARTIAL || third.offered != 5 || third.persisted != 2) { ret 4; }
     if (capture.calls != 3 || !bytes_equal((?capture.data)::*u8, capture.len, "secondth")) { ret 5; }
     ret 0;
+}
+
+rec ShortWriter {
+    count: usize;
+}
+
+fun short_writer(ctx: ptr, data: *u8, len: usize) R.Result[usize, str] {
+    val state: *ShortWriter = ctx::*ShortWriter;
+    ret R.ok[usize, str](state.count);
+}
+
+test "log.sink: writer adapter preserves confirmed short-write bytes" {
+    var state: ShortWriter = ShortWriter{count: 2};
+    val output: writer.Writer = writer.Writer{ctx: ?state, f_write: short_writer};
+    var direct: Direct;
+    val sr: R.Result[Sink, str] = from_writer(?direct, output, 128, record.OVERSIZE_REJECT, 0);
+    if (R.is_err[Sink, str](sr)) { ret 1; }
+    var sink: Sink = R.unwrap_ok[Sink, str](sr);
+
+    val partial_result: WriteReport = publish(?sink, "short", 5);
+    if (partial_result.status != WRITE_PARTIAL || partial_result.persisted != 2
+     || partial_result.error != writer.ERR_SHORT_WRITE) { ret 2; }
+
+    state.count = 0;
+    val stalled: WriteReport = publish(?sink, "stalled", 7);
+    if (stalled.status != WRITE_FAILED || stalled.persisted != 0
+     || stalled.error != writer.ERR_SHORT_WRITE) { ret 3; }
+    ret 0;
+}
+
+rec DirectReportCase {
+    result: WriteReport;
+    valid:  bool;
 }
 
 rec MalformedCapture {
@@ -363,7 +413,7 @@ fun malformed_write(ctx: ptr, data: *u8, len: usize) WriteReport {
     ret capture.result;
 }
 
-test "log.sink: direct publication rejects contradictory adapter reports" {
+test "log.sink: direct adapter report status error and count matrix" {
     val cr: R.Result[Contract, str] = direct_contract(128, record.OVERSIZE_REJECT, ADAPTER_CUSTOM, 0);
     if (R.is_err[Contract, str](cr)) { ret 1; }
     var capture: MalformedCapture;
@@ -371,41 +421,40 @@ test "log.sink: direct publication rejects contradictory adapter reports" {
     if (R.is_err[Sink, str](sr)) { ret 2; }
     var sink: Sink = R.unwrap_ok[Sink, str](sr);
 
-    capture.result = report(WRITE_PERSISTED, 4, 3, false, nil);
-    val short_ok: WriteReport = publish(?sink, "test", 4);
-    if (short_ok.status != WRITE_FAILED || short_ok.persisted != 0 || short_ok.error != ERR_INVALID_REPORT) { ret 3; }
+    var cases: [18]DirectReportCase;
+    cases[0] = DirectReportCase{result: report(WRITE_PERSISTED, 4, 4, false, nil), valid: true};
+    cases[1] = DirectReportCase{result: report(WRITE_PARTIAL, 4, 2, false, writer.ERR_SHORT_WRITE), valid: true};
+    cases[2] = DirectReportCase{result: report(WRITE_FAILED, 4, 0, false, ERR_DIRECT_WRITE_FAILED), valid: true};
+    cases[3] = DirectReportCase{result: report(WRITE_FAILED, 4, 2, false, ERR_DIRECT_WRITE_FAILED), valid: true};
+    cases[4] = DirectReportCase{result: report(WRITE_PERSISTED, 4, 3, false, nil), valid: false};
+    cases[5] = DirectReportCase{result: report(WRITE_PERSISTED, 4, 4, false, ERR_DIRECT_WRITE_FAILED), valid: false};
+    cases[6] = DirectReportCase{result: report(WRITE_PARTIAL, 4, 0, false, writer.ERR_SHORT_WRITE), valid: false};
+    cases[7] = DirectReportCase{result: report(WRITE_PARTIAL, 4, 4, false, writer.ERR_SHORT_WRITE), valid: false};
+    cases[8] = DirectReportCase{result: report(WRITE_PARTIAL, 4, 2, false, nil), valid: false};
+    cases[9] = DirectReportCase{result: report(WRITE_FAILED, 4, 0, false, nil), valid: false};
+    cases[10] = DirectReportCase{result: report(WRITE_FAILED, 4, 4, false, ERR_DIRECT_WRITE_FAILED), valid: false};
+    cases[11] = DirectReportCase{result: report(WRITE_REJECTED, 4, 0, false, ERR_DIRECT_WRITE_FAILED), valid: false};
+    cases[12] = DirectReportCase{result: report(WRITE_DROPPED, 4, 0, false, ERR_DIRECT_WRITE_FAILED), valid: false};
+    cases[13] = DirectReportCase{result: report(WRITE_ENQUEUED, 4, 0, false, nil), valid: false};
+    cases[14] = DirectReportCase{result: report(WRITE_SUPPRESSED, 4, 0, false, nil), valid: false};
+    cases[15] = DirectReportCase{result: report((WRITE_SUPPRESSED + 1)::WriteStatus, 4, 0, false, nil), valid: false};
+    cases[16] = DirectReportCase{result: report(WRITE_PERSISTED, 4, 5, false, nil), valid: false};
+    cases[17] = DirectReportCase{result: report(WRITE_PERSISTED, 3, 3, false, nil), valid: false};
 
-    capture.result = report(WRITE_FAILED, 4, 4, false, ERR_DIRECT_WRITE_FAILED);
-    val failed_full: WriteReport = publish(?sink, "test", 4);
-    if (failed_full.status != WRITE_FAILED || failed_full.persisted != 0 || failed_full.error != ERR_INVALID_REPORT) { ret 4; }
-
-    capture.result = report(WRITE_REJECTED, 4, 4, false, ERR_DIRECT_WRITE_FAILED);
-    val rejected_full: WriteReport = publish(?sink, "test", 4);
-    if (rejected_full.status != WRITE_FAILED || rejected_full.persisted != 0 || rejected_full.error != ERR_INVALID_REPORT) { ret 5; }
-
-    capture.result = report(WRITE_PERSISTED, 4, 5, false, nil);
-    val oversized: WriteReport = publish(?sink, "test", 4);
-    if (oversized.status != WRITE_FAILED || oversized.persisted != 0 || oversized.error != ERR_INVALID_REPORT) { ret 6; }
-    ret 0;
-}
-
-test "log.sink: direct publication exposes no partial persistence" {
-    val cr: R.Result[Contract, str] = direct_contract(128, record.OVERSIZE_REJECT, ADAPTER_CUSTOM, 0);
-    if (R.is_err[Contract, str](cr)) { ret 1; }
-    var capture: MalformedCapture;
-    val sr: R.Result[Sink, str] = make(?capture, malformed_write, R.unwrap_ok[Contract, str](cr));
-    if (R.is_err[Sink, str](sr)) { ret 2; }
-    var sink: Sink = R.unwrap_ok[Sink, str](sr);
-
-    capture.result = report(WRITE_PARTIAL, 4, 2, false, writer.ERR_SHORT_WRITE);
-    val partial_result: WriteReport = publish(?sink, "test", 4);
-    if (partial_result.status != WRITE_PARTIAL || partial_result.persisted != 0
-     || partial_result.error != writer.ERR_SHORT_WRITE) { ret 3; }
-
-    capture.result = report(WRITE_FAILED, 4, 2, false, ERR_DIRECT_WRITE_FAILED);
-    val failed_result: WriteReport = publish(?sink, "test", 4);
-    if (failed_result.status != WRITE_FAILED || failed_result.persisted != 0
-     || failed_result.error != ERR_DIRECT_WRITE_FAILED) { ret 4; }
+    var i: usize = 0;
+    for (i < 18) {
+        capture.result = cases[i].result;
+        val result: WriteReport = publish(?sink, "test", 4);
+        if (cases[i].valid) {
+            if (result.status != cases[i].result.status || result.offered != cases[i].result.offered
+             || result.persisted != cases[i].result.persisted || result.error != cases[i].result.error) { ret 3; }
+        }
+        or {
+            if (result.status != WRITE_FAILED || result.offered != 4 || result.persisted != 0
+             || result.error != ERR_INVALID_REPORT) { ret 4; }
+        }
+        i = i + 1;
+    }
     ret 0;
 }
 


### PR DESCRIPTION
## Summary

- serialize typed structured records completely before one sink publication
- add mutex-protected direct console, pipe, file, writer, and custom adapters with validated publication results and confirmed partial byte counts
- make timestamp source, precision, context ownership, handle ownership, size policy, and target atomic limits explicit
- define the shared bounded queue contract for #493 without adding a placeholder worker pool
- keep the existing global logging functions while making each emitted record atomic

## Scope

This PR lands direct sinks and the queued sink extension contract. Bounded queue capacity, overload behavior, and asynchronous failure handling remain dependent on #493, so #497 stays open.

## Verification

- focused direct sink tests pass in native debug and optimized modes
- full Linux x86-64 suite passes with 869 tests in debug and optimized modes
- full native release-gating fixture passes with 861 tests and no known failures
- debug and optimized library builds pass for Linux x86-64, Linux arm64, Linux riscv64, Darwin x86-64, and Darwin arm64
- native test dispatchers compile for Linux arm64, Darwin x86-64, Darwin arm64, and Windows x86-64
- the pure suite dispatcher compiles for Linux riscv64

Refs #497