### PR TITLE
feat(test): add deterministic fault models

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Run the complete native suite
         run: bash test/native/verify.sh mach linux-x86_64
 
+      - name: Run the deterministic fault verifier
+        run: bash test/fault/verify.sh mach linux-x86_64
+
       - name: Collect native ELF evidence
         run: |
           set -o pipefail
@@ -95,6 +98,9 @@ jobs:
       - name: Run the test suite on riscv64
         run: mach test . --target linux-riscv64 --runner qemu-riscv64
 
+      - name: Run the deterministic fault verifier on riscv64
+        run: bash test/fault/verify.sh mach linux-riscv64 qemu-riscv64
+
       - name: RELRO re-protection contract (riscv64)
         run: bash test/relro/verify.sh mach linux-riscv64 qemu-riscv64
 
@@ -125,6 +131,9 @@ jobs:
         run: mach info
       - name: Run the complete native suite on aarch64
         run: bash test/native/verify.sh mach linux-arm64
+
+      - name: Run the deterministic fault verifier on aarch64
+        run: bash test/fault/verify.sh mach linux-arm64
 
       - name: Collect native ELF evidence
         run: |
@@ -169,6 +178,10 @@ jobs:
       - name: Run the complete native suite
         shell: bash
         run: bash test/native/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
+
+      - name: Run the deterministic fault verifier
+        shell: bash
+        run: AR=llvm-ar bash test/fault/verify.sh "$PWD/.mach-seed/mach.exe" windows-x86_64
 
       - name: Collect native PE evidence
         shell: bash
@@ -242,6 +255,9 @@ jobs:
 
       - name: Run the complete native suite on darwin
         run: bash test/native/verify.sh mach "darwin-${{ matrix.arch }}"
+
+      - name: Run the deterministic fault verifier on darwin
+        run: bash test/fault/verify.sh mach "darwin-${{ matrix.arch }}"
 
       - name: SIGPIPE suppression
         run: bash test/sigpipe/verify.sh mach "darwin-${{ matrix.arch }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,8 @@ jobs:
       - name: Build
         run: mach build .
 
+      - name: Verify release artifact excludes test-only modules
+        run: bash test/fault/verify-release.sh out/linux-x86_64/debug/lib/std
+
       - name: Create release
         uses: softprops/action-gh-release@v3

--- a/test/fault/mach.toml
+++ b/test/fault/mach.toml
@@ -1,0 +1,56 @@
+[project]
+id = "fault"
+version = "0.0.0"
+src = "src"
+out = "../../../.mach-out/std-fault/{target.name}/{profile.name}"
+
+[target.linux-x86_64]
+isa = "x86_64"
+os = "linux"
+abi = "sysv64"
+
+[target.linux-arm64]
+isa = "aarch64"
+os = "linux"
+abi = "aapcs64"
+
+[target.linux-riscv64]
+isa = "riscv64"
+os = "linux"
+abi = "lp64"
+
+[target.windows-x86_64]
+isa = "x86_64"
+os = "windows"
+abi = "win64"
+
+[target.darwin-x86_64]
+isa = "x86_64"
+os = "darwin"
+abi = "sysv64"
+
+[target.darwin-aarch64]
+isa = "aarch64"
+os = "darwin"
+abi = "aapcs64"
+
+[profile.debug]
+opt = 0
+debug = true
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.fault]
+kind = "static"
+entry = "lib/libfault.mach"
+out = "lib/fault"
+targets = ["*"]
+link = []
+need = []
+
+[dep.std]
+path = "../.."

--- a/test/fault/mach.toml
+++ b/test/fault/mach.toml
@@ -2,7 +2,7 @@
 id = "fault"
 version = "0.0.0"
 src = "src"
-out = "../../../.mach-out/std-fault/{target.name}/{profile.name}"
+out = "out/{target.name}/{profile.name}"
 
 [target.linux-x86_64]
 isa = "x86_64"

--- a/test/fault/src/allocator.mach
+++ b/test/fault/src/allocator.mach
@@ -1,0 +1,228 @@
+# exact counting and fail-point allocator adapter
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.option;
+use std.types.result;
+use std.allocator;
+use std.allocator.fixed;
+use std.allocator.page;
+
+pub val UNLIMITED: usize = 0xFFFFFFFFFFFFFFFF;
+
+pub rec Config {
+    fail_at:     usize;
+    byte_budget: usize;
+}
+
+pub rec CountingAllocator {
+    backing:          *allocator.Allocator;
+    config:           Config;
+    attempts:         usize;
+    allocation_calls: usize;
+    reallocate_calls: usize;
+    deallocate_calls: usize;
+    successes:        usize;
+    failures:         usize;
+    live_allocations: usize;
+    live_bytes:       usize;
+    peak_live_bytes:  usize;
+    acquired_bytes:   usize;
+    released_bytes:   usize;
+}
+
+pub fun make(state: *CountingAllocator, out: *allocator.Allocator, backing: *allocator.Allocator, config: Config) bool {
+    if (state == nil || out == nil || backing == nil) { ret false; }
+    state.backing = backing;
+    state.config = config;
+    state.attempts = 0;
+    state.allocation_calls = 0;
+    state.reallocate_calls = 0;
+    state.deallocate_calls = 0;
+    state.successes = 0;
+    state.failures = 0;
+    state.live_allocations = 0;
+    state.live_bytes = 0;
+    state.peak_live_bytes = 0;
+    state.acquired_bytes = 0;
+    state.released_bytes = 0;
+    out.ctx = state::ptr;
+    out.fn_allocate = allocate;
+    out.fn_reallocate = reallocate;
+    out.fn_deallocate = deallocate;
+    ret true;
+}
+
+# the byte budget counts successful newly acquired bytes, including realloc growth
+fun selected_failure(state: *CountingAllocator, growth: usize) bool {
+    state.attempts = state.attempts + 1;
+    if (state.config.fail_at != 0 && state.attempts == state.config.fail_at) { ret true; }
+    if (state.config.byte_budget != UNLIMITED) {
+        if (state.acquired_bytes > state.config.byte_budget) { ret true; }
+        if (growth > state.config.byte_budget - state.acquired_bytes) { ret true; }
+    }
+    ret false;
+}
+
+fun record_growth(state: *CountingAllocator, growth: usize) {
+    state.acquired_bytes = state.acquired_bytes + growth;
+    state.live_bytes = state.live_bytes + growth;
+    if (state.live_bytes > state.peak_live_bytes) {
+        state.peak_live_bytes = state.live_bytes;
+    }
+}
+
+fun allocate(ctx: ptr, size: usize, align: usize) option.Option[ptr] {
+    val state: *CountingAllocator = ctx::*CountingAllocator;
+    state.allocation_calls = state.allocation_calls + 1;
+    if (selected_failure(state, size)) {
+        state.failures = state.failures + 1;
+        ret option.none[ptr]();
+    }
+
+    val p: option.Option[ptr] = state.backing.fn_allocate(state.backing.ctx, size, align);
+    if (option.is_none[ptr](p)) {
+        state.failures = state.failures + 1;
+        ret p;
+    }
+    state.successes = state.successes + 1;
+    state.live_allocations = state.live_allocations + 1;
+    record_growth(state, size);
+    ret p;
+}
+
+fun reallocate(ctx: ptr, p: ptr, old_size: usize, new_size: usize, align: usize) option.Option[ptr] {
+    val state: *CountingAllocator = ctx::*CountingAllocator;
+    state.reallocate_calls = state.reallocate_calls + 1;
+    var growth: usize = 0;
+    if (new_size > old_size) { growth = new_size - old_size; }
+    if (selected_failure(state, growth)) {
+        state.failures = state.failures + 1;
+        ret option.none[ptr]();
+    }
+
+    val np: option.Option[ptr] = state.backing.fn_reallocate(state.backing.ctx, p, old_size, new_size, align);
+    if (option.is_none[ptr](np)) {
+        state.failures = state.failures + 1;
+        ret np;
+    }
+
+    state.successes = state.successes + 1;
+    if (p == nil && new_size > 0) { state.live_allocations = state.live_allocations + 1; }
+    if (new_size >= old_size) {
+        record_growth(state, growth);
+    } or {
+        val released: usize = old_size - new_size;
+        state.live_bytes = state.live_bytes - released;
+        state.released_bytes = state.released_bytes + released;
+    }
+    if (new_size == 0 && p != nil && state.live_allocations > 0) {
+        state.live_allocations = state.live_allocations - 1;
+    }
+    ret np;
+}
+
+fun deallocate(ctx: ptr, p: ptr, size: usize, align: usize) i64 {
+    val state: *CountingAllocator = ctx::*CountingAllocator;
+    state.deallocate_calls = state.deallocate_calls + 1;
+    val code: i64 = state.backing.fn_deallocate(state.backing.ctx, p, size, align);
+    if (code != 0) { ret code; }
+    if (p != nil && size > 0) {
+        state.live_allocations = state.live_allocations - 1;
+        state.live_bytes = state.live_bytes - size;
+        state.released_bytes = state.released_bytes + size;
+    }
+    ret 0;
+}
+
+pub fun balanced(state: *CountingAllocator) bool {
+    ret state.live_allocations == 0 && state.live_bytes == 0
+        && state.acquired_bytes == state.released_bytes;
+}
+
+test "fault allocator: allocation balance and byte counts are exact" {
+    var storage: [512]u8;
+    var fixed_state: fixed.FixedState;
+    var backing: allocator.Allocator;
+    if (option.is_some[*u8](fixed.make(?backing, ?fixed_state, ?storage[0], 512))) { ret 1; }
+    var state: CountingAllocator;
+    var a: allocator.Allocator;
+    if (!make(?state, ?a, ?backing, Config{fail_at: 0, byte_budget: UNLIMITED})) { ret 1; }
+
+    val a0: result.Result[*u8, *u8] = allocator.allocate[u8](?a, 16);
+    if (result.is_err[*u8, *u8](a0)) { ret 1; }
+    val p0: *u8 = result.unwrap_ok[*u8, *u8](a0);
+    val r0: result.Result[*u8, *u8] = allocator.reallocate[u8](?a, p0, 16, 24);
+    if (result.is_err[*u8, *u8](r0)) { ret 1; }
+    val p1: *u8 = result.unwrap_ok[*u8, *u8](r0);
+    val a1: result.Result[*u8, *u8] = allocator.allocate[u8](?a, 8);
+    if (result.is_err[*u8, *u8](a1)) { ret 1; }
+    val p2: *u8 = result.unwrap_ok[*u8, *u8](a1);
+
+    if (state.live_allocations != 2 || state.live_bytes != 32 || state.peak_live_bytes != 32) { ret 1; }
+    if (state.acquired_bytes != 32 || state.attempts != 3 || state.successes != 3) { ret 1; }
+    if (result.is_err[bool, *u8](allocator.deallocate[u8](?a, p1, 24))) { ret 1; }
+    if (result.is_err[bool, *u8](allocator.deallocate[u8](?a, p2, 8))) { ret 1; }
+    if (!balanced(?state) || state.deallocate_calls != 2) { ret 1; }
+    ret 0;
+}
+
+test "fault allocator: selected attempt fails without accounting mutation" {
+    var storage: [128]u8;
+    var fixed_state: fixed.FixedState;
+    var backing: allocator.Allocator;
+    if (option.is_some[*u8](fixed.make(?backing, ?fixed_state, ?storage[0], 128))) { ret 1; }
+    var state: CountingAllocator;
+    var a: allocator.Allocator;
+    make(?state, ?a, ?backing, Config{fail_at: 2, byte_budget: UNLIMITED});
+
+    val first: result.Result[*u8, *u8] = allocator.allocate[u8](?a, 8);
+    if (result.is_err[*u8, *u8](first)) { ret 1; }
+    val p: *u8 = result.unwrap_ok[*u8, *u8](first);
+    val failed: result.Result[*u8, *u8] = allocator.reallocate[u8](?a, p, 8, 16);
+    if (!result.is_err[*u8, *u8](failed)) { ret 1; }
+    if (state.live_bytes != 8 || state.acquired_bytes != 8 || state.failures != 1) { ret 1; }
+    if (result.is_err[bool, *u8](allocator.deallocate[u8](?a, p, 8))) { ret 1; }
+    if (!balanced(?state)) { ret 1; }
+    ret 0;
+}
+
+test "fault allocator: cumulative byte budget rejects excess growth" {
+    var storage: [128]u8;
+    var fixed_state: fixed.FixedState;
+    var backing: allocator.Allocator;
+    if (option.is_some[*u8](fixed.make(?backing, ?fixed_state, ?storage[0], 128))) { ret 1; }
+    var state: CountingAllocator;
+    var a: allocator.Allocator;
+    make(?state, ?a, ?backing, Config{fail_at: 0, byte_budget: 12});
+
+    val first: result.Result[*u8, *u8] = allocator.allocate[u8](?a, 8);
+    if (result.is_err[*u8, *u8](first)) { ret 1; }
+    val failed: result.Result[*u8, *u8] = allocator.allocate[u8](?a, 5);
+    if (!result.is_err[*u8, *u8](failed)) { ret 1; }
+    val second: result.Result[*u8, *u8] = allocator.allocate[u8](?a, 4);
+    if (result.is_err[*u8, *u8](second)) { ret 1; }
+    if (state.acquired_bytes != 12 || state.live_bytes != 12 || state.failures != 1) { ret 1; }
+    allocator.deallocate[u8](?a, result.unwrap_ok[*u8, *u8](first), 8);
+    allocator.deallocate[u8](?a, result.unwrap_ok[*u8, *u8](second), 4);
+    if (!balanced(?state)) { ret 1; }
+    ret 0;
+}
+
+test "fault allocator: page adapter obeys the same accounting contract" {
+    var backing: allocator.Allocator;
+    if (option.is_some[*u8](page.make(?backing))) { ret 1; }
+    var state: CountingAllocator;
+    var a: allocator.Allocator;
+    make(?state, ?a, ?backing, Config{fail_at: 0, byte_budget: UNLIMITED});
+    val allocated: result.Result[*u8, *u8] = allocator.allocate[u8](?a, 4096);
+    if (result.is_err[*u8, *u8](allocated)) { ret 1; }
+    val p: *u8 = result.unwrap_ok[*u8, *u8](allocated);
+    p[0] = 1;
+    p[4095] = 2;
+    if (result.is_err[bool, *u8](allocator.deallocate[u8](?a, p, 4096))) { ret 1; }
+    if (!balanced(?state) || state.peak_live_bytes != 4096) { ret 1; }
+    ret 0;
+}

--- a/test/fault/src/clock.mach
+++ b/test/fault/src/clock.mach
@@ -1,0 +1,145 @@
+# caller-controlled monotonic clock and timer queue
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+
+pub val TIMER_PENDING:  u8 = 1;
+pub val TIMER_CANCELED: u8 = 2;
+pub val TIMER_FIRED:    u8 = 3;
+
+pub rec Timer {
+    id:       u64;
+    deadline: u64;
+    sequence: u64;
+    state:    u8;
+}
+
+pub rec Event {
+    id:       u64;
+    deadline: u64;
+    fired_at: u64;
+}
+
+pub rec Clock {
+    now:           u64;
+    timers:        *Timer;
+    cap:           usize;
+    len:           usize;
+    next_sequence: u64;
+}
+
+pub fun init(c: *Clock, start: u64, storage: *Timer, cap: usize) bool {
+    if (c == nil || (cap > 0 && storage == nil)) { ret false; }
+    c.now = start;
+    c.timers = storage;
+    c.cap = cap;
+    c.len = 0;
+    c.next_sequence = 0;
+    ret true;
+}
+
+pub fun time(c: *Clock) u64 {
+    ret c.now;
+}
+
+pub fun advance_to(c: *Clock, target: u64) bool {
+    if (target < c.now) { ret false; }
+    c.now = target;
+    ret true;
+}
+
+pub fun advance(c: *Clock, amount: u64) bool {
+    val target: u64 = c.now + amount;
+    if (target < c.now) { ret false; }
+    c.now = target;
+    ret true;
+}
+
+pub fun schedule(c: *Clock, id: u64, deadline: u64) bool {
+    if (deadline < c.now || c.len >= c.cap) { ret false; }
+    var i: usize = 0;
+    for (i < c.len) {
+        if (c.timers[i].id == id) { ret false; }
+        i = i + 1;
+    }
+    c.timers[c.len] = Timer{id: id, deadline: deadline, sequence: c.next_sequence, state: TIMER_PENDING};
+    c.next_sequence = c.next_sequence + 1;
+    c.len = c.len + 1;
+    ret true;
+}
+
+pub fun cancel(c: *Clock, id: u64) bool {
+    var i: usize = 0;
+    for (i < c.len) {
+        if (c.timers[i].id == id && c.timers[i].state == TIMER_PENDING) {
+            c.timers[i].state = TIMER_CANCELED;
+            ret true;
+        }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# due timers are delivered by deadline then insertion order
+pub fun pop_due(c: *Clock, out: *Event) bool {
+    if (out == nil) { ret false; }
+    var found: bool = false;
+    var selected: usize = 0;
+    var i: usize = 0;
+    for (i < c.len) {
+        val timer: Timer = c.timers[i];
+        if (timer.state == TIMER_PENDING && timer.deadline <= c.now) {
+            if (!found || timer.deadline < c.timers[selected].deadline
+             || (timer.deadline == c.timers[selected].deadline && timer.sequence < c.timers[selected].sequence)) {
+                found = true;
+                selected = i;
+            }
+        }
+        i = i + 1;
+    }
+    if (!found) { ret false; }
+    c.timers[selected].state = TIMER_FIRED;
+    out.id = c.timers[selected].id;
+    out.deadline = c.timers[selected].deadline;
+    out.fired_at = c.now;
+    ret true;
+}
+
+pub fun pending(c: *Clock) usize {
+    var count: usize = 0;
+    var i: usize = 0;
+    for (i < c.len) {
+        if (c.timers[i].state == TIMER_PENDING) { count = count + 1; }
+        i = i + 1;
+    }
+    ret count;
+}
+
+test "fault clock: time and delivery move only when driven" {
+    var storage: [3]Timer;
+    var c: Clock;
+    if (!init(?c, 100, ?storage[0], 3)) { ret 1; }
+    if (!schedule(?c, 1, 110) || !schedule(?c, 2, 105) || !schedule(?c, 3, 110)) { ret 1; }
+    var event: Event;
+    if (pop_due(?c, ?event)) { ret 1; }
+    if (!advance(?c, 10) || time(?c) != 110) { ret 1; }
+    if (!pop_due(?c, ?event) || event.id != 2 || event.fired_at != 110) { ret 1; }
+    if (!pop_due(?c, ?event) || event.id != 1) { ret 1; }
+    if (!pop_due(?c, ?event) || event.id != 3) { ret 1; }
+    if (pop_due(?c, ?event) || pending(?c) != 0) { ret 1; }
+    ret 0;
+}
+
+test "fault clock: cancellation and monotonic bounds are explicit" {
+    var storage: [2]Timer;
+    var c: Clock;
+    init(?c, 50, ?storage[0], 2);
+    if (!schedule(?c, 7, 51) || schedule(?c, 7, 52)) { ret 1; }
+    if (!cancel(?c, 7) || cancel(?c, 7)) { ret 1; }
+    if (advance_to(?c, 49) || !advance_to(?c, 100)) { ret 1; }
+    var event: Event;
+    if (pop_due(?c, ?event) || pending(?c) != 0) { ret 1; }
+    ret 0;
+}

--- a/test/fault/src/clock.mach
+++ b/test/fault/src/clock.mach
@@ -10,24 +10,31 @@ pub val TIMER_CANCELED: u8 = 2;
 pub val TIMER_FIRED:    u8 = 3;
 
 pub rec Timer {
-    id:       u64;
-    deadline: u64;
-    sequence: u64;
-    state:    u8;
+    id:         u64;
+    generation: u64;
+    deadline:   u64;
+    state:      u8;
+}
+
+# tokens are valid for one initialized clock lifetime
+pub rec Token {
+    id:         u64;
+    generation: u64;
 }
 
 pub rec Event {
-    id:       u64;
-    deadline: u64;
-    fired_at: u64;
+    id:         u64;
+    generation: u64;
+    deadline:   u64;
+    fired_at:   u64;
 }
 
 pub rec Clock {
-    now:           u64;
-    timers:        *Timer;
-    cap:           usize;
-    len:           usize;
-    next_sequence: u64;
+    now:             u64;
+    timers:          *Timer;
+    cap:             usize;
+    len:             usize;
+    next_generation: u64;
 }
 
 pub fun init(c: *Clock, start: u64, storage: *Timer, cap: usize) bool {
@@ -36,7 +43,7 @@ pub fun init(c: *Clock, start: u64, storage: *Timer, cap: usize) bool {
     c.timers = storage;
     c.cap = cap;
     c.len = 0;
-    c.next_sequence = 0;
+    c.next_generation = 1;
     ret true;
 }
 
@@ -57,23 +64,37 @@ pub fun advance(c: *Clock, amount: u64) bool {
     ret true;
 }
 
-pub fun schedule(c: *Clock, id: u64, deadline: u64) bool {
-    if (deadline < c.now || c.len >= c.cap) { ret false; }
+# generation exhaustion refuses new timers rather than aliasing stale tokens
+pub fun schedule(c: *Clock, id: u64, deadline: u64, out: *Token) bool {
+    if (c == nil || out == nil || deadline < c.now || c.next_generation == 0) { ret false; }
+    var slot: usize = c.cap;
     var i: usize = 0;
     for (i < c.len) {
-        if (c.timers[i].id == id) { ret false; }
+        if (c.timers[i].state == TIMER_PENDING && c.timers[i].id == id) { ret false; }
+        if (slot == c.cap && c.timers[i].state != TIMER_PENDING) { slot = i; }
         i = i + 1;
     }
-    c.timers[c.len] = Timer{id: id, deadline: deadline, sequence: c.next_sequence, state: TIMER_PENDING};
-    c.next_sequence = c.next_sequence + 1;
-    c.len = c.len + 1;
+    if (slot == c.cap) {
+        if (c.len >= c.cap) { ret false; }
+        slot = c.len;
+        c.len = c.len + 1;
+    }
+
+    val generation: u64 = c.next_generation;
+    if (generation == ~(0::u64)) { c.next_generation = 0; }
+    or { c.next_generation = generation + 1; }
+    c.timers[slot] = Timer{id: id, generation: generation, deadline: deadline, state: TIMER_PENDING};
+    out.id = id;
+    out.generation = generation;
     ret true;
 }
 
-pub fun cancel(c: *Clock, id: u64) bool {
+pub fun cancel(c: *Clock, token: Token) bool {
+    if (c == nil || token.generation == 0) { ret false; }
     var i: usize = 0;
     for (i < c.len) {
-        if (c.timers[i].id == id && c.timers[i].state == TIMER_PENDING) {
+        if (c.timers[i].id == token.id && c.timers[i].generation == token.generation
+         && c.timers[i].state == TIMER_PENDING) {
             c.timers[i].state = TIMER_CANCELED;
             ret true;
         }
@@ -82,9 +103,9 @@ pub fun cancel(c: *Clock, id: u64) bool {
     ret false;
 }
 
-# due timers are delivered by deadline then insertion order
+# due timers are delivered by deadline then generation
 pub fun pop_due(c: *Clock, out: *Event) bool {
-    if (out == nil) { ret false; }
+    if (c == nil || out == nil) { ret false; }
     var found: bool = false;
     var selected: usize = 0;
     var i: usize = 0;
@@ -92,7 +113,7 @@ pub fun pop_due(c: *Clock, out: *Event) bool {
         val timer: Timer = c.timers[i];
         if (timer.state == TIMER_PENDING && timer.deadline <= c.now) {
             if (!found || timer.deadline < c.timers[selected].deadline
-             || (timer.deadline == c.timers[selected].deadline && timer.sequence < c.timers[selected].sequence)) {
+             || (timer.deadline == c.timers[selected].deadline && timer.generation < c.timers[selected].generation)) {
                 found = true;
                 selected = i;
             }
@@ -102,12 +123,14 @@ pub fun pop_due(c: *Clock, out: *Event) bool {
     if (!found) { ret false; }
     c.timers[selected].state = TIMER_FIRED;
     out.id = c.timers[selected].id;
+    out.generation = c.timers[selected].generation;
     out.deadline = c.timers[selected].deadline;
     out.fired_at = c.now;
     ret true;
 }
 
 pub fun pending(c: *Clock) usize {
+    if (c == nil) { ret 0; }
     var count: usize = 0;
     var i: usize = 0;
     for (i < c.len) {
@@ -121,25 +144,54 @@ test "fault clock: time and delivery move only when driven" {
     var storage: [3]Timer;
     var c: Clock;
     if (!init(?c, 100, ?storage[0], 3)) { ret 1; }
-    if (!schedule(?c, 1, 110) || !schedule(?c, 2, 105) || !schedule(?c, 3, 110)) { ret 1; }
+    var first: Token;
+    var second: Token;
+    var third: Token;
+    if (!schedule(?c, 1, 110, ?first) || !schedule(?c, 2, 105, ?second)
+     || !schedule(?c, 3, 110, ?third)) { ret 1; }
     var event: Event;
     if (pop_due(?c, ?event)) { ret 1; }
     if (!advance(?c, 10) || time(?c) != 110) { ret 1; }
-    if (!pop_due(?c, ?event) || event.id != 2 || event.fired_at != 110) { ret 1; }
-    if (!pop_due(?c, ?event) || event.id != 1) { ret 1; }
-    if (!pop_due(?c, ?event) || event.id != 3) { ret 1; }
+    if (!pop_due(?c, ?event) || event.id != 2 || event.generation != second.generation
+     || event.fired_at != 110) { ret 1; }
+    if (!pop_due(?c, ?event) || event.id != 1 || event.generation != first.generation) { ret 1; }
+    if (!pop_due(?c, ?event) || event.id != 3 || event.generation != third.generation) { ret 1; }
     if (pop_due(?c, ?event) || pending(?c) != 0) { ret 1; }
     ret 0;
 }
 
-test "fault clock: cancellation and monotonic bounds are explicit" {
-    var storage: [2]Timer;
+test "fault clock: completed and cancelled slots reuse capacity safely" {
+    var storage: [1]Timer;
     var c: Clock;
-    init(?c, 50, ?storage[0], 2);
-    if (!schedule(?c, 7, 51) || schedule(?c, 7, 52)) { ret 1; }
-    if (!cancel(?c, 7) || cancel(?c, 7)) { ret 1; }
+    init(?c, 50, ?storage[0], 1);
+    var canceled: Token;
+    if (!schedule(?c, 7, 51, ?canceled)) { ret 1; }
+    var duplicate: Token;
+    if (schedule(?c, 7, 52, ?duplicate)) { ret 1; }
+    if (!cancel(?c, canceled) || cancel(?c, canceled)) { ret 1; }
+
+    var replacement: Token;
+    if (!schedule(?c, 7, 52, ?replacement)) { ret 1; }
+    if (replacement.generation == canceled.generation || cancel(?c, canceled)) { ret 1; }
     if (advance_to(?c, 49) || !advance_to(?c, 100)) { ret 1; }
     var event: Event;
-    if (pop_due(?c, ?event) || pending(?c) != 0) { ret 1; }
+    if (!pop_due(?c, ?event) || event.id != 7 || event.generation != replacement.generation) { ret 1; }
+    if (pending(?c) != 0 || cancel(?c, replacement)) { ret 1; }
+
+    var after_fire: Token;
+    if (!schedule(?c, 8, 101, ?after_fire) || after_fire.generation == replacement.generation) { ret 1; }
+    ret 0;
+}
+
+test "fault clock: generation exhaustion never aliases a stale token" {
+    var storage: [1]Timer;
+    var c: Clock;
+    init(?c, 0, ?storage[0], 1);
+    c.next_generation = ~(0::u64);
+    var last: Token;
+    if (!schedule(?c, 1, 0, ?last) || last.generation != ~(0::u64)) { ret 1; }
+    if (!cancel(?c, last)) { ret 1; }
+    var refused: Token;
+    if (schedule(?c, 2, 0, ?refused)) { ret 1; }
     ret 0;
 }

--- a/test/fault/src/datagram.mach
+++ b/test/fault/src/datagram.mach
@@ -1,0 +1,363 @@
+# deterministic datagram fault network
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.memory;
+use fault.script;
+
+pub val DATAGRAM: u8 = 1;
+
+pub val DROP:           u8 = 1;
+pub val DUPLICATE:      u8 = 2;
+pub val TRUNCATE:       u8 = 4;
+pub val ADDRESS_CHANGE: u8 = 8;
+pub val REORDER:        u8 = 16;
+
+pub rec Packet {
+    active:       bool;
+    from:         u64;
+    to:           u64;
+    len:          usize;
+    original_len: usize;
+    due:          u64;
+    order:        u64;
+    sequence:     u64;
+    truncated:    bool;
+}
+
+pub rec Delivery {
+    from:         u64;
+    to:           u64;
+    len:          usize;
+    original_len: usize;
+    delivered_at: u64;
+    truncated:    bool;
+}
+
+pub rec Network {
+    now:         u64;
+    packets:     *Packet;
+    cap:         usize;
+    storage:     *u8;
+    packet_cap:  usize;
+    replay:      *script.Step;
+    replay_len:  usize;
+    replay_pos:  usize;
+    seeded:      bool;
+    seed:        u64;
+    sequence:    u64;
+    dropped:     usize;
+}
+
+fun init_common(n: *Network, packets: *Packet, cap: usize, storage: *u8, packet_cap: usize) bool {
+    if (n == nil || (cap > 0 && (packets == nil || storage == nil || packet_cap == 0))) { ret false; }
+    if (packet_cap > 0 && cap > ~(0::usize) / packet_cap) { ret false; }
+    n.now = 0;
+    n.packets = packets;
+    n.cap = cap;
+    n.storage = storage;
+    n.packet_cap = packet_cap;
+    n.replay = nil;
+    n.replay_len = 0;
+    n.replay_pos = 0;
+    n.seeded = false;
+    n.seed = 0;
+    n.sequence = 0;
+    n.dropped = 0;
+    var i: usize = 0;
+    for (i < cap) { n.packets[i].active = false; i = i + 1; }
+    ret true;
+}
+
+pub fun init_scripted(n: *Network, packets: *Packet, cap: usize,
+                      storage: *u8, packet_cap: usize, replay: *script.Script) bool {
+    if (replay == nil || !init_common(n, packets, cap, storage, packet_cap)) { ret false; }
+    n.replay = replay.steps;
+    n.replay_len = replay.len;
+    n.seed = replay.seed;
+    ret true;
+}
+
+pub fun init_seeded(n: *Network, packets: *Packet, cap: usize, storage: *u8, packet_cap: usize, seed: u64) bool {
+    if (!init_common(n, packets, cap, storage, packet_cap)) { ret false; }
+    n.seeded = true;
+    n.seed = seed;
+    ret true;
+}
+
+fun random(state: *u64) u64 {
+    var x: u64 = @state;
+    if (x == 0) { x = 0x9E3779B97F4A7C15; }
+    x = x ^ (x << 13);
+    x = x ^ (x >> 7);
+    x = x ^ (x << 17);
+    @state = x;
+    ret x;
+}
+
+# seeded generation is stable and the initial seed is the replay artifact
+pub fun seeded_step(state: *u64) script.Step {
+    val value: u64 = random(state);
+    val choice: u64 = value % 7;
+    var flags: u8 = 0;
+    if (choice == 1) { flags = DROP; }
+    if (choice == 2) { flags = DUPLICATE; }
+    if (choice == 4) { flags = REORDER; }
+    if (choice == 5) { flags = TRUNCATE; }
+    if (choice == 6) { flags = ADDRESS_CHANGE; }
+    var delay: u64 = 0;
+    if (choice == 3) { delay = 1 + ((value >> 8) % 8); }
+    val duplicate_delay: u64 = 1 + ((value >> 16) % 8);
+    val truncate_to: u64 = 1 + ((value >> 24) % 8);
+    val source: u64 = value ^ 0xA5A5A5A5A5A5A5A5;
+    val order: u64 = ~(value >> 32);
+    ret script.Step{kind: DATAGRAM, flags: flags, value0: delay, value1: duplicate_delay,
+        value2: truncate_to, value3: source, value4: order};
+}
+
+fun next_step(n: *Network) script.Step {
+    if (n.seeded) { ret seeded_step(?n.seed); }
+    if (n.replay_pos < n.replay_len) {
+        val step: script.Step = n.replay[n.replay_pos];
+        n.replay_pos = n.replay_pos + 1;
+        ret step;
+    }
+    ret script.Step{kind: DATAGRAM, flags: 0, value0: 0, value1: 0, value2: 0, value3: 0, value4: 0};
+}
+
+fun free_slots(n: *Network) usize {
+    var count: usize = 0;
+    var i: usize = 0;
+    for (i < n.cap) {
+        if (!n.packets[i].active) { count = count + 1; }
+        i = i + 1;
+    }
+    ret count;
+}
+
+fun enqueue(n: *Network, from: u64, to: u64, data: *u8, len: usize, original_len: usize,
+            due: u64, order: u64, truncated: bool) bool {
+    var slot: usize = n.cap;
+    var i: usize = 0;
+    for (i < n.cap) {
+        if (!n.packets[i].active) { slot = i; brk; }
+        i = i + 1;
+    }
+    if (slot == n.cap) { ret false; }
+
+    n.packets[slot] = Packet{active: true, from: from, to: to, len: len,
+        original_len: original_len, due: due, order: order, sequence: n.sequence,
+        truncated: truncated};
+    if (len > 0) { memory.copy[u8](?n.storage[slot * n.packet_cap], data, len); }
+    n.sequence = n.sequence + 1;
+    ret true;
+}
+
+pub fun send(n: *Network, from: u64, to: u64, data: *u8, len: usize) bool {
+    if (len > n.packet_cap || (len > 0 && data == nil)) { ret false; }
+    val step: script.Step = next_step(n);
+    if (step.kind != DATAGRAM) { ret false; }
+    if ((step.flags & DROP) != 0) {
+        n.dropped = n.dropped + 1;
+        ret true;
+    }
+
+    var copies: usize = 1;
+    if ((step.flags & DUPLICATE) != 0) { copies = 2; }
+    if (free_slots(n) < copies) { ret false; }
+    if (step.value0 > ~(0::u64) - n.now) { ret false; }
+    if (copies == 2 && step.value1 > ~(0::u64) - n.now) { ret false; }
+
+    var amount: usize = len;
+    var truncated: bool = false;
+    if ((step.flags & TRUNCATE) != 0) {
+        val wanted: usize = step.value2::usize;
+        if (step.value2 != wanted::u64) { ret false; }
+        if (wanted < amount) { amount = wanted; truncated = true; }
+    }
+    var source: u64 = from;
+    if ((step.flags & ADDRESS_CHANGE) != 0) { source = step.value3; }
+    var order: u64 = n.sequence;
+    if ((step.flags & REORDER) != 0) { order = step.value4; }
+
+    if (!enqueue(n, source, to, data, amount, len, n.now + step.value0, order, truncated)) { ret false; }
+    if (copies == 2) {
+        if (!enqueue(n, source, to, data, amount, len, n.now + step.value1, order, truncated)) { ret false; }
+    }
+    ret true;
+}
+
+pub fun advance_to(n: *Network, target: u64) bool {
+    if (target < n.now) { ret false; }
+    n.now = target;
+    ret true;
+}
+
+pub fun advance(n: *Network, amount: u64) bool {
+    if (amount > ~(0::u64) - n.now) { ret false; }
+    n.now = n.now + amount;
+    ret true;
+}
+
+# delivery is ordered by due time, scripted order, then enqueue sequence
+pub fun receive(n: *Network, dst: *u8, cap: usize, out: *Delivery) bool {
+    if (out == nil || (cap > 0 && dst == nil)) { ret false; }
+    var found: bool = false;
+    var selected: usize = 0;
+    var i: usize = 0;
+    for (i < n.cap) {
+        val packet: Packet = n.packets[i];
+        if (packet.active && packet.due <= n.now) {
+            if (!found || packet.due < n.packets[selected].due
+             || (packet.due == n.packets[selected].due && packet.order < n.packets[selected].order)
+             || (packet.due == n.packets[selected].due && packet.order == n.packets[selected].order
+                 && packet.sequence < n.packets[selected].sequence)) {
+                found = true;
+                selected = i;
+            }
+        }
+        i = i + 1;
+    }
+    if (!found) { ret false; }
+
+    val packet: Packet = n.packets[selected];
+    var amount: usize = packet.len;
+    if (amount > cap) { amount = cap; }
+    if (amount > 0) { memory.copy[u8](dst, ?n.storage[selected * n.packet_cap], amount); }
+    out.from = packet.from;
+    out.to = packet.to;
+    out.len = amount;
+    out.original_len = packet.original_len;
+    out.delivered_at = n.now;
+    out.truncated = packet.truncated || amount < packet.len;
+    n.packets[selected].active = false;
+    ret true;
+}
+
+pub fun queued(n: *Network) usize {
+    ret n.cap - free_slots(n);
+}
+
+test "fault datagram: loss duplication and delay are driven without sleeps" {
+    var steps: [3]script.Step;
+    steps[0] = script.Step{kind: DATAGRAM, flags: DROP, value0: 0, value1: 0, value2: 0, value3: 0, value4: 0};
+    steps[1] = script.Step{kind: DATAGRAM, flags: DUPLICATE, value0: 0, value1: 2, value2: 0, value3: 0, value4: 0};
+    steps[2] = script.Step{kind: DATAGRAM, flags: 0, value0: 5, value1: 0, value2: 0, value3: 0, value4: 0};
+    var replay: script.Script = script.Script{seed: 3, steps: ?steps[0], len: 3};
+    var packets: [4]Packet;
+    var storage: [32]u8;
+    var n: Network;
+    if (!init_scripted(?n, ?packets[0], 4, ?storage[0], 8, ?replay)) { ret 1; }
+    if (!send(?n, 1, 2, "D", 1) || !send(?n, 1, 2, "U", 1) || !send(?n, 1, 2, "L", 1)) { ret 1; }
+    if (n.dropped != 1 || queued(?n) != 3) { ret 1; }
+
+    var data: [2]u8;
+    var delivery: Delivery;
+    if (!receive(?n, ?data[0], 2, ?delivery) || data[0] != 'U'::u8) { ret 1; }
+    if (receive(?n, ?data[0], 2, ?delivery)) { ret 1; }
+    advance(?n, 2);
+    if (!receive(?n, ?data[0], 2, ?delivery) || data[0] != 'U'::u8) { ret 1; }
+    advance(?n, 3);
+    if (!receive(?n, ?data[0], 2, ?delivery) || data[0] != 'L'::u8) { ret 1; }
+    if (queued(?n) != 0) { ret 1; }
+    ret 0;
+}
+
+test "fault datagram: saved script replays reorder truncation and address change" {
+    var steps: [3]script.Step;
+    steps[0] = script.Step{kind: DATAGRAM, flags: REORDER, value0: 0, value1: 0, value2: 0, value3: 0, value4: 2};
+    steps[1] = script.Step{kind: DATAGRAM, flags: REORDER, value0: 0, value1: 0, value2: 0, value3: 0, value4: 1};
+    steps[2] = script.Step{kind: DATAGRAM, flags: TRUNCATE | ADDRESS_CHANGE,
+        value0: 0, value1: 0, value2: 2, value3: 99, value4: 0};
+    var original: script.Script = script.Script{seed: 44, steps: ?steps[0], len: 3};
+    var bytes: [142]u8;
+    if (script.encode(?original, ?bytes[0], 142) != 142) { ret 1; }
+    var decoded_steps: [3]script.Step;
+    var replay: script.Script;
+    if (!script.decode(?bytes[0], 142, ?decoded_steps[0], 3, ?replay)) { ret 1; }
+
+    var packets: [3]Packet;
+    var storage: [24]u8;
+    var n: Network;
+    init_scripted(?n, ?packets[0], 3, ?storage[0], 8, ?replay);
+    if (!send(?n, 10, 20, "A", 1) || !send(?n, 10, 20, "B", 1) || !send(?n, 10, 20, "hello", 5)) { ret 1; }
+    var data: [8]u8;
+    var delivery: Delivery;
+    if (!receive(?n, ?data[0], 8, ?delivery) || data[0] != 'B'::u8) { ret 1; }
+    if (!receive(?n, ?data[0], 8, ?delivery) || data[0] != 'A'::u8) { ret 1; }
+    if (!receive(?n, ?data[0], 8, ?delivery)) { ret 1; }
+    if (delivery.from != 99 || delivery.to != 20 || delivery.len != 2 || delivery.original_len != 5) { ret 1; }
+    if (!delivery.truncated || data[0] != 'h'::u8 || data[1] != 'e'::u8) { ret 1; }
+    ret 0;
+}
+
+test "fault datagram: a serialized seed regenerates the same fault stream" {
+    var empty: script.Script = script.Script{seed: 0x123456789ABCDEF0, steps: nil, len: 0};
+    var bytes: [16]u8;
+    if (script.encode(?empty, ?bytes[0], 16) != 16) { ret 1; }
+    var replay: script.Script;
+    if (!script.decode(?bytes[0], 16, nil, 0, ?replay)) { ret 1; }
+    var a: u64 = empty.seed;
+    var b: u64 = replay.seed;
+    var saw_drop: bool = false;
+    var saw_reorder: bool = false;
+    var i: usize = 0;
+    for (i < 128) {
+        val left: script.Step = seeded_step(?a);
+        val right: script.Step = seeded_step(?b);
+        if (left.kind != right.kind || left.flags != right.flags || left.value0 != right.value0
+         || left.value1 != right.value1 || left.value2 != right.value2
+         || left.value3 != right.value3 || left.value4 != right.value4) { ret 1; }
+        if ((left.flags & DROP) != 0) { saw_drop = true; }
+        if ((left.flags & REORDER) != 0) { saw_reorder = true; }
+        i = i + 1;
+    }
+    if (!saw_drop || !saw_reorder) { ret 1; }
+    ret 0;
+}
+
+test "fault datagram: seeded networks replay the same deliveries" {
+    var artifact: script.Script = script.Script{seed: 0x123456789ABCDEF0, steps: nil, len: 0};
+    var bytes: [16]u8;
+    if (script.encode(?artifact, ?bytes[0], 16) != 16) { ret 1; }
+    var saved: script.Script;
+    if (!script.decode(?bytes[0], 16, nil, 0, ?saved)) { ret 1; }
+
+    var left_packets: [64]Packet;
+    var right_packets: [64]Packet;
+    var left_storage: [64]u8;
+    var right_storage: [64]u8;
+    var left: Network;
+    var right: Network;
+    if (!init_seeded(?left, ?left_packets[0], 64, ?left_storage[0], 1, saved.seed)) { ret 1; }
+    if (!init_seeded(?right, ?right_packets[0], 64, ?right_storage[0], 1, saved.seed)) { ret 1; }
+
+    var payloads: [32]u8;
+    var i: usize = 0;
+    for (i < 32) {
+        payloads[i] = i::u8;
+        if (!send(?left, 10, 20, ?payloads[i], 1)) { ret 1; }
+        if (!send(?right, 10, 20, ?payloads[i], 1)) { ret 1; }
+        i = i + 1;
+    }
+    if (left.dropped == 0 || left.dropped != right.dropped || queued(?left) != queued(?right)) { ret 1; }
+    advance_to(?left, 1000);
+    advance_to(?right, 1000);
+
+    var left_data: u8 = 0;
+    var right_data: u8 = 0;
+    var left_delivery: Delivery;
+    var right_delivery: Delivery;
+    for (receive(?left, ?left_data, 1, ?left_delivery)) {
+        if (!receive(?right, ?right_data, 1, ?right_delivery)) { ret 1; }
+        if (left_data != right_data || left_delivery.from != right_delivery.from
+         || left_delivery.to != right_delivery.to || left_delivery.len != right_delivery.len
+         || left_delivery.original_len != right_delivery.original_len
+         || left_delivery.delivered_at != right_delivery.delivered_at
+         || left_delivery.truncated != right_delivery.truncated) { ret 1; }
+    }
+    if (receive(?right, ?right_data, 1, ?right_delivery)) { ret 1; }
+    ret 0;
+}

--- a/test/fault/src/lib/libfault.mach
+++ b/test/fault/src/lib/libfault.mach
@@ -1,0 +1,9 @@
+# explicit test-only aggregate
+
+fwd fault.script;
+fwd fault.reader;
+fwd fault.writer;
+fwd fault.allocator;
+fwd fault.clock;
+fwd fault.datagram;
+fwd fault.race;

--- a/test/fault/src/native.mach
+++ b/test/fault/src/native.mach
@@ -44,9 +44,18 @@ test "fault native: udp truncation matches the deterministic datagram contract" 
     var source: ip.Endpoint;
     val received: result.Result[usize, error.Error] = udp.recv_from(?receiver, ?native_data[0], 2, ?source);
     close_pair(?sender, ?receiver);
-    if (result.is_err[usize, error.Error](received)
-     || result.unwrap_ok[usize, error.Error](received) != 2) { ret 1; }
-    if (native_data[0] != 'a'::u8 || native_data[1] != 'b'::u8 || source.port != sender_endpoint.port) { ret 1; }
+    $if ($mach.build.os == $mach.os.windows) {
+        # winsock copies the prefix but reports emsgsize instead of a byte count
+        if (!result.is_err[usize, error.Error](received)) { ret 1; }
+        val receive_error: error.Error = result.unwrap_err[usize, error.Error](received);
+        if (receive_error.code != -90 || receive_error.operation != error.OP_RECEIVE) { ret 1; }
+    }
+    $or {
+        if (result.is_err[usize, error.Error](received)
+         || result.unwrap_ok[usize, error.Error](received) != 2) { ret 1; }
+        if (source.port != sender_endpoint.port) { ret 1; }
+    }
+    if (native_data[0] != 'a'::u8 || native_data[1] != 'b'::u8) { ret 1; }
 
     var step: script.Step = script.Step{kind: datagram.DATAGRAM, flags: 0, value0: 0,
         value1: 0, value2: 0, value3: 0, value4: 0};
@@ -55,7 +64,7 @@ test "fault native: udp truncation matches the deterministic datagram contract" 
     var storage: [3]u8;
     var network: datagram.Network;
     if (!datagram.init_scripted(?network, ?packet, 1, ?storage[0], 3, ?replay)) { ret 1; }
-    if (!datagram.send(?network, source.port::u64, endpoint.port::u64, "abc", 3)) { ret 1; }
+    if (!datagram.send(?network, sender_endpoint.port::u64, endpoint.port::u64, "abc", 3)) { ret 1; }
     var modeled_data: [2]u8;
     var delivery: datagram.Delivery;
     if (!datagram.receive(?network, ?modeled_data[0], 2, ?delivery)) { ret 1; }

--- a/test/fault/src/native.mach
+++ b/test/fault/src/native.mach
@@ -1,0 +1,65 @@
+# native conformance probes for contracts that support isolated loopback tests
+
+use std.types.size.usize;
+use std.types.result;
+use std.io.error;
+use std.net.ip;
+use std.net.udp;
+use fault.script;
+use fault.datagram;
+
+fun close_pair(sender: *udp.Socket, receiver: *udp.Socket) {
+    udp.socket_close(sender);
+    udp.socket_close(receiver);
+}
+
+test "fault native: udp truncation matches the deterministic datagram contract" {
+    val bound_result: result.Result[udp.Socket, error.Error] = udp.bind(ip.endpoint(127, 0, 0, 1, 0));
+    if (result.is_err[udp.Socket, error.Error](bound_result)) { ret 1; }
+    var receiver: udp.Socket = result.unwrap_ok[udp.Socket, error.Error](bound_result);
+    val endpoint_result: result.Result[ip.Endpoint, error.Error] = udp.local_endpoint(?receiver);
+    if (result.is_err[ip.Endpoint, error.Error](endpoint_result)) {
+        udp.socket_close(?receiver);
+        ret 1;
+    }
+    val endpoint: ip.Endpoint = result.unwrap_ok[ip.Endpoint, error.Error](endpoint_result);
+
+    val created: result.Result[udp.Socket, error.Error] = udp.create();
+    if (result.is_err[udp.Socket, error.Error](created)) { udp.socket_close(?receiver); ret 1; }
+    var sender: udp.Socket = result.unwrap_ok[udp.Socket, error.Error](created);
+    val sent: result.Result[usize, error.Error] = udp.send_to(?sender, "abc", 3, endpoint);
+    if (result.is_err[usize, error.Error](sent)
+     || result.unwrap_ok[usize, error.Error](sent) != 3) {
+        close_pair(?sender, ?receiver);
+        ret 1;
+    }
+    val sender_endpoint_result: result.Result[ip.Endpoint, error.Error] = udp.local_endpoint(?sender);
+    if (result.is_err[ip.Endpoint, error.Error](sender_endpoint_result)) {
+        close_pair(?sender, ?receiver);
+        ret 1;
+    }
+    val sender_endpoint: ip.Endpoint = result.unwrap_ok[ip.Endpoint, error.Error](sender_endpoint_result);
+
+    var native_data: [2]u8;
+    var source: ip.Endpoint;
+    val received: result.Result[usize, error.Error] = udp.recv_from(?receiver, ?native_data[0], 2, ?source);
+    close_pair(?sender, ?receiver);
+    if (result.is_err[usize, error.Error](received)
+     || result.unwrap_ok[usize, error.Error](received) != 2) { ret 1; }
+    if (native_data[0] != 'a'::u8 || native_data[1] != 'b'::u8 || source.port != sender_endpoint.port) { ret 1; }
+
+    var step: script.Step = script.Step{kind: datagram.DATAGRAM, flags: 0, value0: 0,
+        value1: 0, value2: 0, value3: 0, value4: 0};
+    var replay: script.Script = script.Script{seed: 0, steps: ?step, len: 1};
+    var packet: datagram.Packet;
+    var storage: [3]u8;
+    var network: datagram.Network;
+    if (!datagram.init_scripted(?network, ?packet, 1, ?storage[0], 3, ?replay)) { ret 1; }
+    if (!datagram.send(?network, source.port::u64, endpoint.port::u64, "abc", 3)) { ret 1; }
+    var modeled_data: [2]u8;
+    var delivery: datagram.Delivery;
+    if (!datagram.receive(?network, ?modeled_data[0], 2, ?delivery)) { ret 1; }
+    if (delivery.len != 2 || delivery.original_len != 3 || !delivery.truncated) { ret 1; }
+    if (modeled_data[0] != native_data[0] || modeled_data[1] != native_data[1]) { ret 1; }
+    ret 0;
+}

--- a/test/fault/src/race.mach
+++ b/test/fault/src/race.mach
@@ -1,0 +1,135 @@
+# step-driven completion, cancellation, and close model
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use fault.script;
+
+pub val SUBMIT:   u8 = 1;
+pub val COMPLETE: u8 = 2;
+pub val CANCEL:   u8 = 3;
+pub val CLOSE:    u8 = 4;
+
+pub val RUNTIME_OPEN:    u8 = 1;
+pub val RUNTIME_CLOSING: u8 = 2;
+pub val RUNTIME_CLOSED:  u8 = 3;
+
+pub val OP_IDLE:      u8 = 1;
+pub val OP_PENDING:   u8 = 2;
+pub val OP_COMPLETED: u8 = 3;
+pub val OP_CANCELED:  u8 = 4;
+
+pub val APPLIED:      u8 = 1;
+pub val TOO_LATE:     u8 = 2;
+pub val REJECTED:     u8 = 3;
+pub val LATE_IGNORED: u8 = 4;
+pub val INVALID:      u8 = 5;
+
+pub rec Runtime {
+    state:    u8;
+    inflight: usize;
+}
+
+pub rec Operation {
+    state: u8;
+}
+
+pub fun runtime() Runtime {
+    ret Runtime{state: RUNTIME_OPEN, inflight: 0};
+}
+
+pub fun operation() Operation {
+    ret Operation{state: OP_IDLE};
+}
+
+fun settle(r: *Runtime) {
+    if (r.state == RUNTIME_CLOSING && r.inflight == 0) { r.state = RUNTIME_CLOSED; }
+}
+
+pub fun step(r: *Runtime, op: *Operation, action: u8) u8 {
+    if (action == SUBMIT) {
+        if (r.state != RUNTIME_OPEN || op.state != OP_IDLE) { ret REJECTED; }
+        op.state = OP_PENDING;
+        r.inflight = r.inflight + 1;
+        ret APPLIED;
+    }
+    if (action == COMPLETE) {
+        if (op.state == OP_PENDING) {
+            op.state = OP_COMPLETED;
+            r.inflight = r.inflight - 1;
+            settle(r);
+            ret APPLIED;
+        }
+        if (op.state == OP_CANCELED) { ret LATE_IGNORED; }
+        if (op.state == OP_COMPLETED) { ret TOO_LATE; }
+        ret INVALID;
+    }
+    if (action == CANCEL) {
+        if (op.state == OP_PENDING) {
+            op.state = OP_CANCELED;
+            r.inflight = r.inflight - 1;
+            settle(r);
+            ret APPLIED;
+        }
+        if (op.state == OP_COMPLETED || op.state == OP_CANCELED) { ret TOO_LATE; }
+        ret INVALID;
+    }
+    if (action == CLOSE) {
+        if (r.state != RUNTIME_OPEN) { ret TOO_LATE; }
+        r.state = RUNTIME_CLOSING;
+        settle(r);
+        ret APPLIED;
+    }
+    ret INVALID;
+}
+
+# script steps use kind as the action and preserve the execution result
+pub fun drive(r: *Runtime, op: *Operation, replay: *script.Script, outcomes: *u8, cap: usize) usize {
+    if (r == nil || op == nil || replay == nil) { ret 0; }
+    if (cap < replay.len || (replay.len > 0 && outcomes == nil)) { ret 0; }
+    var i: usize = 0;
+    for (i < replay.len) {
+        outcomes[i] = step(r, op, replay.steps[i].kind);
+        i = i + 1;
+    }
+    ret replay.len;
+}
+
+test "fault race: completion before cancellation is stable" {
+    var steps: [4]script.Step;
+    steps[0].kind = SUBMIT;
+    steps[1].kind = COMPLETE;
+    steps[2].kind = CANCEL;
+    steps[3].kind = CLOSE;
+    var replay: script.Script = script.Script{seed: 1, steps: ?steps[0], len: 4};
+    var r: Runtime = runtime();
+    var op: Operation = operation();
+    var outcomes: [4]u8;
+    if (drive(?r, ?op, ?replay, ?outcomes[0], 4) != 4) { ret 1; }
+    if (outcomes[0] != APPLIED || outcomes[1] != APPLIED
+     || outcomes[2] != TOO_LATE || outcomes[3] != APPLIED) { ret 1; }
+    if (op.state != OP_COMPLETED || r.state != RUNTIME_CLOSED || r.inflight != 0) { ret 1; }
+    ret 0;
+}
+
+test "fault race: cancellation wins and late completion is ignored" {
+    var r: Runtime = runtime();
+    var op: Operation = operation();
+    if (step(?r, ?op, SUBMIT) != APPLIED) { ret 1; }
+    if (step(?r, ?op, CANCEL) != APPLIED) { ret 1; }
+    if (step(?r, ?op, COMPLETE) != LATE_IGNORED) { ret 1; }
+    if (op.state != OP_CANCELED || r.inflight != 0) { ret 1; }
+    ret 0;
+}
+
+test "fault race: close rejects submissions and drains pending work" {
+    var r: Runtime = runtime();
+    var first: Operation = operation();
+    var second: Operation = operation();
+    if (step(?r, ?first, SUBMIT) != APPLIED || step(?r, ?first, CLOSE) != APPLIED) { ret 1; }
+    if (r.state != RUNTIME_CLOSING || step(?r, ?second, SUBMIT) != REJECTED) { ret 1; }
+    if (step(?r, ?first, COMPLETE) != APPLIED) { ret 1; }
+    if (r.state != RUNTIME_CLOSED || r.inflight != 0) { ret 1; }
+    ret 0;
+}

--- a/test/fault/src/reader.mach
+++ b/test/fault/src/reader.mach
@@ -1,0 +1,97 @@
+# deterministic reader adapter
+
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.result;
+use std.types.option;
+use std.io.reader;
+use std.memory;
+use fault.script;
+
+pub val BYTES: u8 = 1;
+pub val EOF:   u8 = 2;
+pub val ERROR: u8 = 3;
+
+pub val ERR_SCRIPTED_READ: str = "ERR_SCRIPTED_READ";
+pub val ERR_INVALID_STEP:  str = "ERR_INVALID_READER_STEP";
+
+pub rec ScriptedReader {
+    data:     *u8;
+    len:      usize;
+    pos:      usize;
+    steps:    *script.Step;
+    step_len: usize;
+    step_pos: usize;
+    calls:    usize;
+}
+
+pub fun make(s: *ScriptedReader, data: *u8, len: usize, replay: *script.Script) reader.Reader {
+    s.data = data;
+    s.len = len;
+    s.pos = 0;
+    s.steps = replay.steps;
+    s.step_len = replay.len;
+    s.step_pos = 0;
+    s.calls = 0;
+    ret reader.Reader{ctx: s::ptr, f_read: read};
+}
+
+# each callback consumes exactly one scripted operation
+fun read(ctx: ptr, dst: *u8, len: usize) result.Result[usize, str] {
+    val s: *ScriptedReader = ctx::*ScriptedReader;
+    s.calls = s.calls + 1;
+    if (s.step_pos >= s.step_len) { ret result.ok[usize, str](0); }
+
+    val step: script.Step = s.steps[s.step_pos];
+    s.step_pos = s.step_pos + 1;
+    if (step.kind == EOF) { ret result.ok[usize, str](0); }
+    if (step.kind == ERROR) { ret result.err[usize, str](ERR_SCRIPTED_READ); }
+    if (step.kind != BYTES) { ret result.err[usize, str](ERR_INVALID_STEP); }
+
+    var amount: usize = step.value0::usize;
+    if (step.value0 != amount::u64) { ret result.err[usize, str](ERR_INVALID_STEP); }
+    if (amount > len) { amount = len; }
+    if (amount > s.len - s.pos) { amount = s.len - s.pos; }
+    if (amount > 0) {
+        memory.copy[u8](dst, ?s.data[s.pos], amount);
+        s.pos = s.pos + amount;
+    }
+    ret result.ok[usize, str](amount);
+}
+
+test "fault reader: fragmentation and eof follow the saved script" {
+    var steps: [4]script.Step;
+    steps[0] = script.Step{kind: BYTES, flags: 0, value0: 1, value1: 0, value2: 0, value3: 0, value4: 0};
+    steps[1] = script.Step{kind: BYTES, flags: 0, value0: 2, value1: 0, value2: 0, value3: 0, value4: 0};
+    steps[2] = script.Step{kind: BYTES, flags: 0, value0: 3, value1: 0, value2: 0, value3: 0, value4: 0};
+    steps[3] = script.Step{kind: EOF, flags: 0, value0: 0, value1: 0, value2: 0, value3: 0, value4: 0};
+    var replay: script.Script = script.Script{seed: 7, steps: ?steps[0], len: 4};
+    var state: ScriptedReader;
+    var source: [6]u8;
+    source[0] = 'a'::u8; source[1] = 'b'::u8; source[2] = 'c'::u8;
+    source[3] = 'd'::u8; source[4] = 'e'::u8; source[5] = 'f'::u8;
+    var r: reader.Reader = make(?state, ?source[0], 6, ?replay);
+    var dst: [6]u8;
+    if (option.is_some[str](reader.read_exact(?r, ?dst[0], 6))) { ret 1; }
+    if (state.calls != 3 || state.pos != 6 || dst[0] != 'a'::u8 || dst[5] != 'f'::u8) { ret 1; }
+    val eof: result.Result[usize, str] = reader.read(?r, ?dst[0], 6);
+    if (result.is_err[usize, str](eof) || result.unwrap_ok[usize, str](eof) != 0) { ret 1; }
+    ret 0;
+}
+
+test "fault reader: selected failure is normalized" {
+    var steps: [2]script.Step;
+    steps[0] = script.Step{kind: BYTES, flags: 0, value0: 2, value1: 0, value2: 0, value3: 0, value4: 0};
+    steps[1] = script.Step{kind: ERROR, flags: 0, value0: 0, value1: 0, value2: 0, value3: 0, value4: 0};
+    var replay: script.Script = script.Script{seed: 0, steps: ?steps[0], len: 2};
+    var state: ScriptedReader;
+    var source: [4]u8;
+    var r: reader.Reader = make(?state, ?source[0], 4, ?replay);
+    var dst: [4]u8;
+    val first: result.Result[usize, str] = reader.read(?r, ?dst[0], 4);
+    if (result.is_err[usize, str](first) || result.unwrap_ok[usize, str](first) != 2) { ret 1; }
+    val failed: result.Result[usize, str] = reader.read(?r, ?dst[0], 2);
+    if (!result.is_err[usize, str](failed)) { ret 1; }
+    if (result.unwrap_err[usize, str](failed) != ERR_SCRIPTED_READ) { ret 1; }
+    ret 0;
+}

--- a/test/fault/src/script.mach
+++ b/test/fault/src/script.mach
@@ -1,0 +1,143 @@
+# canonical replay script encoding
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.encoding.binary;
+
+pub val HEADER_SIZE: usize = 16;
+pub val STEP_SIZE:   usize = 42;
+
+pub rec Step {
+    kind:   u8;
+    flags:  u8;
+    value0: u64;
+    value1: u64;
+    value2: u64;
+    value3: u64;
+    value4: u64;
+}
+
+pub rec Script {
+    seed:  u64;
+    steps: *Step;
+    len:   usize;
+}
+
+pub fun encoded_size(len: usize) usize {
+    if (len > 0xFFFFFFFF) { ret 0; }
+    if (len > (~(0::usize) - HEADER_SIZE) / STEP_SIZE) { ret 0; }
+    ret HEADER_SIZE + len * STEP_SIZE;
+}
+
+# the fixed little-endian form is stable across targets and compiler versions
+pub fun encode(s: *Script, dst: *u8, cap: usize) usize {
+    if (s == nil) { ret 0; }
+    val need: usize = encoded_size(s.len);
+    if (need == 0 || cap < need || dst == nil || (s.len > 0 && s.steps == nil)) { ret 0; }
+
+    dst[0] = 'M'::u8;
+    dst[1] = 'F'::u8;
+    dst[2] = 'T'::u8;
+    dst[3] = '1'::u8;
+    binary.put_uint(?dst[4], s.seed, 8, binary.LITTLE);
+    binary.put_uint(?dst[12], s.len::u64, 4, binary.LITTLE);
+
+    var pos: usize = HEADER_SIZE;
+    var i: usize = 0;
+    for (i < s.len) {
+        dst[pos] = s.steps[i].kind;
+        dst[pos + 1] = s.steps[i].flags;
+        binary.put_uint(?dst[pos + 2], s.steps[i].value0, 8, binary.LITTLE);
+        binary.put_uint(?dst[pos + 10], s.steps[i].value1, 8, binary.LITTLE);
+        binary.put_uint(?dst[pos + 18], s.steps[i].value2, 8, binary.LITTLE);
+        binary.put_uint(?dst[pos + 26], s.steps[i].value3, 8, binary.LITTLE);
+        binary.put_uint(?dst[pos + 34], s.steps[i].value4, 8, binary.LITTLE);
+        pos = pos + STEP_SIZE;
+        i = i + 1;
+    }
+    ret need;
+}
+
+# decoding uses caller storage so replay never allocates
+pub fun decode(src: *u8, len: usize, steps: *Step, cap: usize, out: *Script) bool {
+    if (src == nil || out == nil || len < HEADER_SIZE) { ret false; }
+    if (src[0] != 'M'::u8 || src[1] != 'F'::u8 || src[2] != 'T'::u8 || src[3] != '1'::u8) {
+        ret false;
+    }
+
+    val count64: u64 = binary.get_uint(?src[12], 4, binary.LITTLE);
+    val count: usize = count64::usize;
+    if (count64 != count::u64 || count > cap || encoded_size(count) != len) { ret false; }
+    if (count > 0 && steps == nil) { ret false; }
+
+    var pos: usize = HEADER_SIZE;
+    var i: usize = 0;
+    for (i < count) {
+        steps[i].kind = src[pos];
+        steps[i].flags = src[pos + 1];
+        steps[i].value0 = binary.get_uint(?src[pos + 2], 8, binary.LITTLE);
+        steps[i].value1 = binary.get_uint(?src[pos + 10], 8, binary.LITTLE);
+        steps[i].value2 = binary.get_uint(?src[pos + 18], 8, binary.LITTLE);
+        steps[i].value3 = binary.get_uint(?src[pos + 26], 8, binary.LITTLE);
+        steps[i].value4 = binary.get_uint(?src[pos + 34], 8, binary.LITTLE);
+        pos = pos + STEP_SIZE;
+        i = i + 1;
+    }
+
+    out.seed = binary.get_uint(?src[4], 8, binary.LITTLE);
+    out.steps = steps;
+    out.len = count;
+    ret true;
+}
+
+pub fun equal(a: *Script, b: *Script) bool {
+    if (a.seed != b.seed || a.len != b.len) { ret false; }
+    var i: usize = 0;
+    for (i < a.len) {
+        if (a.steps[i].kind != b.steps[i].kind
+         || a.steps[i].flags != b.steps[i].flags
+         || a.steps[i].value0 != b.steps[i].value0
+         || a.steps[i].value1 != b.steps[i].value1
+         || a.steps[i].value2 != b.steps[i].value2
+         || a.steps[i].value3 != b.steps[i].value3
+         || a.steps[i].value4 != b.steps[i].value4) {
+            ret false;
+        }
+        i = i + 1;
+    }
+    ret true;
+}
+
+test "fault script: canonical encoding replays every field" {
+    var steps: [2]Step;
+    steps[0] = Step{kind: 1, flags: 2, value0: 3, value1: 4, value2: 5, value3: 6, value4: 7};
+    steps[1] = Step{kind: 8, flags: 9, value0: 10, value1: 11, value2: 12, value3: 13, value4: 14};
+    var original: Script = Script{seed: 0x0123456789ABCDEF, steps: ?steps[0], len: 2};
+    var bytes: [100]u8;
+    if (encode(?original, ?bytes[0], 100) != 100) { ret 1; }
+
+    var decoded_steps: [2]Step;
+    var decoded: Script;
+    if (!decode(?bytes[0], 100, ?decoded_steps[0], 2, ?decoded)) { ret 1; }
+    if (!equal(?original, ?decoded)) { ret 1; }
+    ret 0;
+}
+
+test "fault script: malformed and undersized artifacts are rejected" {
+    var step: Step = Step{kind: 1, flags: 0, value0: 0, value1: 0, value2: 0, value3: 0, value4: 0};
+    var original: Script = Script{seed: 1, steps: ?step, len: 1};
+    var bytes: [58]u8;
+    if (encode(?original, ?bytes[0], 57) != 0) { ret 1; }
+    if (encode(?original, ?bytes[0], 58) != 58) { ret 1; }
+
+    var decoded_step: Step;
+    var decoded: Script;
+    bytes[0] = 'X'::u8;
+    if (decode(?bytes[0], 58, ?decoded_step, 1, ?decoded)) { ret 1; }
+    bytes[0] = 'M'::u8;
+    if (decode(?bytes[0], 57, ?decoded_step, 1, ?decoded)) { ret 1; }
+    if (decode(?bytes[0], 58, ?decoded_step, 0, ?decoded)) { ret 1; }
+    ret 0;
+}

--- a/test/fault/src/test_runtime.mach
+++ b/test/fault/src/test_runtime.mach
@@ -1,0 +1,7 @@
+# test dispatcher startup without coupling pure modules to the runtime
+
+use std.runtime;
+
+test "fault harness: test runtime is linked only by the test dispatcher" {
+    ret 0;
+}

--- a/test/fault/src/writer.mach
+++ b/test/fault/src/writer.mach
@@ -1,0 +1,93 @@
+# deterministic writer adapter
+
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.result;
+use std.types.option;
+use std.io.writer;
+use std.memory;
+use fault.script;
+
+pub val BYTES: u8 = 1;
+pub val ZERO:  u8 = 2;
+pub val ERROR: u8 = 3;
+
+pub val ERR_SCRIPTED_WRITE: str = "ERR_SCRIPTED_WRITE";
+pub val ERR_SCRIPT_EXHAUSTED: str = "ERR_WRITER_SCRIPT_EXHAUSTED";
+pub val ERR_CAPTURE_FULL: str = "ERR_WRITER_CAPTURE_FULL";
+pub val ERR_INVALID_STEP: str = "ERR_INVALID_WRITER_STEP";
+
+pub rec ScriptedWriter {
+    capture:  *u8;
+    cap:      usize;
+    len:      usize;
+    steps:    *script.Step;
+    step_len: usize;
+    step_pos: usize;
+    calls:    usize;
+}
+
+pub fun make(s: *ScriptedWriter, capture: *u8, cap: usize, replay: *script.Script) writer.Writer {
+    s.capture = capture;
+    s.cap = cap;
+    s.len = 0;
+    s.steps = replay.steps;
+    s.step_len = replay.len;
+    s.step_pos = 0;
+    s.calls = 0;
+    ret writer.Writer{ctx: s::ptr, f_write: write};
+}
+
+# each callback consumes exactly one scripted operation
+fun write(ctx: ptr, src: *u8, len: usize) result.Result[usize, str] {
+    val s: *ScriptedWriter = ctx::*ScriptedWriter;
+    s.calls = s.calls + 1;
+    if (s.step_pos >= s.step_len) { ret result.err[usize, str](ERR_SCRIPT_EXHAUSTED); }
+
+    val step: script.Step = s.steps[s.step_pos];
+    s.step_pos = s.step_pos + 1;
+    if (step.kind == ZERO) { ret result.ok[usize, str](0); }
+    if (step.kind == ERROR) { ret result.err[usize, str](ERR_SCRIPTED_WRITE); }
+    if (step.kind != BYTES) { ret result.err[usize, str](ERR_INVALID_STEP); }
+
+    var amount: usize = step.value0::usize;
+    if (step.value0 != amount::u64) { ret result.err[usize, str](ERR_INVALID_STEP); }
+    if (amount > len) { amount = len; }
+    if (amount > s.cap - s.len) { ret result.err[usize, str](ERR_CAPTURE_FULL); }
+    if (amount > 0) {
+        memory.copy[u8](?s.capture[s.len], src, amount);
+        s.len = s.len + amount;
+    }
+    ret result.ok[usize, str](amount);
+}
+
+test "fault writer: short writes preserve the exact byte sequence" {
+    var steps: [3]script.Step;
+    steps[0] = script.Step{kind: BYTES, flags: 0, value0: 1, value1: 0, value2: 0, value3: 0, value4: 0};
+    steps[1] = script.Step{kind: BYTES, flags: 0, value0: 2, value1: 0, value2: 0, value3: 0, value4: 0};
+    steps[2] = script.Step{kind: BYTES, flags: 0, value0: 3, value1: 0, value2: 0, value3: 0, value4: 0};
+    var replay: script.Script = script.Script{seed: 8, steps: ?steps[0], len: 3};
+    var state: ScriptedWriter;
+    var capture: [6]u8;
+    var w: writer.Writer = make(?state, ?capture[0], 6, ?replay);
+    if (option.is_some[str](writer.write_all(?w, "abcdef", 6))) { ret 1; }
+    if (state.calls != 3 || state.len != 6) { ret 1; }
+    if (capture[0] != 'a'::u8 || capture[1] != 'b'::u8 || capture[5] != 'f'::u8) { ret 1; }
+    ret 0;
+}
+
+test "fault writer: zero and error outcomes stay distinct" {
+    var steps: [2]script.Step;
+    steps[0] = script.Step{kind: ZERO, flags: 0, value0: 0, value1: 0, value2: 0, value3: 0, value4: 0};
+    steps[1] = script.Step{kind: ERROR, flags: 0, value0: 0, value1: 0, value2: 0, value3: 0, value4: 0};
+    var replay: script.Script = script.Script{seed: 0, steps: ?steps[0], len: 2};
+    var state: ScriptedWriter;
+    var capture: [4]u8;
+    var w: writer.Writer = make(?state, ?capture[0], 4, ?replay);
+    val stalled: result.Result[usize, str] = writer.write(?w, "x", 1);
+    if (result.is_err[usize, str](stalled) || result.unwrap_ok[usize, str](stalled) != 0) { ret 1; }
+    val failed: result.Result[usize, str] = writer.write(?w, "x", 1);
+    if (!result.is_err[usize, str](failed)) { ret 1; }
+    if (result.unwrap_err[usize, str](failed) != ERR_SCRIPTED_WRITE) { ret 1; }
+    ret 0;
+}

--- a/test/fault/verify-release.sh
+++ b/test/fault/verify-release.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+archive="${1:-}"
+archive_tool="${AR:-ar}"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+[ -n "$archive" ] || fail "release archive path is required"
+[ -f "$archive" ] || fail "release archive was not built at $archive"
+
+members="$($archive_tool t "$archive")" \
+    || fail "release archive could not be inspected"
+normalized="$(printf '%s\n' "$members" | tr '\\' '/')"
+if printf '%s\n' "$normalized" | grep -Eq '(^|[./])fault([./]|$)'; then
+    fail "test-only fault module entered the release archive"
+fi
+
+echo "OK: $archive excludes test-only fault modules"

--- a/test/fault/verify-release.sh
+++ b/test/fault/verify-release.sh
@@ -12,7 +12,7 @@ fail() { echo "FAIL: $1" >&2; exit 1; }
 members="$($archive_tool t "$archive")" \
     || fail "release archive could not be inspected"
 normalized="$(printf '%s\n' "$members" | tr '\\' '/')"
-if printf '%s\n' "$normalized" | grep -Eq '(^|[./])fault([./]|$)'; then
+if grep -Eq '(^|[./])fault([./]|$)' <<< "$normalized"; then
     fail "test-only fault module entered the release archive"
 fi
 

--- a/test/fault/verify.sh
+++ b/test/fault/verify.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mach="${1:-mach}"
+target="${2:-linux-x86_64}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+scratch="$(mktemp -d "${TMPDIR:-/tmp}/mach-std-fault.XXXXXX")"
+trap 'rm -rf -- "$scratch"' EXIT
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+# the production compiler source root cannot resolve the test-only project
+case "$here/src/" in
+    "$root/src/"*) fail "fault sources overlap the production source root" ;;
+esac
+
+mkdir -p "$scratch/repo/test/fault"
+cp "$root/mach.toml" "$scratch/repo/mach.toml"
+cp -R "$root/src" "$scratch/repo/src"
+cp "$here/mach.toml" "$scratch/repo/test/fault/mach.toml"
+cp -R "$here/src" "$scratch/repo/test/fault/src"
+
+"$mach" build "$scratch/repo" -O2 --target "$target"
+production="$scratch/repo/out/$target/debug/lib/std"
+[ -f "$production" ] || fail "production archive was not built"
+if ar t "$production" | grep -q '^fault\.'; then
+    fail "test-only module entered the production archive"
+fi
+
+"$mach" dep pull "$scratch/repo/test/fault"
+"$mach" build "$scratch/repo/test/fault" -O2 --target "$target"
+explicit="$scratch/.mach-out/std-fault/$target/debug/lib/fault"
+[ -f "$explicit" ] || fail "explicit fault archive was not built"
+
+members="$(ar t "$explicit")"
+for module in script reader writer allocator clock datagram race; do
+    printf '%s\n' "$members" | grep -q "^fault\.$module$" \
+        || fail "explicit fault archive omitted fault.$module"
+done
+
+echo "OK: production archive excludes the separate fault source root"
+echo "OK: explicit fault artifact contains every deterministic facility"

--- a/test/fault/verify.sh
+++ b/test/fault/verify.sh
@@ -43,7 +43,7 @@ explicit="$scratch/repo/test/fault/out/$target/debug/lib/fault"
 
 members="$("${AR:-ar}" t "$explicit")"
 for module in script reader writer allocator clock datagram race; do
-    printf '%s\n' "$members" | grep -q "^fault\.$module$" \
+    grep -q "^fault\.$module$" <<< "$members" \
         || fail "explicit fault archive omitted fault.$module"
 done
 

--- a/test/fault/verify.sh
+++ b/test/fault/verify.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 mach="${1:-mach}"
 target="${2:-linux-x86_64}"
+runner="${3:-}"
 here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 root="$(cd "$here/../.." && pwd)"
 scratch="$(mktemp -d "${TMPDIR:-/tmp}/mach-std-fault.XXXXXX")"
@@ -21,23 +22,35 @@ cp -R "$root/src" "$scratch/repo/src"
 cp "$here/mach.toml" "$scratch/repo/test/fault/mach.toml"
 cp -R "$here/src" "$scratch/repo/test/fault/src"
 
-"$mach" build "$scratch/repo" -O2 --target "$target"
-production="$scratch/repo/out/$target/debug/lib/std"
-[ -f "$production" ] || fail "production archive was not built"
-if ar t "$production" | grep -q '^fault\.'; then
-    fail "test-only module entered the production archive"
+release_checked=0
+if grep -qF "[target.$target]" "$scratch/repo/mach.toml"; then
+    "$mach" build "$scratch/repo" -O2 --target "$target"
+    production="$scratch/repo/out/$target/debug/lib/std"
+    bash "$here/verify-release.sh" "$production"
+    release_checked=1
 fi
 
 "$mach" dep pull "$scratch/repo/test/fault"
+test_args=(test "$scratch/repo/test/fault" --target "$target")
+if [ -n "$runner" ]; then
+    test_args+=(--runner "$runner")
+fi
+"$mach" "${test_args[@]}"
+"$mach" "${test_args[@]}" -O2
 "$mach" build "$scratch/repo/test/fault" -O2 --target "$target"
-explicit="$scratch/.mach-out/std-fault/$target/debug/lib/fault"
+explicit="$scratch/repo/test/fault/out/$target/debug/lib/fault"
 [ -f "$explicit" ] || fail "explicit fault archive was not built"
 
-members="$(ar t "$explicit")"
+members="$("${AR:-ar}" t "$explicit")"
 for module in script reader writer allocator clock datagram race; do
     printf '%s\n' "$members" | grep -q "^fault\.$module$" \
         || fail "explicit fault archive omitted fault.$module"
 done
 
-echo "OK: production archive excludes the separate fault source root"
+if [ "$release_checked" = 1 ]; then
+    echo "OK: production archive excludes the separate fault source root"
+else
+    echo "OK: $target has no production release artifact to inspect"
+fi
+echo "OK: deterministic fault tests pass in debug and optimized modes"
 echo "OK: explicit fault artifact contains every deterministic facility"

--- a/test/fault/verify.sh
+++ b/test/fault/verify.sh
@@ -42,9 +42,14 @@ explicit="$scratch/repo/test/fault/out/$target/debug/lib/fault"
 [ -f "$explicit" ] || fail "explicit fault archive was not built"
 
 members="$("${AR:-ar}" t "$explicit")"
+normalized_members="$(printf '%s\n' "$members" \
+    | tr '\\' '/' \
+    | sed -E 's#/$##; s#^.*/##; s#[.]o$##; s#[[:space:]]+$##')"
 for module in script reader writer allocator clock datagram race; do
-    grep -q "^fault\.$module$" <<< "$members" \
-        || fail "explicit fault archive omitted fault.$module"
+    if ! grep -Fxq "fault.$module" <<< "$normalized_members"; then
+        printf '%s\n' "$members" >&2
+        fail "explicit fault archive omitted fault.$module"
+    fi
 done
 
 if [ "$release_checked" = 1 ]; then


### PR DESCRIPTION
## Summary

- add a separate test-only project with canonical serialized replay scripts and seeds
- add scripted readers and writers plus exact counting, allocation fail-point, and byte-budget adapters
- add a controlled clock with reusable generation-safe timer slots
- add a deterministic datagram network and step-driven runtime race model
- normalize native UDP truncation conformance across Winsock and Unix behavior
- run the fault verifier in every supported native CI leg and riscv64 under QEMU
- inspect real production release archives to prove test-only modules are excluded

## Scope

This lands the independently usable deterministic model and conformance portion of #499. It does not close the issue.

Cancellation and asynchronous socket adapters still depend on #489 and #490. Those issues remain open.

## Verification

- fault suite: 22 passed in native debug and optimized modes
- Linux arm64 and riscv64: 22 passed under QEMU in debug and optimized modes
- Windows x86-64 and both Darwin test dispatchers compile
- optimized fault artifact builds for all six declared targets
- production suite: 857 passed in debug and optimized modes
- native release gate: 849 passed
- optimized production artifacts build for all five declared targets
- production archive excludes every fault module while the explicit fault artifact contains all seven facilities
- exclusion verifier rejects the explicit fault artifact when treated as a release artifact

Refs #499
