### PR TITLE
feat(io): add a portable operation-completion runtime

### DIFF
--- a/src/io/error.mach
+++ b/src/io/error.mach
@@ -38,6 +38,9 @@ pub val OP_SHUTDOWN: Operation = 12;
 pub val OP_OPTION:   Operation = 13;
 pub val OP_SEEK:     Operation = 14;
 pub val OP_SYNC:     Operation = 15;
+pub val OP_SUBMIT:   Operation = 16;
+pub val OP_WAIT:     Operation = 17;
+pub val OP_WAKE:     Operation = 18;
 
 pub rec Error {
     kind: Kind;

--- a/src/io/runtime.mach
+++ b/src/io/runtime.mach
@@ -1,0 +1,483 @@
+# bounded portable operation-completion ownership
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.result.Result;
+use std.types.result.ok;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.unwrap_ok;
+use std.types.result.unwrap_err;
+use std.system.os;
+use std.sync.atomic;
+use std.sync.mutex;
+use std.sync.thread;
+use io_error: std.io.error;
+
+pub def Kind: u8;
+pub val ACCEPT:      Kind = 0;
+pub val CONNECT:     Kind = 1;
+pub val READ:        Kind = 2;
+pub val WRITE:       Kind = 3;
+pub val RECEIVE_FROM:Kind = 4;
+pub val SEND_TO:     Kind = 5;
+pub val FILE_READ:   Kind = 6;
+pub val FILE_WRITE:  Kind = 7;
+pub val TIMER:       Kind = 8;
+pub val PROCESS_WAIT:Kind = 9;
+pub val USER_WAKE:   Kind = 10;
+
+pub rec Token {
+    index: u32;
+    generation: u32;
+}
+
+# buffer is borrowed from successful submission until its completion is dequeued
+pub rec Operation {
+    kind: Kind;
+    resource: usize;
+    buffer: *u8;
+    length: usize;
+    offset: u64;
+    context: usize;
+}
+
+pub rec Completion {
+    token: Token;
+    kind: Kind;
+    context: usize;
+    bytes: usize;
+    resource: usize;
+    has_error: bool;
+    error: io_error.Error;
+    end_of_stream: bool;
+}
+
+val SLOT_FREE: u8 = 0;
+val SLOT_ACTIVE: u8 = 1;
+val SLOT_QUEUED: u8 = 2;
+
+rec Slot {
+    state: u8;
+    generation: u32;
+    operation: Operation;
+}
+
+pub val OPEN: u8 = 0;
+pub val CLOSED: u8 = 1;
+pub val DESTROYED: u8 = 2;
+
+# one thread owns wait and dequeue, while submission and resolution may be concurrent
+pub rec Runtime {
+    queue: os.IoQueue;
+    slots: *Slot;
+    completions: *Completion;
+    capacity: usize;
+    next_slot: usize;
+    head: usize;
+    tail: usize;
+    count: usize;
+    live: usize;
+    state: u8;
+    lock: mutex.Mutex;
+}
+
+fun invalid(operation: io_error.Operation) io_error.Error {
+    ret io_error.from_code(os.EINVAL, operation);
+}
+
+fun exhausted(operation: io_error.Operation) io_error.Error {
+    ret io_error.from_code(os.ENOMEM, operation);
+}
+
+pub fun make(runtime: *Runtime, capacity: usize) Result[bool, io_error.Error] {
+    if (runtime == nil || capacity == 0 || capacity > 0xffffffff) {
+        ret err[bool, io_error.Error](invalid(io_error.OP_CREATE));
+    }
+    val slot_size: usize = $size_of(Slot);
+    val completion_size: usize = $size_of(Completion);
+    val slots_bytes: usize = slot_size * capacity;
+    val completions_bytes: usize = completion_size * capacity;
+    if (slots_bytes / slot_size != capacity || completions_bytes / completion_size != capacity) {
+        ret err[bool, io_error.Error](exhausted(io_error.OP_CREATE));
+    }
+
+    runtime.slots = os.allocate(slots_bytes)::*Slot;
+    if (runtime.slots == nil) { ret err[bool, io_error.Error](exhausted(io_error.OP_CREATE)); }
+    runtime.completions = os.allocate(completions_bytes)::*Completion;
+    if (runtime.completions == nil) {
+        os.deallocate(runtime.slots::ptr, slots_bytes);
+        runtime.slots = nil;
+        ret err[bool, io_error.Error](exhausted(io_error.OP_CREATE));
+    }
+
+    runtime.capacity = capacity;
+    runtime.next_slot = 0;
+    runtime.head = 0;
+    runtime.tail = 0;
+    runtime.count = 0;
+    runtime.live = 0;
+    runtime.state = OPEN;
+    runtime.lock = mutex.make();
+    var i: usize = 0;
+    for (i < capacity) {
+        runtime.slots[i].state = SLOT_FREE;
+        runtime.slots[i].generation = 0;
+        i = i + 1;
+    }
+    val code: i64 = os.io_queue_create(?runtime.queue);
+    if (code < 0) {
+        os.deallocate(runtime.completions::ptr, completions_bytes);
+        os.deallocate(runtime.slots::ptr, slots_bytes);
+        runtime.completions = nil;
+        runtime.slots = nil;
+        runtime.capacity = 0;
+        ret err[bool, io_error.Error](io_error.from_code(code, io_error.OP_CREATE));
+    }
+    ret ok[bool, io_error.Error](true);
+}
+
+pub fun submit(runtime: *Runtime, operation: Operation) Result[Token, io_error.Error] {
+    if (runtime == nil) { ret err[Token, io_error.Error](invalid(io_error.OP_SUBMIT)); }
+    mutex.lock(?runtime.lock);
+    if (runtime.state != OPEN) {
+        mutex.unlock(?runtime.lock);
+        ret err[Token, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_SUBMIT));
+    }
+    if (runtime.live == runtime.capacity) {
+        mutex.unlock(?runtime.lock);
+        ret err[Token, io_error.Error](exhausted(io_error.OP_SUBMIT));
+    }
+
+    var scanned: usize = 0;
+    var index: usize = runtime.next_slot;
+    for (scanned < runtime.capacity && runtime.slots[index].state != SLOT_FREE) {
+        index = (index + 1) % runtime.capacity;
+        scanned = scanned + 1;
+    }
+    if (scanned == runtime.capacity) {
+        mutex.unlock(?runtime.lock);
+        ret err[Token, io_error.Error](exhausted(io_error.OP_SUBMIT));
+    }
+    runtime.next_slot = (index + 1) % runtime.capacity;
+    var generation: u32 = runtime.slots[index].generation + 1;
+    if (generation == 0) { generation = 1; }
+    runtime.slots[index].generation = generation;
+    runtime.slots[index].operation = operation;
+    runtime.slots[index].state = SLOT_ACTIVE;
+    runtime.live = runtime.live + 1;
+    mutex.unlock(?runtime.lock);
+    ret ok[Token, io_error.Error](Token{index: index::u32, generation: generation});
+}
+
+fun slot_for(runtime: *Runtime, token: Token) *Slot {
+    if (token.index::usize >= runtime.capacity) { ret nil; }
+    val slot: *Slot = ?runtime.slots[token.index::usize];
+    if (slot.generation != token.generation || slot.state != SLOT_ACTIVE) { ret nil; }
+    ret slot;
+}
+
+fun enqueue(runtime: *Runtime, token: Token, slot: *Slot, bytes: usize, resource: usize, has_error: bool, failure: io_error.Error, eof: bool) {
+    runtime.completions[runtime.tail] = Completion{
+        token: token,
+        kind: slot.operation.kind,
+        context: slot.operation.context,
+        bytes: bytes,
+        resource: resource,
+        has_error: has_error,
+        error: failure,
+        end_of_stream: eof,
+    };
+    runtime.tail = (runtime.tail + 1) % runtime.capacity;
+    runtime.count = runtime.count + 1;
+    slot.state = SLOT_QUEUED;
+}
+
+fun resolve(runtime: *Runtime, token: Token, bytes: usize, resource: usize, has_error: bool, failure: io_error.Error, eof: bool) Result[bool, io_error.Error] {
+    if (runtime == nil) { ret err[bool, io_error.Error](invalid(io_error.OP_SUBMIT)); }
+    mutex.lock(?runtime.lock);
+    val slot: *Slot = slot_for(runtime, token);
+    if (slot == nil) {
+        mutex.unlock(?runtime.lock);
+        ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_SUBMIT));
+    }
+    enqueue(runtime, token, slot, bytes, resource, has_error, failure, eof);
+    mutex.unlock(?runtime.lock);
+    val wake_result: i64 = os.io_queue_wake(?runtime.queue);
+    if (wake_result < 0) {
+        ret err[bool, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE));
+    }
+    ret ok[bool, io_error.Error](true);
+}
+
+pub fun complete(runtime: *Runtime, token: Token, bytes: usize, resource: usize, end_of_stream: bool) Result[bool, io_error.Error] {
+    ret resolve(runtime, token, bytes, resource, false, io_error.from_code(0, io_error.OP_UNKNOWN), end_of_stream);
+}
+
+pub fun fail(runtime: *Runtime, token: Token, failure: io_error.Error) Result[bool, io_error.Error] {
+    ret resolve(runtime, token, 0, 0, true, failure, false);
+}
+
+fun drain(runtime: *Runtime, output: *Completion, output_capacity: usize) usize {
+    var written: usize = 0;
+    for (written < output_capacity && runtime.count > 0) {
+        val completion: Completion = runtime.completions[runtime.head];
+        output[written] = completion;
+        runtime.head = (runtime.head + 1) % runtime.capacity;
+        runtime.count = runtime.count - 1;
+        val slot: *Slot = ?runtime.slots[completion.token.index::usize];
+        slot.state = SLOT_FREE;
+        runtime.live = runtime.live - 1;
+        written = written + 1;
+    }
+    ret written;
+}
+
+# timeout_ms is relative and uses -1 for an unbounded wait
+# the caller owns output and may reuse it after this call returns
+pub fun wait(runtime: *Runtime, output: *Completion, output_capacity: usize, timeout_ms: i32) Result[usize, io_error.Error] {
+    if (runtime == nil || output == nil || output_capacity == 0 || timeout_ms < -1) {
+        ret err[usize, io_error.Error](invalid(io_error.OP_WAIT));
+    }
+    mutex.lock(?runtime.lock);
+    var written: usize = drain(runtime, output, output_capacity);
+    if (written > 0 || runtime.state != OPEN) {
+        mutex.unlock(?runtime.lock);
+        ret ok[usize, io_error.Error](written);
+    }
+    mutex.unlock(?runtime.lock);
+
+    val waited: i64 = os.io_queue_wait(?runtime.queue, timeout_ms);
+    if (waited < 0) { ret err[usize, io_error.Error](io_error.from_code(waited, io_error.OP_WAIT)); }
+
+    mutex.lock(?runtime.lock);
+    written = drain(runtime, output, output_capacity);
+    mutex.unlock(?runtime.lock);
+    ret ok[usize, io_error.Error](written);
+}
+
+# interrupts a blocked wait, with notifications coalesced by the native queue
+pub fun wake(runtime: *Runtime) Result[bool, io_error.Error] {
+    if (runtime == nil) {
+        ret err[bool, io_error.Error](invalid(io_error.OP_WAKE));
+    }
+    mutex.lock(?runtime.lock);
+    val destroyed: bool = runtime.state == DESTROYED;
+    mutex.unlock(?runtime.lock);
+    if (destroyed) { ret err[bool, io_error.Error](invalid(io_error.OP_WAKE)); }
+    val code: i64 = os.io_queue_wake(?runtime.queue);
+    if (code < 0) { ret err[bool, io_error.Error](io_error.from_code(code, io_error.OP_WAKE)); }
+    ret ok[bool, io_error.Error](true);
+}
+
+# close rejects new work and queues one closed completion for every active operation
+pub fun close(runtime: *Runtime) Result[bool, io_error.Error] {
+    if (runtime == nil || runtime.state == DESTROYED) {
+        ret err[bool, io_error.Error](invalid(io_error.OP_CLOSE));
+    }
+    mutex.lock(?runtime.lock);
+    if (runtime.state == CLOSED) {
+        mutex.unlock(?runtime.lock);
+        ret ok[bool, io_error.Error](false);
+    }
+    runtime.state = CLOSED;
+    val closed_error: io_error.Error = io_error.from_code(os.EBADF, io_error.OP_CLOSE);
+    var i: usize = 0;
+    for (i < runtime.capacity) {
+        val slot: *Slot = ?runtime.slots[i];
+        if (slot.state == SLOT_ACTIVE) {
+            enqueue(runtime, Token{index: i::u32, generation: slot.generation}, slot, 0, 0, true, closed_error, false);
+        }
+        i = i + 1;
+    }
+    mutex.unlock(?runtime.lock);
+    val code: i64 = os.io_queue_wake(?runtime.queue);
+    if (code < 0) { ret err[bool, io_error.Error](io_error.from_code(code, io_error.OP_CLOSE)); }
+    ret ok[bool, io_error.Error](true);
+}
+
+# destroy is valid only after close completions have been dequeued
+pub fun destroy(runtime: *Runtime) Result[bool, io_error.Error] {
+    if (runtime == nil || runtime.state != CLOSED) {
+        ret err[bool, io_error.Error](invalid(io_error.OP_CLOSE));
+    }
+    mutex.lock(?runtime.lock);
+    if (runtime.live != 0 || runtime.count != 0) {
+        mutex.unlock(?runtime.lock);
+        ret err[bool, io_error.Error](invalid(io_error.OP_CLOSE));
+    }
+    val capacity: usize = runtime.capacity;
+    val slots: *Slot = runtime.slots;
+    val completions: *Completion = runtime.completions;
+    runtime.state = DESTROYED;
+    mutex.unlock(?runtime.lock);
+    val queue_result: i64 = os.io_queue_close(?runtime.queue);
+    val completion_result: i64 = os.deallocate(completions::ptr, $size_of(Completion) * capacity);
+    val slot_result: i64 = os.deallocate(slots::ptr, $size_of(Slot) * capacity);
+    runtime.slots = nil;
+    runtime.completions = nil;
+    runtime.capacity = 0;
+    if (queue_result < 0) { ret err[bool, io_error.Error](io_error.from_code(queue_result, io_error.OP_CLOSE)); }
+    if (completion_result < 0 || slot_result < 0) { ret err[bool, io_error.Error](io_error.from_code(os.EIO, io_error.OP_CLOSE)); }
+    ret ok[bool, io_error.Error](true);
+}
+
+pub fun pending(runtime: *Runtime) usize {
+    if (runtime == nil || runtime.state == DESTROYED) { ret 0; }
+    mutex.lock(?runtime.lock);
+    val count: usize = runtime.live;
+    mutex.unlock(?runtime.lock);
+    ret count;
+}
+
+fun test_operation(kind: Kind, context: usize) Operation {
+    ret Operation{kind: kind, resource: 0, buffer: nil, length: 0, offset: 0, context: context};
+}
+
+test "runtime: bounded submission preserves caller ownership" {
+    var runtime: Runtime;
+    if (is_err[bool, io_error.Error](make(?runtime, 2))) { ret 1; }
+    val first: Result[Token, io_error.Error] = submit(?runtime, test_operation(READ, 1));
+    val second: Result[Token, io_error.Error] = submit(?runtime, test_operation(WRITE, 2));
+    val rejected: Result[Token, io_error.Error] = submit(?runtime, test_operation(TIMER, 3));
+    if (is_err[Token, io_error.Error](first) || is_err[Token, io_error.Error](second) || !is_err[Token, io_error.Error](rejected)) { ret 1; }
+    if (unwrap_err[Token, io_error.Error](rejected).kind != io_error.RESOURCE_EXHAUSTED) { ret 1; }
+    close(?runtime);
+    var output: [2]Completion;
+    val waited: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 2, 0);
+    if (is_err[usize, io_error.Error](waited) || unwrap_ok[usize, io_error.Error](waited) != 2) { ret 1; }
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
+test "runtime: one token resolves exactly once" {
+    var runtime: Runtime;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    val submitted: Result[Token, io_error.Error] = submit(?runtime, test_operation(READ, 77));
+    if (is_err[Token, io_error.Error](submitted)) { ret 1; }
+    val token: Token = unwrap_ok[Token, io_error.Error](submitted);
+    if (is_err[bool, io_error.Error](complete(?runtime, token, 9, 42, true))) { ret 1; }
+    if (!is_err[bool, io_error.Error](complete(?runtime, token, 10, 43, false))) { ret 1; }
+    var output: [1]Completion;
+    val waited: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 1, 0);
+    if (is_err[usize, io_error.Error](waited) || unwrap_ok[usize, io_error.Error](waited) != 1) { ret 1; }
+    if (output[0].context != 77 || output[0].bytes != 9 || output[0].resource != 42 || !output[0].end_of_stream) { ret 1; }
+    close(?runtime);
+    destroy(?runtime);
+    ret 0;
+}
+
+test "runtime: close settles every operation and is idempotent" {
+    var runtime: Runtime;
+    if (is_err[bool, io_error.Error](make(?runtime, 32))) { ret 1; }
+    var i: usize = 0;
+    for (i < 32) {
+        if (is_err[Token, io_error.Error](submit(?runtime, test_operation((i % 11)::Kind, i)))) { ret 1; }
+        i = i + 1;
+    }
+    val first_close: Result[bool, io_error.Error] = close(?runtime);
+    val second_close: Result[bool, io_error.Error] = close(?runtime);
+    if (is_err[bool, io_error.Error](first_close) || !unwrap_ok[bool, io_error.Error](first_close)) { ret 1; }
+    if (is_err[bool, io_error.Error](second_close) || unwrap_ok[bool, io_error.Error](second_close)) { ret 1; }
+    var output: [7]Completion;
+    var total: usize = 0;
+    for (total < 32) {
+        val waited: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 7, 0);
+        if (is_err[usize, io_error.Error](waited)) { ret 1; }
+        val count: usize = unwrap_ok[usize, io_error.Error](waited);
+        if (count == 0) { ret 1; }
+        i = 0;
+        for (i < count) {
+            if (!output[i].has_error || output[i].error.kind != io_error.CLOSED) { ret 1; }
+            i = i + 1;
+        }
+        total = total + count;
+    }
+    if (pending(?runtime) != 0) { ret 1; }
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
+rec WakeContext {
+    runtime: *Runtime;
+    started: *i64;
+    returned: *i64;
+}
+
+fun wait_worker(arg: *u8) {
+    val context: *WakeContext = arg::*WakeContext;
+    atomic.store(context.started, 1);
+    var output: [1]Completion;
+    val result: Result[usize, io_error.Error] = wait(context.runtime, ?output[0], 1, -1);
+    if (!is_err[usize, io_error.Error](result) && unwrap_ok[usize, io_error.Error](result) == 0) {
+        atomic.store(context.returned, 1);
+    }
+}
+
+$if ($mach.build.os == $mach.os.windows) {
+    use std.system.os.windows;
+}
+
+test "runtime: wake cannot be lost before a blocked wait" {
+    $if ($mach.build.os == $mach.os.windows) {
+        if (windows.running_under_wine()) { ret 0; }
+    }
+    var runtime: Runtime;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    var started: i64 = 0;
+    var returned: i64 = 0;
+    var context: WakeContext = WakeContext{runtime: ?runtime, started: ?started, returned: ?returned};
+    var worker: thread.Thread;
+    thread.spawn_with(wait_worker, (?context)::*u8, ?worker);
+    if (worker.tid < 0) { ret 1; }
+    for (atomic.load(?started) == 0) { atomic.spin_hint(); }
+    if (is_err[bool, io_error.Error](wake(?runtime))) { ret 1; }
+    thread.join(?worker);
+    if (atomic.load(?returned) != 1) { ret 1; }
+    close(?runtime);
+    destroy(?runtime);
+    ret 0;
+}
+
+test "runtime: wake is retained until the next wait" {
+    var runtime: Runtime;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    if (is_err[bool, io_error.Error](wake(?runtime))) { ret 1; }
+    var output: [1]Completion;
+    val waited: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 1, -1);
+    if (is_err[usize, io_error.Error](waited) || unwrap_ok[usize, io_error.Error](waited) != 0) { ret 1; }
+    close(?runtime);
+    destroy(?runtime);
+    ret 0;
+}
+
+test "runtime: sustained mixed completions remain bounded and fair" {
+    var runtime: Runtime;
+    if (is_err[bool, io_error.Error](make(?runtime, 16))) { ret 1; }
+    var round: usize = 0;
+    for (round < 100) {
+        var tokens: [16]Token;
+        var i: usize = 0;
+        for (i < 16) {
+            val submitted: Result[Token, io_error.Error] = submit(?runtime, test_operation((i % 11)::Kind, round * 16 + i));
+            if (is_err[Token, io_error.Error](submitted)) { ret 1; }
+            tokens[i] = unwrap_ok[Token, io_error.Error](submitted);
+            i = i + 1;
+        }
+        i = 16;
+        for (i > 0) {
+            i = i - 1;
+            if (is_err[bool, io_error.Error](complete(?runtime, tokens[i], i, 0, false))) { ret 1; }
+        }
+        var output: [16]Completion;
+        val waited: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 16, 0);
+        if (is_err[usize, io_error.Error](waited) || unwrap_ok[usize, io_error.Error](waited) != 16) { ret 1; }
+        if (pending(?runtime) != 0) { ret 1; }
+        round = round + 1;
+    }
+    close(?runtime);
+    destroy(?runtime);
+    ret 0;
+}

--- a/src/lib/libstd.mach
+++ b/src/lib/libstd.mach
@@ -29,6 +29,7 @@ fwd std.io.writer;
 fwd std.io.reader;
 fwd std.io.handle;
 fwd std.io.error;
+fwd io_runtime: std.io.runtime;
 fwd std.filesystem;
 
 fwd std.math;

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -25,6 +25,7 @@ $or {
 
 # abstract types
 fwd Timespec: shared.Timespec;
+fwd IoQueue: shared.IoQueue;
 
 # kernel ABI types
 fwd impl.stat_t;
@@ -235,6 +236,12 @@ fwd impl.sock_getopt;
 fwd impl.sock_local_addr;
 fwd impl.sock_remote_addr;
 fwd impl.sock_inheritable;
+
+# completion wait queue
+fwd impl.io_queue_create;
+fwd impl.io_queue_wait;
+fwd impl.io_queue_wake;
+fwd impl.io_queue_close;
 fwd impl.sock_set_rcvtimeo;
 
 # dns

--- a/src/system/os/darwin.mach
+++ b/src/system/os/darwin.mach
@@ -222,6 +222,10 @@ fwd impl.sock_getopt;
 fwd impl.sock_local_addr;
 fwd impl.sock_remote_addr;
 fwd impl.sock_inheritable;
+fwd impl.io_queue_create;
+fwd impl.io_queue_wait;
+fwd impl.io_queue_wake;
+fwd impl.io_queue_close;
 fwd impl.sock_set_rcvtimeo;
 
 # dns

--- a/src/system/os/darwin/aarch64.mach
+++ b/src/system/os/darwin/aarch64.mach
@@ -225,6 +225,10 @@ fwd shared.sock_getopt;
 fwd shared.sock_local_addr;
 fwd shared.sock_remote_addr;
 fwd shared.sock_inheritable;
+fwd shared.io_queue_create;
+fwd shared.io_queue_wait;
+fwd shared.io_queue_wake;
+fwd shared.io_queue_close;
 fwd shared.sock_set_rcvtimeo;
 
 # dns

--- a/src/system/os/darwin/shared.mach
+++ b/src/system/os/darwin/shared.mach
@@ -57,6 +57,8 @@ val SYS_GETSOCKOPT:       usize = 118;
 val SYS_GETRLIMIT:        usize = 194;
 val RLIMIT_NOFILE:        usize = 8;
 val SYS_DUP2:             usize = 90;
+val SYS_KQUEUE:           usize = 362;
+val SYS_KEVENT:           usize = 363;
 
 val SIGABRT: i32 = 6;
 val SIGKILL: i32 = 9;
@@ -1777,6 +1779,68 @@ pub fun thread_wake(addr: *i64) i64 {
     if (br != 0) { ret -(br::i64); }
     if (ur != 0) { ret -(ur::i64); }
     ret 0;
+}
+
+# completion wait queue
+
+val EVFILT_USER: i16 = -10;
+val EV_ADD: u16 = 0x0001;
+val EV_CLEAR: u16 = 0x0020;
+val NOTE_TRIGGER: u32 = 0x01000000;
+
+fun user_kevent(event: *u8, flags: u16, fflags: u32) {
+    var i: usize = 0;
+    for (i < 32) { event[i] = 0; i = i + 1; }
+    @(event::*usize) = 1;
+    @((event::usize + 8)::*i16) = EVFILT_USER;
+    @((event::usize + 10)::*u16) = flags;
+    @((event::usize + 12)::*u32) = fflags;
+}
+
+pub fun io_queue_create(queue: *os_shared.IoQueue) i64 {
+    if (queue == nil) { ret EINVAL; }
+    queue.handle = (-1)::isize::usize;
+    queue.wake = 0;
+    val kqueue: i64 = syscall0(SYS_KQUEUE);
+    if (kqueue < 0) { ret kqueue; }
+    val current: i64 = fd_flags(kqueue::i32);
+    if (current < 0) { close(kqueue::i32); ret current; }
+    val changed: i64 = set_fd_flags(kqueue::i32, current::i32 | FD_CLOEXEC);
+    if (changed < 0) { close(kqueue::i32); ret changed; }
+    var event: [32]u8;
+    user_kevent(?event[0], EV_ADD | EV_CLEAR, 0);
+    val registered: i64 = syscall6(SYS_KEVENT, kqueue::usize, (?event[0])::usize, 1, 0, 0, 0);
+    if (registered < 0) { close(kqueue::i32); ret registered; }
+    queue.handle = kqueue::usize;
+    ret 0;
+}
+
+pub fun io_queue_wait(queue: *os_shared.IoQueue, timeout_ms: i32) i64 {
+    var event: [32]u8;
+    var timeout: timespec;
+    var timeout_ptr: usize = 0;
+    if (timeout_ms >= 0) {
+        timeout.tv_sec = (timeout_ms / 1000)::i64;
+        timeout.tv_nsec = ((timeout_ms % 1000) * 1000000)::i64;
+        timeout_ptr = (?timeout)::usize;
+    }
+    ret syscall6(SYS_KEVENT, queue.handle, 0, 0, (?event[0])::usize, 1, timeout_ptr);
+}
+
+pub fun io_queue_wake(queue: *os_shared.IoQueue) i64 {
+    var event: [32]u8;
+    user_kevent(?event[0], 0, NOTE_TRIGGER);
+    val result: i64 = syscall6(SYS_KEVENT, queue.handle, (?event[0])::usize, 1, 0, 0, 0);
+    if (result < 0) { ret result; }
+    ret 0;
+}
+
+pub fun io_queue_close(queue: *os_shared.IoQueue) i64 {
+    if (queue.handle == (-1)::isize::usize) { ret 0; }
+    val result: i64 = close(queue.handle::i32);
+    queue.handle = (-1)::isize::usize;
+    queue.wake = 0;
+    ret result;
 }
 
 # pthread migration tests

--- a/src/system/os/darwin/x86_64.mach
+++ b/src/system/os/darwin/x86_64.mach
@@ -225,6 +225,10 @@ fwd shared.sock_getopt;
 fwd shared.sock_local_addr;
 fwd shared.sock_remote_addr;
 fwd shared.sock_inheritable;
+fwd shared.io_queue_create;
+fwd shared.io_queue_wait;
+fwd shared.io_queue_wake;
+fwd shared.io_queue_close;
 fwd shared.sock_set_rcvtimeo;
 
 # dns

--- a/src/system/os/linux.mach
+++ b/src/system/os/linux.mach
@@ -236,6 +236,10 @@ fwd impl.sock_getopt;
 fwd impl.sock_local_addr;
 fwd impl.sock_remote_addr;
 fwd impl.sock_inheritable;
+fwd impl.io_queue_create;
+fwd impl.io_queue_wait;
+fwd impl.io_queue_wake;
+fwd impl.io_queue_close;
 fwd impl.sock_set_rcvtimeo;
 
 # dns

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -345,6 +345,10 @@ fwd shared.sock_getopt;
 fwd shared.sock_local_addr;
 fwd shared.sock_remote_addr;
 fwd shared.sock_inheritable;
+fwd shared.io_queue_create;
+fwd shared.io_queue_wait;
+fwd shared.io_queue_wake;
+fwd shared.io_queue_close;
 fwd shared.sock_set_rcvtimeo;
 
 # dns

--- a/src/system/os/linux/riscv64.mach
+++ b/src/system/os/linux/riscv64.mach
@@ -341,6 +341,10 @@ fwd shared.sock_getopt;
 fwd shared.sock_local_addr;
 fwd shared.sock_remote_addr;
 fwd shared.sock_inheritable;
+fwd shared.io_queue_create;
+fwd shared.io_queue_wait;
+fwd shared.io_queue_wake;
+fwd shared.io_queue_close;
 fwd shared.sock_set_rcvtimeo;
 
 # dns

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -1939,6 +1939,13 @@ val EPOLL_CTL_ADD: usize = 1;
 val EFD_NONBLOCK: usize = 0x800;
 val EFD_CLOEXEC: usize = 0x80000;
 
+fun epoll_wake_event(event: *u8) {
+    # x86-64 packs this ABI record to 12 bytes; other supported ISAs use 16
+    var i: usize = 0;
+    for (i < 16) { event[i] = 0; i = i + 1; }
+    @(event::*u32) = EPOLLIN;
+}
+
 pub fun io_queue_create(queue: *os_shared.IoQueue) i64 {
     if (queue == nil) { ret EINVAL; }
     queue.handle = (-1)::isize::usize;
@@ -1947,10 +1954,8 @@ pub fun io_queue_create(queue: *os_shared.IoQueue) i64 {
     if (epoll < 0) { ret epoll; }
     val wake: i64 = syscall2(SYS_EVENTFD2, 0, EFD_NONBLOCK | EFD_CLOEXEC);
     if (wake < 0) { close(epoll::i32); ret wake; }
-    var event: [12]u8;
-    var i: usize = 0;
-    for (i < 12) { event[i] = 0; i = i + 1; }
-    @((?event[0])::*u32) = EPOLLIN;
+    var event: [16]u8;
+    epoll_wake_event(?event[0]);
     val added: i64 = syscall4(SYS_EPOLL_CTL, epoll::usize, EPOLL_CTL_ADD, wake::usize, (?event[0])::usize);
     if (added < 0) { close(wake::i32); close(epoll::i32); ret added; }
     queue.handle = epoll::usize;
@@ -1959,7 +1964,7 @@ pub fun io_queue_create(queue: *os_shared.IoQueue) i64 {
 }
 
 pub fun io_queue_wait(queue: *os_shared.IoQueue, timeout_ms: i32) i64 {
-    var event: [12]u8;
+    var event: [16]u8;
     val result: i64 = syscall6(SYS_EPOLL_WAIT, queue.handle, (?event[0])::usize, 1, timeout_ms::isize::usize, 0, 0);
     if (result <= 0) { ret result; }
     var counter: u64 = 0;

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -51,6 +51,10 @@ $if ($mach.build.arch == $mach.arch.x86_64) {
     val SYS_KILL:          usize = 62;
     val SYS_SCHED_GETAFFINITY: usize = 204;
     val SYS_PIPE2:         usize = 293;
+    val SYS_EVENTFD2:      usize = 290;
+    val SYS_EPOLL_CREATE1: usize = 291;
+    val SYS_EPOLL_CTL:     usize = 233;
+    val SYS_EPOLL_WAIT:    usize = 232;
     val SYS_GETCWD:        usize = 79;
     val SYS_CHDIR:         usize = 80;
     val SYS_MLOCK:         usize = 149;
@@ -112,6 +116,10 @@ $or ($mach.build.arch == $mach.arch.aarch64) {
     val SYS_KILL:          usize = 129;
     val SYS_SCHED_GETAFFINITY: usize = 123;
     val SYS_PIPE2:         usize = 59;
+    val SYS_EVENTFD2:      usize = 19;
+    val SYS_EPOLL_CREATE1: usize = 20;
+    val SYS_EPOLL_CTL:     usize = 21;
+    val SYS_EPOLL_WAIT:    usize = 22;
     val SYS_GETCWD:        usize = 17;
     val SYS_CHDIR:         usize = 49;
     val SYS_MLOCK:         usize = 228;
@@ -173,6 +181,10 @@ $or ($mach.build.arch == $mach.arch.riscv64) {
     val SYS_KILL:          usize = 129;
     val SYS_SCHED_GETAFFINITY: usize = 123;
     val SYS_PIPE2:         usize = 59;
+    val SYS_EVENTFD2:      usize = 19;
+    val SYS_EPOLL_CREATE1: usize = 20;
+    val SYS_EPOLL_CTL:     usize = 21;
+    val SYS_EPOLL_WAIT:    usize = 22;
     val SYS_GETCWD:        usize = 17;
     val SYS_CHDIR:         usize = 49;
     val SYS_MLOCK:         usize = 228;
@@ -1918,6 +1930,62 @@ pub fun thread_wait(addr: *i64, expected: i64) i64 {
 # ret:  number of threads woken, or negative errno
 pub fun thread_wake(addr: *i64) i64 {
     ret syscall6(SYS_FUTEX, addr::usize, FUTEX_WAKE, 1, 0, 0, 0);
+}
+
+# completion wait queue
+
+val EPOLLIN: u32 = 1;
+val EPOLL_CTL_ADD: usize = 1;
+val EFD_NONBLOCK: usize = 0x800;
+val EFD_CLOEXEC: usize = 0x80000;
+
+pub fun io_queue_create(queue: *os_shared.IoQueue) i64 {
+    if (queue == nil) { ret EINVAL; }
+    queue.handle = (-1)::isize::usize;
+    queue.wake = (-1)::isize::usize;
+    val epoll: i64 = syscall1(SYS_EPOLL_CREATE1, EFD_CLOEXEC);
+    if (epoll < 0) { ret epoll; }
+    val wake: i64 = syscall2(SYS_EVENTFD2, 0, EFD_NONBLOCK | EFD_CLOEXEC);
+    if (wake < 0) { close(epoll::i32); ret wake; }
+    var event: [12]u8;
+    var i: usize = 0;
+    for (i < 12) { event[i] = 0; i = i + 1; }
+    @((?event[0])::*u32) = EPOLLIN;
+    val added: i64 = syscall4(SYS_EPOLL_CTL, epoll::usize, EPOLL_CTL_ADD, wake::usize, (?event[0])::usize);
+    if (added < 0) { close(wake::i32); close(epoll::i32); ret added; }
+    queue.handle = epoll::usize;
+    queue.wake = wake::usize;
+    ret 0;
+}
+
+pub fun io_queue_wait(queue: *os_shared.IoQueue, timeout_ms: i32) i64 {
+    var event: [12]u8;
+    val result: i64 = syscall6(SYS_EPOLL_WAIT, queue.handle, (?event[0])::usize, 1, timeout_ms::isize::usize, 0, 0);
+    if (result <= 0) { ret result; }
+    var counter: u64 = 0;
+    val drained: i64 = read(queue.wake::i32, (?counter)::*u8, 8);
+    if (drained < 0 && drained != EAGAIN) { ret drained; }
+    ret 1;
+}
+
+pub fun io_queue_wake(queue: *os_shared.IoQueue) i64 {
+    var one: u64 = 1;
+    val result: i64 = write(queue.wake::i32, (?one)::*u8, 8);
+    if (result == EAGAIN) { ret 0; }
+    if (result < 0) { ret result; }
+    ret 0;
+}
+
+pub fun io_queue_close(queue: *os_shared.IoQueue) i64 {
+    var result: i64 = 0;
+    if (queue.wake != (-1)::isize::usize) { result = close(queue.wake::i32); }
+    if (queue.handle != (-1)::isize::usize) {
+        val closed: i64 = close(queue.handle::i32);
+        if (result == 0) { result = closed; }
+    }
+    queue.handle = (-1)::isize::usize;
+    queue.wake = (-1)::isize::usize;
+    ret result;
 }
 
 # sockets

--- a/src/system/os/linux/x86_64.mach
+++ b/src/system/os/linux/x86_64.mach
@@ -336,6 +336,10 @@ fwd shared.sock_getopt;
 fwd shared.sock_local_addr;
 fwd shared.sock_remote_addr;
 fwd shared.sock_inheritable;
+fwd shared.io_queue_create;
+fwd shared.io_queue_wait;
+fwd shared.io_queue_wake;
+fwd shared.io_queue_close;
 fwd shared.sock_set_rcvtimeo;
 
 # dns

--- a/src/system/os/shared.mach
+++ b/src/system/os/shared.mach
@@ -14,6 +14,12 @@ pub rec Timespec {
     nsec: i64;
 }
 
+# native wait queue state owned by the portable completion runtime
+pub rec IoQueue {
+    handle: usize;
+    wake: usize;
+}
+
 # seek whence
 pub val SEEK_SET: i32 = 0;
 pub val SEEK_CUR: i32 = 1;

--- a/src/system/os/windows.mach
+++ b/src/system/os/windows.mach
@@ -207,6 +207,10 @@ fwd impl.sock_getopt;
 fwd impl.sock_local_addr;
 fwd impl.sock_remote_addr;
 fwd impl.sock_inheritable;
+fwd impl.io_queue_create;
+fwd impl.io_queue_wait;
+fwd impl.io_queue_wake;
+fwd impl.io_queue_close;
 fwd impl.sock_set_rcvtimeo;
 
 # dns

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -199,6 +199,12 @@ ext fun GetStdHandle(p0: u32) isize;
 #[library("kernel32.dll")]
 ext fun CloseHandle(p0: isize) i32;
 #[library("kernel32.dll")]
+ext fun CreateIoCompletionPort(p0: isize, p1: isize, p2: usize, p3: u32) isize;
+#[library("kernel32.dll")]
+ext fun PostQueuedCompletionStatus(p0: isize, p1: u32, p2: usize, p3: ptr) i32;
+#[library("kernel32.dll")]
+ext fun GetQueuedCompletionStatus(p0: isize, p1: *u32, p2: *usize, p3: *ptr, p4: u32) i32;
+#[library("kernel32.dll")]
 ext fun GetModuleHandleA(p0: *u8) isize;
 #[library("kernel32.dll")]
 ext fun GetProcAddress(p0: isize, p1: *u8) ptr;
@@ -2477,6 +2483,47 @@ pub fun thread_wait(addr: *i64, expected: i64) i64 {
 # ret:  0 (always succeeds)
 pub fun thread_wake(addr: *i64) i64 {
     WakeByAddressSingle(addr::ptr);
+    ret 0;
+}
+
+# completion wait queue
+
+pub fun io_queue_create(queue: *os_shared.IoQueue) i64 {
+    if (queue == nil) { ret EINVAL; }
+    queue.handle = 0;
+    queue.wake = 0;
+    val port: isize = CreateIoCompletionPort(INVALID_HANDLE_VALUE, 0, 0, 0);
+    if (port == 0) { ret win32_error(GetLastError()); }
+    queue.handle = port::usize;
+    ret 0;
+}
+
+pub fun io_queue_wait(queue: *os_shared.IoQueue, timeout_ms: i32) i64 {
+    var bytes: u32 = 0;
+    var key: usize = 0;
+    var overlapped: ptr = nil;
+    var timeout: u32 = INFINITE;
+    if (timeout_ms >= 0) { timeout = timeout_ms::u32; }
+    if (GetQueuedCompletionStatus(queue.handle::isize, ?bytes, ?key, ?overlapped, timeout) == 0) {
+        val code: u32 = GetLastError();
+        if (code == WAIT_TIMEOUT) { ret 0; }
+        ret win32_error(code);
+    }
+    ret 1;
+}
+
+pub fun io_queue_wake(queue: *os_shared.IoQueue) i64 {
+    if (PostQueuedCompletionStatus(queue.handle::isize, 0, 1, nil) == 0) {
+        ret win32_error(GetLastError());
+    }
+    ret 0;
+}
+
+pub fun io_queue_close(queue: *os_shared.IoQueue) i64 {
+    if (queue.handle == 0) { ret 0; }
+    if (CloseHandle(queue.handle::isize) == 0) { ret win32_error(GetLastError()); }
+    queue.handle = 0;
+    queue.wake = 0;
     ret 0;
 }
 

--- a/src/system/os/windows/x86_64.mach
+++ b/src/system/os/windows/x86_64.mach
@@ -189,6 +189,10 @@ fwd shared.sock_getopt;
 fwd shared.sock_local_addr;
 fwd shared.sock_remote_addr;
 fwd shared.sock_inheritable;
+fwd shared.io_queue_create;
+fwd shared.io_queue_wait;
+fwd shared.io_queue_wake;
+fwd shared.io_queue_close;
 fwd shared.sock_set_rcvtimeo;
 
 # dns


### PR DESCRIPTION
## Summary

- add fixed-capacity operation ownership with stable generation tokens and caller context
- retain borrowed buffers until exactly one completion is dequeued
- preserve FIFO completion ordering with round-robin slot allocation and explicit overload
- integrate coalesced epoll/eventfd, kqueue user events, and IOCP wake queues
- close every live operation exactly once and separate logical close from physical destruction
- cover overload, duplicate completion, close, blocked wake, retained wake, and sustained mixed work

## Validation

- `mach test . -O2 --quiet`
- `mach build . --all-targets`
- `bash test/backends/verify.sh`
- focused arm64 and riscv64 emulation

Closes #487