### PR TITLE
feat(sync): add hierarchical cancellation scopes

### DIFF
--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -913,8 +913,7 @@ fun atomic_paths_free(a: *A.Allocator, parent: Path, temp: Path) {
     A.deallocate[u8](a, parent, str_len(parent) + 1);
 }
 
-# the tests exercise the real filesystem under posix literal /tmp paths (the
-# hosts that run `mach test`); each test uses a distinct name and removes
+# the tests use distinct relative paths and remove what they create
 # what it creates
 
 # write_bytes then read_string round-trips content through the io adapters
@@ -924,7 +923,7 @@ test "std.filesystem.write_bytes:read_string_roundtrip" {
     var a: A.Allocator;
     fixed.make(?a, ?st, ?buf[0], 4096);
 
-    val p: Path = "/tmp/mach_std_fs_roundtrip";
+    val p: Path = "mach_std_fs_roundtrip";
     if (O.is_some[str](write_bytes(p, "hello, mach", 11, 0o644))) { ret 1; }
 
     val r: R.Result[str, str] = read_string(?a, p);
@@ -942,8 +941,8 @@ test "std.filesystem.replace_bytes_atomic:create_replace_and_cleanup" {
     var a: A.Allocator;
     fixed.make(?a, ?st, ?buf[0], 32768);
 
-    val d: Path = "/tmp/mach_std_fs_atomic";
-    val p: Path = "/tmp/mach_std_fs_atomic/nested/state.dat";
+    val d: Path = "mach_std_fs_atomic";
+    val p: Path = "mach_std_fs_atomic/nested/state.dat";
     remove_all(?a, d);
     if (O.is_some[str](replace_bytes_atomic(?a, p, "first", 5, 0o600, 0o700))) { remove_all(?a, d); ret 1; }
     if (O.is_some[str](replace_bytes_atomic(?a, p, "second", 6, 0o600, 0o700))) { remove_all(?a, d); ret 2; }
@@ -953,7 +952,7 @@ test "std.filesystem.replace_bytes_atomic:create_replace_and_cleanup" {
     if (R.is_err[str, str](rr)) { bad = 4; }
     or (!str_equals(R.unwrap_ok[str, str](rr), "second")) { bad = 5; }
 
-    val lr: R.Result[Vector[str], str] = read_dir(?a, "/tmp/mach_std_fs_atomic/nested");
+    val lr: R.Result[Vector[str], str] = read_dir(?a, "mach_std_fs_atomic/nested");
     if (R.is_err[Vector[str], str](lr)) { bad = 6; }
     or {
         var names: Vector[str] = R.unwrap_ok[Vector[str], str](lr);
@@ -973,8 +972,8 @@ test "std.filesystem.replace_bytes_atomic:rename_failure_cleans_temp" {
     var a: A.Allocator;
     fixed.make(?a, ?st, ?buf[0], 32768);
 
-    val d: Path = "/tmp/mach_std_fs_atomic_fail";
-    val p: Path = "/tmp/mach_std_fs_atomic_fail/destination";
+    val d: Path = "mach_std_fs_atomic_fail";
+    val p: Path = "mach_std_fs_atomic_fail/destination";
     remove_all(?a, d);
     if (O.is_some[str](create_dir(d, 0o700))) { ret 1; }
     if (O.is_some[str](create_dir(p, 0o700))) { remove_all(?a, d); ret 2; }

--- a/src/filesystem.mach
+++ b/src/filesystem.mach
@@ -1002,7 +1002,7 @@ test "std.filesystem.read_bytes:content_and_len" {
     var a: A.Allocator;
     fixed.make(?a, ?st, ?buf[0], 32768);
 
-    val p: Path = "/tmp/mach_std_fs_bytes";
+    val p: Path = "mach_std_fs_bytes";
     if (O.is_some[str](write_bytes(p, "abc", 3, 0o644))) { ret 1; }
 
     val r: R.Result[Vector[u8], str] = read_bytes(?a, p);
@@ -1018,7 +1018,7 @@ test "std.filesystem.read_bytes:content_and_len" {
 
 # a missing path fails open and answers false to every predicate
 test "std.filesystem.open:missing_path" {
-    val p: Path = "/tmp/mach_std_fs_missing";
+    val p: Path = "mach_std_fs_missing";
     if (R.is_ok[File, io_error.Error](open(p))) { ret 1; }
     if (exists(p))                   { ret 1; }
     if (is_file(p))                  { ret 1; }
@@ -1027,7 +1027,7 @@ test "std.filesystem.open:missing_path" {
 }
 
 test "std.filesystem.close:duplicate_is_normalized" {
-    val p: Path = "/tmp/mach_std_fs_close";
+    val p: Path = "mach_std_fs_close";
     if (O.is_some[str](write_bytes(p, "x", 1, 0o600))) { ret 1; }
     val opened: R.Result[File, io_error.Error] = open(p);
     if (R.is_err[File, io_error.Error](opened)) { remove_file(p); ret 1; }
@@ -1042,7 +1042,7 @@ test "std.filesystem.close:duplicate_is_normalized" {
 
 # metadata reports a regular file's kind and size
 test "std.filesystem.metadata:file_kind_and_size" {
-    val p: Path = "/tmp/mach_std_fs_meta";
+    val p: Path = "mach_std_fs_meta";
     if (O.is_some[str](write_bytes(p, "12345", 5, 0o644))) { ret 1; }
 
     val r: R.Result[Metadata, str] = metadata(p);
@@ -1063,7 +1063,7 @@ test "std.filesystem.metadata:file_kind_and_size" {
 
 # create_dir and remove_dir round-trip, with predicates agreeing in between
 test "std.filesystem.create_dir:remove_dir_roundtrip" {
-    val p: Path = "/tmp/mach_std_fs_dir";
+    val p: Path = "mach_std_fs_dir";
     if (O.is_some[str](create_dir(p, 0o755))) { ret 1; }
 
     var bad: i32 = 0;
@@ -1077,8 +1077,8 @@ test "std.filesystem.create_dir:remove_dir_roundtrip" {
 
 # rename moves the entry: the old path vanishes, the new one exists
 test "std.filesystem.rename:moves_entry" {
-    val from: Path = "/tmp/mach_std_fs_ren_a";
-    val to:   Path = "/tmp/mach_std_fs_ren_b";
+    val from: Path = "mach_std_fs_ren_a";
+    val to:   Path = "mach_std_fs_ren_b";
     if (O.is_some[str](write_bytes(from, "x", 1, 0o644))) { ret 1; }
 
     var bad: i32 = 0;
@@ -1097,8 +1097,8 @@ test "std.filesystem.rename:moves_entry" {
 # REPLACE_EXISTING for this: bare MoveFile fails whenever the destination
 # exists, which is the common case for write-a-temp-then-rename (#414)
 test "std.filesystem.rename:replaces_existing_destination" {
-    val from: Path = "/tmp/mach_std_fs_ren_r_a";
-    val to:   Path = "/tmp/mach_std_fs_ren_r_b";
+    val from: Path = "mach_std_fs_ren_r_a";
+    val to:   Path = "mach_std_fs_ren_r_b";
     if (O.is_some[str](write_bytes(from, "new", 3, 0o644))) { ret 1; }
     if (O.is_some[str](write_bytes(to,   "old", 3, 0o644))) { remove_file(from); ret 1; }
 
@@ -1137,15 +1137,15 @@ test "std.filesystem.read_dir:lists_children" {
     var alloc: A.Allocator;
     if (O.is_some[*u8](fixed.make(?alloc, ?st, ?buf[0], 8192))) { ret 1; }
 
-    val d: Path = "/tmp/mach_std_fs_rd";
+    val d: Path = "mach_std_fs_rd";
     remove_all(?alloc, d);
     if (O.is_some[str](create_dir(d, 0o755))) { ret 1; }
 
     # distinct codes per step: a bare 1 says only that something went wrong, which is
     # close to no check at all when the run is on a machine you cannot reach
     var bad: i32 = 0;
-    if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/a.txt", "a", 1, 0o644))) { ret 2; }
-    if (O.is_some[str](write_bytes("/tmp/mach_std_fs_rd/b.txt", "b", 1, 0o644))) { ret 3; }
+    if (O.is_some[str](write_bytes("mach_std_fs_rd/a.txt", "a", 1, 0o644))) { ret 2; }
+    if (O.is_some[str](write_bytes("mach_std_fs_rd/b.txt", "b", 1, 0o644))) { ret 3; }
 
     val rr: R.Result[Vector[str], str] = read_dir(?alloc, d);
     if (R.is_err[Vector[str], str](rr)) { bad = 4; }
@@ -1176,7 +1176,7 @@ test "std.filesystem.read_dir:lists_children" {
 test "std.filesystem.seek:reposition_and_read" {
     var scratch: [16]u8;
 
-    val p: Path = "/tmp/mach_std_fs_seek";
+    val p: Path = "mach_std_fs_seek";
     if (O.is_some[str](write_bytes(p, "hello", 5, 0o644))) { ret 1; }
 
     val ro: R.Result[File, io_error.Error] = open(p);
@@ -1200,8 +1200,8 @@ test "std.filesystem.seek:reposition_and_read" {
 
 # a symlink reports as a link unfollowed and as its target followed
 test "std.filesystem.symlink:link_vs_target" {
-    val target: Path = "/tmp/mach_std_fs_sl_target";
-    val link:   Path = "/tmp/mach_std_fs_sl_link";
+    val target: Path = "mach_std_fs_sl_target";
+    val link:   Path = "mach_std_fs_sl_link";
     if (O.is_some[str](write_bytes(target, "t", 1, 0o644))) { ret 1; }
 
     var bad: i32 = 0;

--- a/src/io/runtime.mach
+++ b/src/io/runtime.mach
@@ -61,6 +61,7 @@ pub rec Completion {
 val SLOT_FREE: u8 = 0;
 val SLOT_ACTIVE: u8 = 1;
 val SLOT_QUEUED: u8 = 2;
+val SLOT_CANCELLING: u8 = 3;
 
 rec Slot {
     state: u8;
@@ -352,13 +353,28 @@ fun scope_cancel_callback(context: ptr, reason: cancel.Reason) {
     val slot: *Slot = context::*Slot;
     val runtime: *Runtime = slot.runtime;
     mutex.lock(?runtime.lock);
-    slot.cancellation_active = false;
-    if (slot.state == SLOT_ACTIVE) {
-        val token: Token = Token{index: slot.index, generation: slot.generation};
-        remove_slot_timers(runtime, token);
-        enqueue(runtime, token, slot, 0, 0, true, cancellation_error(reason), false);
+    if (slot.state != SLOT_ACTIVE) {
+        panic.panic("std.io.runtime: cancellation lost operation ownership\n");
     }
-    # live operations prevent queue destruction, so failure is unrecoverable corruption
+    val token: Token = Token{index: slot.index, generation: slot.generation};
+    remove_slot_timers(runtime, token);
+    slot.state = SLOT_CANCELLING;
+    mutex.unlock(?runtime.lock);
+}
+
+fun scope_cancel_complete(context: ptr, reason: cancel.Reason) {
+    val slot: *Slot = context::*Slot;
+    val runtime: *Runtime = slot.runtime;
+    mutex.lock(?runtime.lock);
+    if (slot.state != SLOT_CANCELLING) {
+        panic.panic("std.io.runtime: cancellation completion lost ownership\n");
+    }
+    val token: Token = Token{index: slot.index, generation: slot.generation};
+    enqueue(runtime, token, slot, 0, 0, true, cancellation_error(reason), false);
+    slot.cancellation_active = false;
+    if (!cancel.finish(?slot.cancellation)) {
+        panic.panic("std.io.runtime: cancellation completion was not owned\n");
+    }
     if (os.io_queue_wake(?runtime.queue) < 0) {
         panic.panic("std.io.runtime: open queue wake failed\n");
     }
@@ -375,7 +391,7 @@ fun release_claim_locked(runtime: *Runtime, token: Token) {
 
 fun attach_scope_locked(runtime: *Runtime, token: Token, scope: *cancel.Scope) cancel.Reason {
     val slot: *Slot = ?runtime.slots[token.index::usize];
-    val attached: cancel.Reason = cancel.attach(scope, ?slot.cancellation, scope_cancel_callback, slot::ptr);
+    val attached: cancel.Reason = cancel.attach_with_completion(scope, ?slot.cancellation, scope_cancel_callback, scope_cancel_complete, slot::ptr);
     if (attached != cancel.ACTIVE) { ret attached; }
     slot.cancellation_active = true;
     var deadline: time.Time;

--- a/src/io/runtime.mach
+++ b/src/io/runtime.mach
@@ -11,6 +11,7 @@ use std.types.result.is_err;
 use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 use std.system.os;
+use std.system.panic;
 use std.chrono.time;
 use std.sync.atomic;
 use std.sync.cancel;
@@ -160,8 +161,7 @@ pub fun make(runtime: *Runtime, capacity: usize) Result[bool, io_error.Error] {
         runtime.slots[i].runtime = runtime;
         runtime.slots[i].operation_timer_index = timer_capacity;
         runtime.slots[i].deadline_timer_index = timer_capacity;
-        runtime.slots[i].cancellation.root = nil;
-        runtime.slots[i].cancellation.state = 0;
+        cancel.init_registration(?runtime.slots[i].cancellation);
         i = i + 1;
     }
     val code: i64 = os.io_queue_create(?runtime.queue);
@@ -202,7 +202,7 @@ fun claim_locked(runtime: *Runtime, operation: Operation, token: *Token) i64 {
     runtime.slots[index].operation = operation;
     runtime.slots[index].operation_timer_index = timer_capacity(runtime);
     runtime.slots[index].deadline_timer_index = timer_capacity(runtime);
-    runtime.slots[index].cancellation.root = nil;
+    cancel.init_registration(?runtime.slots[index].cancellation);
     runtime.slots[index].state = SLOT_ACTIVE;
     runtime.live = runtime.live + 1;
     @token = Token{index: index::u32, generation: generation};
@@ -355,13 +355,16 @@ fun scope_cancel_callback(context: ptr, reason: cancel.Reason) {
         enqueue(runtime, token, slot, 0, 0, true, cancellation_error(reason), false);
     }
     mutex.unlock(?runtime.lock);
-    os.io_queue_wake(?runtime.queue);
+    # live operations prevent queue destruction, so failure is unrecoverable corruption
+    if (os.io_queue_wake(?runtime.queue) < 0) {
+        panic.panic("std.io.runtime: open queue wake failed\n");
+    }
 }
 
 fun release_claim_locked(runtime: *Runtime, token: Token) {
     val slot: *Slot = ?runtime.slots[token.index::usize];
     slot.state = SLOT_FREE;
-    slot.cancellation.root = nil;
+    cancel.init_registration(?slot.cancellation);
     runtime.live = runtime.live - 1;
 }
 
@@ -386,6 +389,9 @@ fun attach_scope_locked(runtime: *Runtime, token: Token, scope: *cancel.Scope) c
 pub fun submit_scoped(runtime: *Runtime, scope: *cancel.Scope, operation: Operation) Result[Token, io_error.Error] {
     if (runtime == nil || scope == nil) { ret err[Token, io_error.Error](invalid(io_error.OP_SUBMIT)); }
     cancel.expire(scope, time.monotonic());
+    var deadline: time.Time;
+    var owner: *cancel.Scope;
+    val needs_wake: bool = cancel.get_deadline(scope, ?deadline, ?owner);
     mutex.lock(?runtime.lock);
     var token: Token;
     val code: i64 = claim_locked(runtime, operation, ?token);
@@ -393,18 +399,21 @@ pub fun submit_scoped(runtime: *Runtime, scope: *cancel.Scope, operation: Operat
         mutex.unlock(?runtime.lock);
         ret err[Token, io_error.Error](io_error.from_code(code, io_error.OP_SUBMIT));
     }
+    if (needs_wake) {
+        val wake_result: i64 = os.io_queue_wake(?runtime.queue);
+        if (wake_result < 0) {
+            release_claim_locked(runtime, token);
+            mutex.unlock(?runtime.lock);
+            ret err[Token, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE));
+        }
+    }
     val attached: cancel.Reason = attach_scope_locked(runtime, token, scope);
     if (attached != cancel.ACTIVE) {
         release_claim_locked(runtime, token);
         mutex.unlock(?runtime.lock);
         ret err[Token, io_error.Error](cancellation_error(attached));
     }
-    val has_deadline: bool = runtime.slots[token.index::usize].deadline_timer_index < runtime.timer_count;
     mutex.unlock(?runtime.lock);
-    if (has_deadline) {
-        val wake_result: i64 = os.io_queue_wake(?runtime.queue);
-        if (wake_result < 0) { ret err[Token, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE)); }
-    }
     ret ok[Token, io_error.Error](token);
 }
 
@@ -449,6 +458,12 @@ pub fun submit_timer(runtime: *Runtime, deadline: time.Time, context: usize) Res
     var token: Token;
     val code: i64 = claim_locked(runtime, operation, ?token);
     if (code == 0) {
+        val wake_result: i64 = os.io_queue_wake(?runtime.queue);
+        if (wake_result < 0) {
+            release_claim_locked(runtime, token);
+            mutex.unlock(?runtime.lock);
+            ret err[Token, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE));
+        }
         timer_push(runtime, TimerEntry{
             deadline: deadline,
             token: token,
@@ -458,8 +473,6 @@ pub fun submit_timer(runtime: *Runtime, deadline: time.Time, context: usize) Res
     }
     mutex.unlock(?runtime.lock);
     if (code < 0) { ret err[Token, io_error.Error](io_error.from_code(code, io_error.OP_SUBMIT)); }
-    val wake_result: i64 = os.io_queue_wake(?runtime.queue);
-    if (wake_result < 0) { ret err[Token, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE)); }
     ret ok[Token, io_error.Error](token);
 }
 
@@ -476,6 +489,12 @@ pub fun submit_timer_scoped(runtime: *Runtime, scope: *cancel.Scope, deadline: t
         mutex.unlock(?runtime.lock);
         ret err[Token, io_error.Error](io_error.from_code(code, io_error.OP_SUBMIT));
     }
+    val wake_result: i64 = os.io_queue_wake(?runtime.queue);
+    if (wake_result < 0) {
+        release_claim_locked(runtime, token);
+        mutex.unlock(?runtime.lock);
+        ret err[Token, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE));
+    }
     val attached: cancel.Reason = attach_scope_locked(runtime, token, scope);
     if (attached != cancel.ACTIVE) {
         release_claim_locked(runtime, token);
@@ -489,8 +508,6 @@ pub fun submit_timer_scoped(runtime: *Runtime, scope: *cancel.Scope, deadline: t
         scope: nil,
     });
     mutex.unlock(?runtime.lock);
-    val wake_result: i64 = os.io_queue_wake(?runtime.queue);
-    if (wake_result < 0) { ret err[Token, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE)); }
     ret ok[Token, io_error.Error](token);
 }
 
@@ -556,7 +573,7 @@ fun drain(runtime: *Runtime, output: *Completion, output_capacity: usize) usize 
         runtime.count = runtime.count - 1;
         val slot: *Slot = ?runtime.slots[completion.token.index::usize];
         slot.state = SLOT_FREE;
-        slot.cancellation.root = nil;
+        cancel.init_registration(?slot.cancellation);
         runtime.live = runtime.live - 1;
         written = written + 1;
     }
@@ -1225,6 +1242,24 @@ test "runtime scope: close remains distinct from cancellation" {
     val result: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 1, 0);
     if (is_err[usize, io_error.Error](result) || unwrap_ok[usize, io_error.Error](result) != 1) { ret 1; }
     if (!output[0].has_error || output[0].error.kind != io_error.CLOSED) { ret 1; }
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
+test "runtime scope: failed submission wake rolls ownership back" {
+    var runtime: Runtime;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    if (os.io_queue_close(?runtime.queue) < 0) { ret 1; }
+    val timer_result: Result[Token, io_error.Error] = submit_timer(?runtime, time.time_add(time.monotonic(), 1000000000), 61);
+    if (!is_err[Token, io_error.Error](timer_result) || pending(?runtime) != 0 || runtime.timer_count != 0) { ret 1; }
+
+    var scope: cancel.Scope;
+    if (!cancel.make_root(?scope, true, time.time_add(time.monotonic(), 1000000000))) { ret 1; }
+    val scoped_result: Result[Token, io_error.Error] = submit_scoped(?runtime, ?scope, test_operation(READ, 62));
+    if (!is_err[Token, io_error.Error](scoped_result) || pending(?runtime) != 0 || runtime.timer_count != 0) { ret 1; }
+    if (!cancel.destroy(?scope)) { ret 1; }
+
+    if (!is_err[bool, io_error.Error](close(?runtime))) { ret 1; }
     if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
     ret 0;
 }

--- a/src/io/runtime.mach
+++ b/src/io/runtime.mach
@@ -13,6 +13,7 @@ use std.types.result.unwrap_err;
 use std.system.os;
 use std.chrono.time;
 use std.sync.atomic;
+use std.sync.cancel;
 use std.sync.mutex;
 use std.sync.thread;
 use io_error: std.io.error;
@@ -63,13 +64,22 @@ val SLOT_QUEUED: u8 = 2;
 rec Slot {
     state: u8;
     generation: u32;
-    timer_index: usize;
+    index: u32;
+    runtime: *Runtime;
+    operation_timer_index: usize;
+    deadline_timer_index: usize;
+    cancellation: cancel.Registration;
     operation: Operation;
 }
+
+val TIMER_OPERATION: u8 = 0;
+val TIMER_SCOPE_DEADLINE: u8 = 1;
 
 rec TimerEntry {
     deadline: time.Time;
     token: Token;
+    purpose: u8;
+    scope: *cancel.Scope;
 }
 
 pub val OPEN: u8 = 0;
@@ -110,8 +120,9 @@ pub fun make(runtime: *Runtime, capacity: usize) Result[bool, io_error.Error] {
     val timer_size: usize = $size_of(TimerEntry);
     val slots_bytes: usize = slot_size * capacity;
     val completions_bytes: usize = completion_size * capacity;
-    val timers_bytes: usize = timer_size * capacity;
-    if (slots_bytes / slot_size != capacity || completions_bytes / completion_size != capacity || timers_bytes / timer_size != capacity) {
+    val timer_capacity: usize = capacity * 2;
+    val timers_bytes: usize = timer_size * timer_capacity;
+    if (slots_bytes / slot_size != capacity || completions_bytes / completion_size != capacity || timer_capacity / 2 != capacity || timers_bytes / timer_size != timer_capacity) {
         ret err[bool, io_error.Error](exhausted(io_error.OP_CREATE));
     }
 
@@ -145,7 +156,12 @@ pub fun make(runtime: *Runtime, capacity: usize) Result[bool, io_error.Error] {
     for (i < capacity) {
         runtime.slots[i].state = SLOT_FREE;
         runtime.slots[i].generation = 0;
-        runtime.slots[i].timer_index = capacity;
+        runtime.slots[i].index = i::u32;
+        runtime.slots[i].runtime = runtime;
+        runtime.slots[i].operation_timer_index = timer_capacity;
+        runtime.slots[i].deadline_timer_index = timer_capacity;
+        runtime.slots[i].cancellation.root = nil;
+        runtime.slots[i].cancellation.state = 0;
         i = i + 1;
     }
     val code: i64 = os.io_queue_create(?runtime.queue);
@@ -184,6 +200,9 @@ fun claim_locked(runtime: *Runtime, operation: Operation, token: *Token) i64 {
     if (generation == 0) { generation = 1; }
     runtime.slots[index].generation = generation;
     runtime.slots[index].operation = operation;
+    runtime.slots[index].operation_timer_index = timer_capacity(runtime);
+    runtime.slots[index].deadline_timer_index = timer_capacity(runtime);
+    runtime.slots[index].cancellation.root = nil;
     runtime.slots[index].state = SLOT_ACTIVE;
     runtime.live = runtime.live + 1;
     @token = Token{index: index::u32, generation: generation};
@@ -214,17 +233,31 @@ fun token_equal(a: Token, b: Token) bool {
 fun timer_less(a: TimerEntry, b: TimerEntry) bool {
     if (time.time_before(a.deadline, b.deadline)) { ret true; }
     if (time.time_after(a.deadline, b.deadline)) { ret false; }
+    if (a.purpose != b.purpose) { ret a.purpose == TIMER_SCOPE_DEADLINE; }
     if (a.token.index < b.token.index) { ret true; }
     if (a.token.index > b.token.index) { ret false; }
     ret a.token.generation < b.token.generation;
+}
+
+fun timer_capacity(runtime: *Runtime) usize {
+    ret runtime.capacity * 2;
+}
+
+fun timer_set_index(runtime: *Runtime, entry: TimerEntry, index: usize) {
+    val slot: *Slot = ?runtime.slots[entry.token.index::usize];
+    if (entry.purpose == TIMER_OPERATION) {
+        slot.operation_timer_index = index;
+    } or {
+        slot.deadline_timer_index = index;
+    }
 }
 
 fun timer_swap(runtime: *Runtime, a: usize, b: usize) {
     val entry: TimerEntry = runtime.timers[a];
     runtime.timers[a] = runtime.timers[b];
     runtime.timers[b] = entry;
-    runtime.slots[runtime.timers[a].token.index::usize].timer_index = a;
-    runtime.slots[runtime.timers[b].token.index::usize].timer_index = b;
+    timer_set_index(runtime, runtime.timers[a], a);
+    timer_set_index(runtime, runtime.timers[b], b);
 }
 
 fun timer_sift_up(runtime: *Runtime, start: usize) {
@@ -254,18 +287,18 @@ fun timer_sift_down(runtime: *Runtime, start: usize) {
 fun timer_push(runtime: *Runtime, entry: TimerEntry) {
     val index: usize = runtime.timer_count;
     runtime.timers[index] = entry;
-    runtime.slots[entry.token.index::usize].timer_index = index;
+    timer_set_index(runtime, entry, index);
     runtime.timer_count = runtime.timer_count + 1;
     timer_sift_up(runtime, index);
 }
 
 fun timer_remove_at(runtime: *Runtime, index: usize) TimerEntry {
     val removed: TimerEntry = runtime.timers[index];
-    runtime.slots[removed.token.index::usize].timer_index = runtime.capacity;
+    timer_set_index(runtime, removed, timer_capacity(runtime));
     runtime.timer_count = runtime.timer_count - 1;
     if (index < runtime.timer_count) {
         runtime.timers[index] = runtime.timers[runtime.timer_count];
-        runtime.slots[runtime.timers[index].token.index::usize].timer_index = index;
+        timer_set_index(runtime, runtime.timers[index], index);
         if (index > 0 && timer_less(runtime.timers[index], runtime.timers[(index - 1) / 2])) {
             timer_sift_up(runtime, index);
         } or {
@@ -275,11 +308,12 @@ fun timer_remove_at(runtime: *Runtime, index: usize) TimerEntry {
     ret removed;
 }
 
-fun timer_remove_token(runtime: *Runtime, token: Token) bool {
+fun timer_remove_token(runtime: *Runtime, token: Token, purpose: u8) bool {
     val slot: *Slot = slot_for(runtime, token);
-    if (slot == nil || slot.operation.kind != TIMER || slot.timer_index >= runtime.timer_count) { ret false; }
-    val index: usize = slot.timer_index;
-    if (!token_equal(runtime.timers[index].token, token)) { ret false; }
+    if (slot == nil) { ret false; }
+    var index: usize = slot.operation_timer_index;
+    if (purpose == TIMER_SCOPE_DEADLINE) { index = slot.deadline_timer_index; }
+    if (index >= runtime.timer_count || runtime.timers[index].purpose != purpose || !token_equal(runtime.timers[index].token, token)) { ret false; }
     timer_remove_at(runtime, index);
     ret true;
 }
@@ -300,6 +334,80 @@ fun enqueue(runtime: *Runtime, token: Token, slot: *Slot, bytes: usize, resource
     slot.state = SLOT_QUEUED;
 }
 
+fun cancellation_error(reason: cancel.Reason) io_error.Error {
+    if (reason == cancel.TIMED_OUT) { ret io_error.from_code(os.ETIMEDOUT, io_error.OP_WAIT); }
+    if (reason == cancel.CANCELLED) { ret io_error.from_code(os.ECANCELED, io_error.OP_WAIT); }
+    ret io_error.from_code(os.EBADF, io_error.OP_SUBMIT);
+}
+
+fun remove_slot_timers(runtime: *Runtime, token: Token) {
+    timer_remove_token(runtime, token, TIMER_OPERATION);
+    timer_remove_token(runtime, token, TIMER_SCOPE_DEADLINE);
+}
+
+fun scope_cancel_callback(context: ptr, reason: cancel.Reason) {
+    val slot: *Slot = context::*Slot;
+    val runtime: *Runtime = slot.runtime;
+    mutex.lock(?runtime.lock);
+    if (slot.state == SLOT_ACTIVE) {
+        val token: Token = Token{index: slot.index, generation: slot.generation};
+        remove_slot_timers(runtime, token);
+        enqueue(runtime, token, slot, 0, 0, true, cancellation_error(reason), false);
+    }
+    mutex.unlock(?runtime.lock);
+    os.io_queue_wake(?runtime.queue);
+}
+
+fun release_claim_locked(runtime: *Runtime, token: Token) {
+    val slot: *Slot = ?runtime.slots[token.index::usize];
+    slot.state = SLOT_FREE;
+    slot.cancellation.root = nil;
+    runtime.live = runtime.live - 1;
+}
+
+fun attach_scope_locked(runtime: *Runtime, token: Token, scope: *cancel.Scope) cancel.Reason {
+    val slot: *Slot = ?runtime.slots[token.index::usize];
+    val attached: cancel.Reason = cancel.attach(scope, ?slot.cancellation, scope_cancel_callback, slot::ptr);
+    if (attached != cancel.ACTIVE) { ret attached; }
+    var deadline: time.Time;
+    var owner: *cancel.Scope;
+    if (cancel.get_deadline(scope, ?deadline, ?owner)) {
+        timer_push(runtime, TimerEntry{
+            deadline: deadline,
+            token: token,
+            purpose: TIMER_SCOPE_DEADLINE,
+            scope: owner,
+        });
+    }
+    ret cancel.ACTIVE;
+}
+
+# prior cancellation is observed or the returned token is atomically scope-owned
+pub fun submit_scoped(runtime: *Runtime, scope: *cancel.Scope, operation: Operation) Result[Token, io_error.Error] {
+    if (runtime == nil || scope == nil) { ret err[Token, io_error.Error](invalid(io_error.OP_SUBMIT)); }
+    cancel.expire(scope, time.monotonic());
+    mutex.lock(?runtime.lock);
+    var token: Token;
+    val code: i64 = claim_locked(runtime, operation, ?token);
+    if (code < 0) {
+        mutex.unlock(?runtime.lock);
+        ret err[Token, io_error.Error](io_error.from_code(code, io_error.OP_SUBMIT));
+    }
+    val attached: cancel.Reason = attach_scope_locked(runtime, token, scope);
+    if (attached != cancel.ACTIVE) {
+        release_claim_locked(runtime, token);
+        mutex.unlock(?runtime.lock);
+        ret err[Token, io_error.Error](cancellation_error(attached));
+    }
+    val has_deadline: bool = runtime.slots[token.index::usize].deadline_timer_index < runtime.timer_count;
+    mutex.unlock(?runtime.lock);
+    if (has_deadline) {
+        val wake_result: i64 = os.io_queue_wake(?runtime.queue);
+        if (wake_result < 0) { ret err[Token, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE)); }
+    }
+    ret ok[Token, io_error.Error](token);
+}
+
 fun resolve(runtime: *Runtime, token: Token, bytes: usize, resource: usize, has_error: bool, failure: io_error.Error, eof: bool) Result[bool, io_error.Error] {
     if (runtime == nil) { ret err[bool, io_error.Error](invalid(io_error.OP_SUBMIT)); }
     mutex.lock(?runtime.lock);
@@ -308,7 +416,11 @@ fun resolve(runtime: *Runtime, token: Token, bytes: usize, resource: usize, has_
         mutex.unlock(?runtime.lock);
         ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_SUBMIT));
     }
-    if (slot.operation.kind == TIMER) { timer_remove_token(runtime, token); }
+    if (slot.cancellation.root != nil && !cancel.unregister(?slot.cancellation)) {
+        mutex.unlock(?runtime.lock);
+        ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_SUBMIT));
+    }
+    remove_slot_timers(runtime, token);
     enqueue(runtime, token, slot, bytes, resource, has_error, failure, eof);
     mutex.unlock(?runtime.lock);
     val wake_result: i64 = os.io_queue_wake(?runtime.queue);
@@ -336,9 +448,47 @@ pub fun submit_timer(runtime: *Runtime, deadline: time.Time, context: usize) Res
     mutex.lock(?runtime.lock);
     var token: Token;
     val code: i64 = claim_locked(runtime, operation, ?token);
-    if (code == 0) { timer_push(runtime, TimerEntry{deadline: deadline, token: token}); }
+    if (code == 0) {
+        timer_push(runtime, TimerEntry{
+            deadline: deadline,
+            token: token,
+            purpose: TIMER_OPERATION,
+            scope: nil,
+        });
+    }
     mutex.unlock(?runtime.lock);
     if (code < 0) { ret err[Token, io_error.Error](io_error.from_code(code, io_error.OP_SUBMIT)); }
+    val wake_result: i64 = os.io_queue_wake(?runtime.queue);
+    if (wake_result < 0) { ret err[Token, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE)); }
+    ret ok[Token, io_error.Error](token);
+}
+
+pub fun submit_timer_scoped(runtime: *Runtime, scope: *cancel.Scope, deadline: time.Time, context: usize) Result[Token, io_error.Error] {
+    if (runtime == nil || scope == nil || deadline.sec < 0 || deadline.nsec < 0 || deadline.nsec >= 1000000000) {
+        ret err[Token, io_error.Error](invalid(io_error.OP_SUBMIT));
+    }
+    cancel.expire(scope, time.monotonic());
+    val operation: Operation = Operation{kind: TIMER, resource: 0, buffer: nil, length: 0, offset: 0, context: context};
+    mutex.lock(?runtime.lock);
+    var token: Token;
+    val code: i64 = claim_locked(runtime, operation, ?token);
+    if (code < 0) {
+        mutex.unlock(?runtime.lock);
+        ret err[Token, io_error.Error](io_error.from_code(code, io_error.OP_SUBMIT));
+    }
+    val attached: cancel.Reason = attach_scope_locked(runtime, token, scope);
+    if (attached != cancel.ACTIVE) {
+        release_claim_locked(runtime, token);
+        mutex.unlock(?runtime.lock);
+        ret err[Token, io_error.Error](cancellation_error(attached));
+    }
+    timer_push(runtime, TimerEntry{
+        deadline: deadline,
+        token: token,
+        purpose: TIMER_OPERATION,
+        scope: nil,
+    });
+    mutex.unlock(?runtime.lock);
     val wake_result: i64 = os.io_queue_wake(?runtime.queue);
     if (wake_result < 0) { ret err[Token, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE)); }
     ret ok[Token, io_error.Error](token);
@@ -349,10 +499,15 @@ pub fun cancel_timer(runtime: *Runtime, token: Token) Result[bool, io_error.Erro
     if (runtime == nil) { ret err[bool, io_error.Error](invalid(io_error.OP_SUBMIT)); }
     mutex.lock(?runtime.lock);
     val slot: *Slot = slot_for(runtime, token);
-    if (slot == nil || slot.operation.kind != TIMER || !timer_remove_token(runtime, token)) {
+    if (slot == nil || slot.operation.kind != TIMER || !timer_remove_token(runtime, token, TIMER_OPERATION)) {
         mutex.unlock(?runtime.lock);
         ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_SUBMIT));
     }
+    if (slot.cancellation.root != nil && !cancel.unregister(?slot.cancellation)) {
+        mutex.unlock(?runtime.lock);
+        ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_SUBMIT));
+    }
+    timer_remove_token(runtime, token, TIMER_SCOPE_DEADLINE);
     enqueue(runtime, token, slot, 0, 0, true, io_error.from_code(os.ECANCELED, io_error.OP_WAIT), false);
     mutex.unlock(?runtime.lock);
     val wake_result: i64 = os.io_queue_wake(?runtime.queue);
@@ -360,15 +515,20 @@ pub fun cancel_timer(runtime: *Runtime, token: Token) Result[bool, io_error.Erro
     ret ok[bool, io_error.Error](true);
 }
 
-fun timers_expire(runtime: *Runtime, now: time.Time) {
+fun timers_expire(runtime: *Runtime, now: time.Time) *cancel.Scope {
     # all due timers enter the completion queue in deadline and token order
     for (runtime.timer_count > 0 && !time.time_before(now, runtime.timers[0].deadline)) {
         val entry: TimerEntry = timer_remove_at(runtime, 0);
         val slot: *Slot = slot_for(runtime, entry.token);
+        if (slot != nil && entry.purpose == TIMER_SCOPE_DEADLINE) { ret entry.scope; }
         if (slot != nil) {
-            enqueue(runtime, entry.token, slot, 0, 0, false, io_error.from_code(0, io_error.OP_UNKNOWN), false);
+            if (slot.cancellation.root == nil || cancel.unregister(?slot.cancellation)) {
+                timer_remove_token(runtime, entry.token, TIMER_SCOPE_DEADLINE);
+                enqueue(runtime, entry.token, slot, 0, 0, false, io_error.from_code(0, io_error.OP_UNKNOWN), false);
+            }
         }
     }
+    ret nil;
 }
 
 fun timer_timeout(runtime: *Runtime, requested_ms: i32, now: time.Time) i32 {
@@ -396,6 +556,7 @@ fun drain(runtime: *Runtime, output: *Completion, output_capacity: usize) usize 
         runtime.count = runtime.count - 1;
         val slot: *Slot = ?runtime.slots[completion.token.index::usize];
         slot.state = SLOT_FREE;
+        slot.cancellation.root = nil;
         runtime.live = runtime.live - 1;
         written = written + 1;
     }
@@ -409,8 +570,15 @@ pub fun wait(runtime: *Runtime, output: *Completion, output_capacity: usize, tim
         ret err[usize, io_error.Error](invalid(io_error.OP_WAIT));
     }
     mutex.lock(?runtime.lock);
-    val before: time.Time = time.monotonic();
-    timers_expire(runtime, before);
+    var before: time.Time = time.monotonic();
+    var expired_scope: *cancel.Scope = timers_expire(runtime, before);
+    for (expired_scope != nil) {
+        mutex.unlock(?runtime.lock);
+        cancel.timeout(expired_scope);
+        mutex.lock(?runtime.lock);
+        before = time.monotonic();
+        expired_scope = timers_expire(runtime, before);
+    }
     var written: usize = drain(runtime, output, output_capacity);
     if (written > 0 || runtime.state != OPEN) {
         mutex.unlock(?runtime.lock);
@@ -423,7 +591,13 @@ pub fun wait(runtime: *Runtime, output: *Completion, output_capacity: usize, tim
     if (waited < 0) { ret err[usize, io_error.Error](io_error.from_code(waited, io_error.OP_WAIT)); }
 
     mutex.lock(?runtime.lock);
-    timers_expire(runtime, time.monotonic());
+    expired_scope = timers_expire(runtime, time.monotonic());
+    for (expired_scope != nil) {
+        mutex.unlock(?runtime.lock);
+        cancel.timeout(expired_scope);
+        mutex.lock(?runtime.lock);
+        expired_scope = timers_expire(runtime, time.monotonic());
+    }
     written = drain(runtime, output, output_capacity);
     mutex.unlock(?runtime.lock);
     ret ok[usize, io_error.Error](written);
@@ -459,8 +633,14 @@ pub fun close(runtime: *Runtime) Result[bool, io_error.Error] {
     for (i < runtime.capacity) {
         val slot: *Slot = ?runtime.slots[i];
         if (slot.state == SLOT_ACTIVE) {
-            enqueue(runtime, Token{index: i::u32, generation: slot.generation}, slot, 0, 0, true, closed_error, false);
+            val token: Token = Token{index: i::u32, generation: slot.generation};
+            if (slot.cancellation.root == nil || cancel.unregister(?slot.cancellation)) {
+                remove_slot_timers(runtime, token);
+                enqueue(runtime, token, slot, 0, 0, true, closed_error, false);
+            }
         }
+        slot.operation_timer_index = timer_capacity(runtime);
+        slot.deadline_timer_index = timer_capacity(runtime);
         i = i + 1;
     }
     runtime.timer_count = 0;
@@ -488,7 +668,7 @@ pub fun destroy(runtime: *Runtime) Result[bool, io_error.Error] {
     mutex.unlock(?runtime.lock);
     val queue_result: i64 = os.io_queue_close(?runtime.queue);
     val completion_result: i64 = os.deallocate(completions::ptr, $size_of(Completion) * capacity);
-    val timer_result: i64 = os.deallocate(timers::ptr, $size_of(TimerEntry) * capacity);
+    val timer_result: i64 = os.deallocate(timers::ptr, $size_of(TimerEntry) * capacity * 2);
     val slot_result: i64 = os.deallocate(slots::ptr, $size_of(Slot) * capacity);
     runtime.slots = nil;
     runtime.completions = nil;
@@ -819,6 +999,232 @@ test "runtime timer: native wait uses monotonic deadlines" {
     if (count != 1 || output[0].context != 91 || output[0].has_error) { ret 1; }
     if (time.time_before(finished, deadline) || time.time_sub(finished, deadline) > 5000000000) { ret 1; }
     close(?runtime);
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
+test "runtime scope: prior cancellation rejects submission" {
+    var runtime: Runtime;
+    var scope: cancel.Scope;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    if (!cancel.make_root(?scope, false, time.Time{sec: 0, nsec: 0}) || !cancel.cancel(?scope)) { ret 1; }
+    val submitted: Result[Token, io_error.Error] = submit_scoped(?runtime, ?scope, test_operation(READ, 1));
+    if (!is_err[Token, io_error.Error](submitted) || unwrap_err[Token, io_error.Error](submitted).kind != io_error.CANCELLED) { ret 1; }
+    if (pending(?runtime) != 0 || !cancel.destroy(?scope)) { ret 1; }
+    close(?runtime);
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
+test "runtime scope: parent cancellation settles descendant work once" {
+    var runtime: Runtime;
+    var root: cancel.Scope;
+    var child: cancel.Scope;
+    val none: time.Time = time.Time{sec: 0, nsec: 0};
+    if (is_err[bool, io_error.Error](make(?runtime, 3))) { ret 1; }
+    if (!cancel.make_root(?root, false, none) || !cancel.make_child(?child, ?root, false, none)) { ret 1; }
+    var tokens: [3]Token;
+    val first: Result[Token, io_error.Error] = submit_scoped(?runtime, ?root, test_operation(READ, 10));
+    val second: Result[Token, io_error.Error] = submit_scoped(?runtime, ?child, test_operation(WRITE, 11));
+    val third: Result[Token, io_error.Error] = submit_timer_scoped(?runtime, ?child, time.time_add(time.monotonic(), 1000000000), 12);
+    if (is_err[Token, io_error.Error](first) || is_err[Token, io_error.Error](second) || is_err[Token, io_error.Error](third)) { ret 1; }
+    tokens[0] = unwrap_ok[Token, io_error.Error](first);
+    tokens[1] = unwrap_ok[Token, io_error.Error](second);
+    tokens[2] = unwrap_ok[Token, io_error.Error](third);
+    if (!cancel.cancel(?root) || cancel.cancel(?root)) { ret 1; }
+    var output: [3]Completion;
+    val result: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 3, 0);
+    if (is_err[usize, io_error.Error](result) || unwrap_ok[usize, io_error.Error](result) != 3) { ret 1; }
+    var i: usize = 0;
+    for (i < 3) {
+        if (!output[i].has_error || output[i].error.kind != io_error.CANCELLED) { ret 1; }
+        if (!is_err[bool, io_error.Error](complete(?runtime, tokens[i], 0, 0, false))) { ret 1; }
+        i = i + 1;
+    }
+    if (pending(?runtime) != 0 || !cancel.destroy(?child) || !cancel.destroy(?root)) { ret 1; }
+    close(?runtime);
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
+test "runtime scope: equal operation and scope deadlines prefer timeout" {
+    var runtime: Runtime;
+    var scope: cancel.Scope;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    val deadline: time.Time = time.time_add(time.monotonic(), 20000000);
+    if (!cancel.make_root(?scope, true, deadline)) { ret 1; }
+    val submitted: Result[Token, io_error.Error] = submit_timer_scoped(?runtime, ?scope, deadline, 21);
+    if (is_err[Token, io_error.Error](submitted)) { ret 1; }
+    var output: [1]Completion;
+    var count: usize = 0;
+    var attempts: usize = 0;
+    for (count == 0 && attempts < 4) {
+        val result: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 1, -1);
+        if (is_err[usize, io_error.Error](result)) { ret 1; }
+        count = unwrap_ok[usize, io_error.Error](result);
+        attempts = attempts + 1;
+    }
+    if (count != 1 || output[0].context != 21 || !output[0].has_error || output[0].error.kind != io_error.TIMEOUT) { ret 1; }
+    if (cancel.reason(?scope) != cancel.TIMED_OUT || !cancel.destroy(?scope)) { ret 1; }
+    close(?runtime);
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
+rec CompletionRaceContext {
+    runtime: *Runtime;
+    token: Token;
+    completed: *i64;
+}
+
+fun completion_race_worker(arg: *u8) {
+    val context: *CompletionRaceContext = arg::*CompletionRaceContext;
+    val result: Result[bool, io_error.Error] = complete(context.runtime, context.token, 1, 0, false);
+    if (is_err[bool, io_error.Error](result)) {
+        atomic.store(context.completed, 0);
+    } or {
+        atomic.store(context.completed, 1);
+    }
+}
+
+test "runtime scope: completion and cancellation races have one winner" {
+    var runtime: Runtime;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    var round: usize = 0;
+    for (round < 32) {
+        var scope: cancel.Scope;
+        if (!cancel.make_root(?scope, false, time.Time{sec: 0, nsec: 0})) { ret 1; }
+        val submitted: Result[Token, io_error.Error] = submit_scoped(?runtime, ?scope, test_operation(READ, round));
+        if (is_err[Token, io_error.Error](submitted)) { ret 1; }
+        var completed: i64 = -1;
+        var context: CompletionRaceContext = CompletionRaceContext{
+            runtime: ?runtime,
+            token: unwrap_ok[Token, io_error.Error](submitted),
+            completed: ?completed,
+        };
+        var worker: thread.Thread;
+        thread.spawn_with(completion_race_worker, (?context)::*u8, ?worker);
+        if (worker.tid < 0) { ret 1; }
+        cancel.cancel(?scope);
+        thread.join(?worker);
+        var output: [1]Completion;
+        val result: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 1, 0);
+        if (is_err[usize, io_error.Error](result) || unwrap_ok[usize, io_error.Error](result) != 1 || output[0].context != round) { ret 1; }
+        if (atomic.load(?completed) == 1 && output[0].has_error) { ret 1; }
+        if (atomic.load(?completed) == 0 && (!output[0].has_error || output[0].error.kind != io_error.CANCELLED)) { ret 1; }
+        if (!cancel.destroy(?scope) || pending(?runtime) != 0) { ret 1; }
+        round = round + 1;
+    }
+    close(?runtime);
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
+rec SubmissionRaceContext {
+    runtime: *Runtime;
+    scope: *cancel.Scope;
+    token: *Token;
+    submitted: *i64;
+}
+
+fun submission_race_worker(arg: *u8) {
+    val context: *SubmissionRaceContext = arg::*SubmissionRaceContext;
+    val result: Result[Token, io_error.Error] = submit_scoped(context.runtime, context.scope, test_operation(READ, 41));
+    if (is_err[Token, io_error.Error](result)) {
+        atomic.store(context.submitted, 0);
+    } or {
+        @context.token = unwrap_ok[Token, io_error.Error](result);
+        atomic.store(context.submitted, 1);
+    }
+}
+
+test "runtime scope: submission and cancellation races preserve ownership" {
+    var runtime: Runtime;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    var round: usize = 0;
+    for (round < 32) {
+        var scope: cancel.Scope;
+        if (!cancel.make_root(?scope, false, time.Time{sec: 0, nsec: 0})) { ret 1; }
+        var token: Token;
+        var submitted: i64 = -1;
+        var context: SubmissionRaceContext = SubmissionRaceContext{
+            runtime: ?runtime,
+            scope: ?scope,
+            token: ?token,
+            submitted: ?submitted,
+        };
+        var worker: thread.Thread;
+        thread.spawn_with(submission_race_worker, (?context)::*u8, ?worker);
+        if (worker.tid < 0) { ret 1; }
+        cancel.cancel(?scope);
+        thread.join(?worker);
+        if (atomic.load(?submitted) == 1) {
+            var output: [1]Completion;
+            val result: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 1, 0);
+            if (is_err[usize, io_error.Error](result) || unwrap_ok[usize, io_error.Error](result) != 1) { ret 1; }
+            if (!output[0].has_error || output[0].error.kind != io_error.CANCELLED || output[0].context != 41) { ret 1; }
+            if (!is_err[bool, io_error.Error](complete(?runtime, token, 0, 0, false))) { ret 1; }
+        } or (pending(?runtime) != 0) {
+            ret 1;
+        }
+        if (!cancel.destroy(?scope) || pending(?runtime) != 0) { ret 1; }
+        round = round + 1;
+    }
+    close(?runtime);
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
+rec ScopeTransitionContext {
+    scope: *cancel.Scope;
+}
+
+fun timeout_race_worker(arg: *u8) {
+    val context: *ScopeTransitionContext = arg::*ScopeTransitionContext;
+    cancel.timeout(context.scope);
+}
+
+test "runtime scope: deadline and cancellation races preserve the first reason" {
+    var runtime: Runtime;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    var round: usize = 0;
+    for (round < 32) {
+        var scope: cancel.Scope;
+        if (!cancel.make_root(?scope, false, time.Time{sec: 0, nsec: 0})) { ret 1; }
+        if (is_err[Token, io_error.Error](submit_scoped(?runtime, ?scope, test_operation(READ, 51)))) { ret 1; }
+        var context: ScopeTransitionContext = ScopeTransitionContext{scope: ?scope};
+        var worker: thread.Thread;
+        thread.spawn_with(timeout_race_worker, (?context)::*u8, ?worker);
+        if (worker.tid < 0) { ret 1; }
+        cancel.cancel(?scope);
+        thread.join(?worker);
+        var output: [1]Completion;
+        val result: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 1, 0);
+        if (is_err[usize, io_error.Error](result) || unwrap_ok[usize, io_error.Error](result) != 1) { ret 1; }
+        val scope_reason: cancel.Reason = cancel.reason(?scope);
+        if (!output[0].has_error || output[0].context != 51) { ret 1; }
+        if (scope_reason == cancel.CANCELLED && output[0].error.kind != io_error.CANCELLED) { ret 1; }
+        if (scope_reason == cancel.TIMED_OUT && output[0].error.kind != io_error.TIMEOUT) { ret 1; }
+        if ((scope_reason != cancel.CANCELLED && scope_reason != cancel.TIMED_OUT) || !cancel.destroy(?scope)) { ret 1; }
+        round = round + 1;
+    }
+    close(?runtime);
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
+test "runtime scope: close remains distinct from cancellation" {
+    var runtime: Runtime;
+    var scope: cancel.Scope;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    if (!cancel.make_root(?scope, false, time.Time{sec: 0, nsec: 0})) { ret 1; }
+    if (is_err[Token, io_error.Error](submit_scoped(?runtime, ?scope, test_operation(READ, 31)))) { ret 1; }
+    if (cancel.destroy(?scope) || is_err[bool, io_error.Error](close(?runtime))) { ret 1; }
+    if (!cancel.destroy(?scope)) { ret 1; }
+    var output: [1]Completion;
+    val result: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 1, 0);
+    if (is_err[usize, io_error.Error](result) || unwrap_ok[usize, io_error.Error](result) != 1) { ret 1; }
+    if (!output[0].has_error || output[0].error.kind != io_error.CLOSED) { ret 1; }
     if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
     ret 0;
 }

--- a/src/io/runtime.mach
+++ b/src/io/runtime.mach
@@ -354,11 +354,11 @@ fun scope_cancel_callback(context: ptr, reason: cancel.Reason) {
         remove_slot_timers(runtime, token);
         enqueue(runtime, token, slot, 0, 0, true, cancellation_error(reason), false);
     }
-    mutex.unlock(?runtime.lock);
     # live operations prevent queue destruction, so failure is unrecoverable corruption
     if (os.io_queue_wake(?runtime.queue) < 0) {
         panic.panic("std.io.runtime: open queue wake failed\n");
     }
+    mutex.unlock(?runtime.lock);
 }
 
 fun release_claim_locked(runtime: *Runtime, token: Token) {
@@ -431,8 +431,8 @@ fun resolve(runtime: *Runtime, token: Token, bytes: usize, resource: usize, has_
     }
     remove_slot_timers(runtime, token);
     enqueue(runtime, token, slot, bytes, resource, has_error, failure, eof);
-    mutex.unlock(?runtime.lock);
     val wake_result: i64 = os.io_queue_wake(?runtime.queue);
+    mutex.unlock(?runtime.lock);
     if (wake_result < 0) {
         ret err[bool, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE));
     }
@@ -526,8 +526,8 @@ pub fun cancel_timer(runtime: *Runtime, token: Token) Result[bool, io_error.Erro
     }
     timer_remove_token(runtime, token, TIMER_SCOPE_DEADLINE);
     enqueue(runtime, token, slot, 0, 0, true, io_error.from_code(os.ECANCELED, io_error.OP_WAIT), false);
-    mutex.unlock(?runtime.lock);
     val wake_result: i64 = os.io_queue_wake(?runtime.queue);
+    mutex.unlock(?runtime.lock);
     if (wake_result < 0) { ret err[bool, io_error.Error](io_error.from_code(wake_result, io_error.OP_WAKE)); }
     ret ok[bool, io_error.Error](true);
 }
@@ -627,9 +627,10 @@ pub fun wake(runtime: *Runtime) Result[bool, io_error.Error] {
     }
     mutex.lock(?runtime.lock);
     val destroyed: bool = runtime.state == DESTROYED;
+    var code: i64 = os.EINVAL;
+    if (!destroyed) { code = os.io_queue_wake(?runtime.queue); }
     mutex.unlock(?runtime.lock);
     if (destroyed) { ret err[bool, io_error.Error](invalid(io_error.OP_WAKE)); }
-    val code: i64 = os.io_queue_wake(?runtime.queue);
     if (code < 0) { ret err[bool, io_error.Error](io_error.from_code(code, io_error.OP_WAKE)); }
     ret ok[bool, io_error.Error](true);
 }
@@ -661,8 +662,8 @@ pub fun close(runtime: *Runtime) Result[bool, io_error.Error] {
         i = i + 1;
     }
     runtime.timer_count = 0;
-    mutex.unlock(?runtime.lock);
     val code: i64 = os.io_queue_wake(?runtime.queue);
+    mutex.unlock(?runtime.lock);
     if (code < 0) { ret err[bool, io_error.Error](io_error.from_code(code, io_error.OP_CLOSE)); }
     ret ok[bool, io_error.Error](true);
 }
@@ -1064,6 +1065,26 @@ test "runtime scope: parent cancellation settles descendant work once" {
     ret 0;
 }
 
+test "runtime scope: completion before cancellation remains successful" {
+    var runtime: Runtime;
+    var scope: cancel.Scope;
+    if (is_err[bool, io_error.Error](make(?runtime, 1))) { ret 1; }
+    if (!cancel.make_root(?scope, false, time.Time{sec: 0, nsec: 0})) { ret 1; }
+    val submitted: Result[Token, io_error.Error] = submit_scoped(?runtime, ?scope, test_operation(READ, 15));
+    if (is_err[Token, io_error.Error](submitted)) { ret 1; }
+    val token: Token = unwrap_ok[Token, io_error.Error](submitted);
+    if (is_err[bool, io_error.Error](complete(?runtime, token, 4, 0, false))) { ret 1; }
+    if (!cancel.cancel(?scope)) { ret 1; }
+    var output: [1]Completion;
+    val result: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 1, 0);
+    if (is_err[usize, io_error.Error](result) || unwrap_ok[usize, io_error.Error](result) != 1) { ret 1; }
+    if (output[0].has_error || output[0].bytes != 4 || output[0].context != 15) { ret 1; }
+    if (!cancel.destroy(?scope)) { ret 1; }
+    close(?runtime);
+    if (is_err[bool, io_error.Error](destroy(?runtime))) { ret 1; }
+    ret 0;
+}
+
 test "runtime scope: equal operation and scope deadlines prefer timeout" {
     var runtime: Runtime;
     var scope: cancel.Scope;
@@ -1237,6 +1258,7 @@ test "runtime scope: close remains distinct from cancellation" {
     if (!cancel.make_root(?scope, false, time.Time{sec: 0, nsec: 0})) { ret 1; }
     if (is_err[Token, io_error.Error](submit_scoped(?runtime, ?scope, test_operation(READ, 31)))) { ret 1; }
     if (cancel.destroy(?scope) || is_err[bool, io_error.Error](close(?runtime))) { ret 1; }
+    if (!cancel.cancel(?scope) || cancel.reason(?scope) != cancel.CANCELLED) { ret 1; }
     if (!cancel.destroy(?scope)) { ret 1; }
     var output: [1]Completion;
     val result: Result[usize, io_error.Error] = wait(?runtime, ?output[0], 1, 0);

--- a/src/io/runtime.mach
+++ b/src/io/runtime.mach
@@ -69,6 +69,7 @@ rec Slot {
     runtime: *Runtime;
     operation_timer_index: usize;
     deadline_timer_index: usize;
+    cancellation_active: bool;
     cancellation: cancel.Registration;
     operation: Operation;
 }
@@ -161,6 +162,7 @@ pub fun make(runtime: *Runtime, capacity: usize) Result[bool, io_error.Error] {
         runtime.slots[i].runtime = runtime;
         runtime.slots[i].operation_timer_index = timer_capacity;
         runtime.slots[i].deadline_timer_index = timer_capacity;
+        runtime.slots[i].cancellation_active = false;
         cancel.init_registration(?runtime.slots[i].cancellation);
         i = i + 1;
     }
@@ -202,6 +204,7 @@ fun claim_locked(runtime: *Runtime, operation: Operation, token: *Token) i64 {
     runtime.slots[index].operation = operation;
     runtime.slots[index].operation_timer_index = timer_capacity(runtime);
     runtime.slots[index].deadline_timer_index = timer_capacity(runtime);
+    runtime.slots[index].cancellation_active = false;
     cancel.init_registration(?runtime.slots[index].cancellation);
     runtime.slots[index].state = SLOT_ACTIVE;
     runtime.live = runtime.live + 1;
@@ -349,6 +352,7 @@ fun scope_cancel_callback(context: ptr, reason: cancel.Reason) {
     val slot: *Slot = context::*Slot;
     val runtime: *Runtime = slot.runtime;
     mutex.lock(?runtime.lock);
+    slot.cancellation_active = false;
     if (slot.state == SLOT_ACTIVE) {
         val token: Token = Token{index: slot.index, generation: slot.generation};
         remove_slot_timers(runtime, token);
@@ -364,6 +368,7 @@ fun scope_cancel_callback(context: ptr, reason: cancel.Reason) {
 fun release_claim_locked(runtime: *Runtime, token: Token) {
     val slot: *Slot = ?runtime.slots[token.index::usize];
     slot.state = SLOT_FREE;
+    slot.cancellation_active = false;
     cancel.init_registration(?slot.cancellation);
     runtime.live = runtime.live - 1;
 }
@@ -372,6 +377,7 @@ fun attach_scope_locked(runtime: *Runtime, token: Token, scope: *cancel.Scope) c
     val slot: *Slot = ?runtime.slots[token.index::usize];
     val attached: cancel.Reason = cancel.attach(scope, ?slot.cancellation, scope_cancel_callback, slot::ptr);
     if (attached != cancel.ACTIVE) { ret attached; }
+    slot.cancellation_active = true;
     var deadline: time.Time;
     var owner: *cancel.Scope;
     if (cancel.get_deadline(scope, ?deadline, ?owner)) {
@@ -425,10 +431,11 @@ fun resolve(runtime: *Runtime, token: Token, bytes: usize, resource: usize, has_
         mutex.unlock(?runtime.lock);
         ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_SUBMIT));
     }
-    if (slot.cancellation.root != nil && !cancel.unregister(?slot.cancellation)) {
+    if (slot.cancellation_active && !cancel.unregister(?slot.cancellation)) {
         mutex.unlock(?runtime.lock);
         ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_SUBMIT));
     }
+    slot.cancellation_active = false;
     remove_slot_timers(runtime, token);
     enqueue(runtime, token, slot, bytes, resource, has_error, failure, eof);
     val wake_result: i64 = os.io_queue_wake(?runtime.queue);
@@ -520,10 +527,11 @@ pub fun cancel_timer(runtime: *Runtime, token: Token) Result[bool, io_error.Erro
         mutex.unlock(?runtime.lock);
         ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_SUBMIT));
     }
-    if (slot.cancellation.root != nil && !cancel.unregister(?slot.cancellation)) {
+    if (slot.cancellation_active && !cancel.unregister(?slot.cancellation)) {
         mutex.unlock(?runtime.lock);
         ret err[bool, io_error.Error](io_error.from_code(os.EBADF, io_error.OP_SUBMIT));
     }
+    slot.cancellation_active = false;
     timer_remove_token(runtime, token, TIMER_SCOPE_DEADLINE);
     enqueue(runtime, token, slot, 0, 0, true, io_error.from_code(os.ECANCELED, io_error.OP_WAIT), false);
     val wake_result: i64 = os.io_queue_wake(?runtime.queue);
@@ -539,7 +547,8 @@ fun timers_expire(runtime: *Runtime, now: time.Time) *cancel.Scope {
         val slot: *Slot = slot_for(runtime, entry.token);
         if (slot != nil && entry.purpose == TIMER_SCOPE_DEADLINE) { ret entry.scope; }
         if (slot != nil) {
-            if (slot.cancellation.root == nil || cancel.unregister(?slot.cancellation)) {
+            if (!slot.cancellation_active || cancel.unregister(?slot.cancellation)) {
+                slot.cancellation_active = false;
                 timer_remove_token(runtime, entry.token, TIMER_SCOPE_DEADLINE);
                 enqueue(runtime, entry.token, slot, 0, 0, false, io_error.from_code(0, io_error.OP_UNKNOWN), false);
             }
@@ -573,6 +582,7 @@ fun drain(runtime: *Runtime, output: *Completion, output_capacity: usize) usize 
         runtime.count = runtime.count - 1;
         val slot: *Slot = ?runtime.slots[completion.token.index::usize];
         slot.state = SLOT_FREE;
+        slot.cancellation_active = false;
         cancel.init_registration(?slot.cancellation);
         runtime.live = runtime.live - 1;
         written = written + 1;
@@ -652,7 +662,8 @@ pub fun close(runtime: *Runtime) Result[bool, io_error.Error] {
         val slot: *Slot = ?runtime.slots[i];
         if (slot.state == SLOT_ACTIVE) {
             val token: Token = Token{index: i::u32, generation: slot.generation};
-            if (slot.cancellation.root == nil || cancel.unregister(?slot.cancellation)) {
+            if (!slot.cancellation_active || cancel.unregister(?slot.cancellation)) {
+                slot.cancellation_active = false;
                 remove_slot_timers(runtime, token);
                 enqueue(runtime, token, slot, 0, 0, true, closed_error, false);
             }

--- a/src/lib/libstd.mach
+++ b/src/lib/libstd.mach
@@ -85,7 +85,11 @@ fwd std.net.udp;
 fwd std.net.dns;
 
 fwd std.sync.atomic;
+fwd std.sync.cancel;
+fwd std.sync.condition;
 fwd std.sync.mutex;
+fwd std.sync.once;
+fwd std.sync.semaphore;
 fwd std.sync.thread;
 
 fwd std.log;

--- a/src/sync/cancel.mach
+++ b/src/sync/cancel.mach
@@ -24,6 +24,7 @@ val REG_ACTIVE:    i64 = 1;
 val REG_CANCELLED: i64 = 2;
 val REG_COMPLETED: i64 = 3;
 val REG_CLAIMING:  i64 = 4;
+val REG_DETACHING: i64 = 5;
 val GATE_CLOSED:   i64 = -1;
 
 pub rec Registration {
@@ -198,13 +199,11 @@ pub fun attach(scope: *Scope, registration: *Registration, callback: CancelFun, 
 
 # completion wins only while the registration remains owned by its scope
 pub fun unregister(registration: *Registration) bool {
-    if (registration == nil || registration.root == nil) { ret false; }
+    if (registration == nil) { ret false; }
+    var expected: i64 = REG_ACTIVE;
+    if (!atomic.cas(?registration.state, ?expected, REG_DETACHING)) { ret false; }
     val root: *Scope = registration.root;
     mutex.lock(?root.lock);
-    if (atomic.load(?registration.state) != REG_ACTIVE) {
-        mutex.unlock(?root.lock);
-        ret false;
-    }
     registration_remove(registration);
     registration.scope = nil;
     registration.root = nil;
@@ -233,13 +232,20 @@ fun mark_tree_locked(scope: *Scope, reason: Reason, callbacks: **Registration, c
             current.first_registration = nil;
             for (registration != nil) {
                 val next: *Registration = registration.next;
-                registration.prev = nil;
-                registration.next = @callbacks;
-                registration.scope = nil;
-                registration.reason = reason;
-                atomic.store(?registration.state, REG_CANCELLED);
-                @callbacks = registration;
-                @callback_count = @callback_count + 1;
+                var expected: i64 = REG_ACTIVE;
+                if (atomic.cas(?registration.state, ?expected, REG_CANCELLED)) {
+                    registration.prev = nil;
+                    registration.next = @callbacks;
+                    registration.scope = nil;
+                    registration.reason = reason;
+                    @callbacks = registration;
+                    @callback_count = @callback_count + 1;
+                } or {
+                    registration.prev = nil;
+                    registration.next = current.first_registration;
+                    if (current.first_registration != nil) { current.first_registration.prev = registration; }
+                    current.first_registration = registration;
+                }
                 registration = next;
             }
         }
@@ -474,6 +480,22 @@ fun attach_race_worker(arg: *u8) {
     atomic.store(context.result, attached);
 }
 
+rec UnregisterRaceContext {
+    registration: *Registration;
+    ready: *i64;
+    go: *i64;
+    result: *i64;
+}
+
+fun unregister_race_worker(arg: *u8) {
+    val context: *UnregisterRaceContext = arg::*UnregisterRaceContext;
+    atomic.store(context.ready, 1);
+    for (atomic.load(context.go) == 0) { atomic.spin_hint(); }
+    var result: i64 = 0;
+    if (unregister(context.registration)) { result = 1; }
+    atomic.store(context.result, result);
+}
+
 test "cancel scope: concurrent roots cannot claim one registration" {
     var first: Scope;
     var second: Scope;
@@ -504,6 +526,37 @@ test "cancel scope: concurrent roots cannot claim one registration" {
     cancel(?first);
     cancel(?second);
     if (atomic.load(?count) != 1 || !destroy(?first) || !destroy(?second)) { ret 1; }
+    ret 0;
+}
+
+test "cancel scope: unregister pins scope lifetime until removal" {
+    var round: usize = 0;
+    for (round < 256) {
+        var scope: Scope;
+        if (!make_root(?scope, false, time.Time{sec: 0, nsec: 0})) { ret 1; }
+        var count: i64 = 0;
+        var why: i64 = ACTIVE;
+        var callback: TestCallback = TestCallback{count: ?count, reason: ?why};
+        var registration: Registration;
+        init_registration(?registration);
+        if (attach(?scope, ?registration, test_callback, (?callback)::ptr) != ACTIVE) { ret 1; }
+        var ready: i64 = 0;
+        var go: i64 = 0;
+        var result: i64 = -1;
+        var context: UnregisterRaceContext = UnregisterRaceContext{registration: ?registration, ready: ?ready, go: ?go, result: ?result};
+        var worker: thread.Thread;
+        thread.spawn_with(unregister_race_worker, (?context)::*u8, ?worker);
+        if (worker.tid < 0) { ret 1; }
+        for (atomic.load(?ready) == 0) { atomic.spin_hint(); }
+        atomic.store(?go, 1);
+        if (!cancel(?scope)) { ret 1; }
+        val destroyed: bool = destroy(?scope);
+        thread.join(?worker);
+        val unregistered: bool = atomic.load(?result) == 1;
+        if (!destroyed && !destroy(?scope)) { ret 1; }
+        if ((unregistered && atomic.load(?count) != 0) || (!unregistered && (atomic.load(?count) != 1 || atomic.load(?why) != CANCELLED))) { ret 1; }
+        round = round + 1;
+    }
     ret 0;
 }
 

--- a/src/sync/cancel.mach
+++ b/src/sync/cancel.mach
@@ -33,6 +33,7 @@ pub rec Registration {
     prev: *Registration;
     next: *Registration;
     callback: CancelFun;
+    completion: CancelFun;
     context: ptr;
     reason: Reason;
     state: i64;
@@ -143,6 +144,7 @@ pub fun init_registration(registration: *Registration) bool {
     registration.prev = nil;
     registration.next = nil;
     registration.callback = (0::usize)::CancelFun;
+    registration.completion = (0::usize)::CancelFun;
     registration.context = nil;
     registration.reason = ACTIVE;
     registration.state = REG_UNUSED;
@@ -159,8 +161,7 @@ fun registration_remove(registration: *Registration) {
     if (registration.next != nil) { registration.next.prev = registration.prev; }
 }
 
-# successful registration is the ownership linearization point
-pub fun attach(scope: *Scope, registration: *Registration, callback: CancelFun, context: ptr) Reason {
+fun attach_internal(scope: *Scope, registration: *Registration, callback: CancelFun, completion: CancelFun, context: ptr) Reason {
     if (scope == nil || registration == nil || callback::usize == 0) { ret INVALID; }
     if (!scope_enter(scope)) { ret DESTROYED; }
     val registration_state: i64 = atomic.load(?registration.state);
@@ -188,6 +189,7 @@ pub fun attach(scope: *Scope, registration: *Registration, callback: CancelFun, 
     registration.next = scope.first_registration;
     if (scope.first_registration != nil) { scope.first_registration.prev = registration; }
     registration.callback = callback;
+    registration.completion = completion;
     registration.context = context;
     registration.reason = ACTIVE;
     atomic.store(?registration.state, REG_ACTIVE);
@@ -195,6 +197,24 @@ pub fun attach(scope: *Scope, registration: *Registration, callback: CancelFun, 
     mutex.unlock(?root.lock);
     scope_leave(scope);
     ret ACTIVE;
+}
+
+# successful registration is the ownership linearization point
+pub fun attach(scope: *Scope, registration: *Registration, callback: CancelFun, context: ptr) Reason {
+    ret attach_internal(scope, registration, callback, (0::usize)::CancelFun, context);
+}
+
+# completion publishes external work and must call finish under its lifetime lock
+pub fun attach_with_completion(scope: *Scope, registration: *Registration, callback: CancelFun, completion: CancelFun, context: ptr) Reason {
+    if (completion::usize == 0) { ret INVALID; }
+    ret attach_internal(scope, registration, callback, completion, context);
+}
+
+# this must be the completion hook's final registration operation
+pub fun finish(registration: *Registration) bool {
+    if (registration == nil) { ret false; }
+    var expected: i64 = REG_CANCELLED;
+    ret atomic.cas(?registration.state, ?expected, REG_COMPLETED);
 }
 
 # completion wins only while the registration remains owned by its scope
@@ -279,11 +299,16 @@ fun transition(scope: *Scope, reason: Reason) bool {
     for (registration != nil) {
         val next: *Registration = registration.next;
         val callback: CancelFun = registration.callback;
+        val completion: CancelFun = registration.completion;
         val context: ptr = registration.context;
         val callback_reason: Reason = registration.reason;
         registration.root = nil;
-        atomic.store(?registration.state, REG_COMPLETED);
         callback(context, callback_reason);
+        if (completion::usize == 0) {
+            finish(registration);
+        } or {
+            completion(context, callback_reason);
+        }
         registration = next;
     }
 
@@ -496,6 +521,33 @@ fun unregister_race_worker(arg: *u8) {
     atomic.store(context.result, result);
 }
 
+rec CallbackBlockContext {
+    count: *i64;
+    reason: *i64;
+    started: *i64;
+    release: *i64;
+}
+
+fun blocking_callback(context: ptr, why: Reason) {
+    val block: *CallbackBlockContext = context::*CallbackBlockContext;
+    atomic.store(block.started, 1);
+    for (atomic.load(block.release) == 0) { atomic.spin_hint(); }
+    atomic.fetch_add(block.count, 1);
+    atomic.store(block.reason, why);
+}
+
+rec CancelRaceContext {
+    scope: *Scope;
+    result: *i64;
+}
+
+fun cancel_race_worker(arg: *u8) {
+    val context: *CancelRaceContext = arg::*CancelRaceContext;
+    var result: i64 = 0;
+    if (cancel(context.scope)) { result = 1; }
+    atomic.store(context.result, result);
+}
+
 test "cancel scope: concurrent roots cannot claim one registration" {
     var first: Scope;
     var second: Scope;
@@ -557,6 +609,34 @@ test "cancel scope: unregister pins scope lifetime until removal" {
         if ((unregistered && atomic.load(?count) != 0) || (!unregistered && (atomic.load(?count) != 1 || atomic.load(?why) != CANCELLED))) { ret 1; }
         round = round + 1;
     }
+    ret 0;
+}
+
+test "cancel scope: registration reuse waits for callback return" {
+    var first: Scope;
+    var second: Scope;
+    val none: time.Time = time.Time{sec: 0, nsec: 0};
+    if (!make_root(?first, false, none) || !make_root(?second, false, none)) { ret 1; }
+    var count: i64 = 0;
+    var why: i64 = ACTIVE;
+    var started: i64 = 0;
+    var release: i64 = 0;
+    var block: CallbackBlockContext = CallbackBlockContext{count: ?count, reason: ?why, started: ?started, release: ?release};
+    var registration: Registration;
+    init_registration(?registration);
+    if (attach(?first, ?registration, blocking_callback, (?block)::ptr) != ACTIVE) { ret 1; }
+    var cancel_result: i64 = 0;
+    var context: CancelRaceContext = CancelRaceContext{scope: ?first, result: ?cancel_result};
+    var worker: thread.Thread;
+    thread.spawn_with(cancel_race_worker, (?context)::*u8, ?worker);
+    if (worker.tid < 0) { ret 1; }
+    for (atomic.load(?started) == 0) { atomic.spin_hint(); }
+    if (attach(?second, ?registration, blocking_callback, (?block)::ptr) != INVALID) { ret 1; }
+    atomic.store(?release, 1);
+    thread.join(?worker);
+    if (atomic.load(?cancel_result) != 1 || atomic.load(?count) != 1 || atomic.load(?why) != CANCELLED) { ret 1; }
+    if (attach(?second, ?registration, blocking_callback, (?block)::ptr) != ACTIVE) { ret 1; }
+    if (!cancel(?second) || atomic.load(?count) != 2 || !destroy(?first) || !destroy(?second)) { ret 1; }
     ret 0;
 }
 

--- a/src/sync/cancel.mach
+++ b/src/sync/cancel.mach
@@ -23,7 +23,7 @@ val REG_UNUSED:    i64 = 0;
 val REG_ACTIVE:    i64 = 1;
 val REG_CANCELLED: i64 = 2;
 val REG_COMPLETED: i64 = 3;
-val CLOSING:       i64 = 5;
+val GATE_CLOSED:   i64 = -1;
 
 pub rec Registration {
     root: *Scope;
@@ -48,7 +48,7 @@ pub rec Scope {
     has_deadline: bool;
     state: i64;
     waiters: i64;
-    entries: i64;
+    gate: i64;
     callback_count: usize;
     lock: mutex.Mutex;
 }
@@ -74,7 +74,7 @@ pub fun make_root(scope: *Scope, has_deadline: bool, deadline: time.Time) bool {
     if (has_deadline) { scope.deadline_owner = scope; }
     scope.state = ACTIVE;
     scope.waiters = 0;
-    scope.entries = 0;
+    scope.gate = 0;
     scope.callback_count = 0;
     scope.lock = mutex.make();
     ret true;
@@ -83,17 +83,17 @@ pub fun make_root(scope: *Scope, has_deadline: bool, deadline: time.Time) bool {
 # child deadlines inherit the earliest absolute monotonic ancestor deadline
 fun scope_enter(scope: *Scope) bool {
     if (scope == nil) { ret false; }
-    atomic.fetch_add(?scope.entries, 1);
-    val state: Reason = atomic.load(?scope.state);
-    if (state == DESTROYED || state == CLOSING) {
-        atomic.fetch_sub(?scope.entries, 1);
-        ret false;
+    for (true) {
+        val current: i64 = atomic.load(?scope.gate);
+        if (current == GATE_CLOSED) { ret false; }
+        var expected: i64 = current;
+        if (atomic.cas(?scope.gate, ?expected, current + 1)) { ret true; }
     }
-    ret true;
+    ret false;
 }
 
 fun scope_leave(scope: *Scope) {
-    atomic.fetch_sub(?scope.entries, 1);
+    atomic.fetch_sub(?scope.gate, 1);
 }
 
 pub fun make_child(scope: *Scope, parent: *Scope, has_deadline: bool, deadline: time.Time) bool {
@@ -125,7 +125,7 @@ pub fun make_child(scope: *Scope, parent: *Scope, has_deadline: bool, deadline: 
     }
     scope.state = atomic.load(?parent.state);
     scope.waiters = 0;
-    scope.entries = 0;
+    scope.gate = 0;
     scope.callback_count = 0;
     scope.lock = mutex.make();
     mutex.unlock(?root.lock);
@@ -348,14 +348,12 @@ pub fun destroy(scope: *Scope) bool {
     if (scope == nil || scope.root == nil) { ret false; }
     val root: *Scope = scope.root;
     mutex.lock(?root.lock);
-    val prior_state: Reason = atomic.load(?scope.state);
-    if (prior_state == DESTROYED || prior_state == CLOSING || scope.first_child != nil || scope.first_registration != nil || atomic.load(?scope.waiters) != 0 || root.callback_count != 0) {
+    if (atomic.load(?scope.state) == DESTROYED || scope.first_child != nil || scope.first_registration != nil || atomic.load(?scope.waiters) != 0 || root.callback_count != 0) {
         mutex.unlock(?root.lock);
         ret false;
     }
-    atomic.store(?scope.state, CLOSING);
-    if (atomic.load(?scope.entries) != 0) {
-        atomic.store(?scope.state, prior_state);
+    var expected: i64 = 0;
+    if (!atomic.cas(?scope.gate, ?expected, GATE_CLOSED)) {
         mutex.unlock(?root.lock);
         ret false;
     }
@@ -426,7 +424,8 @@ test "cancel scope: registration and destruction have one owner" {
     init_registration(?registration);
     if (attach(?scope, ?registration, test_callback, (?callback)::ptr) != ACTIVE) { ret 1; }
     if (destroy(?scope) || !unregister(?registration) || unregister(?registration)) { ret 1; }
-    if (!destroy(?scope) || atomic.load(?count) != 0) { ret 1; }
+    if (!destroy(?scope) || atomic.load(?count) != 0 || scope_enter(?scope)) { ret 1; }
+    if (!make_root(?scope, false, none) || !destroy(?scope)) { ret 1; }
     ret 0;
 }
 

--- a/src/sync/cancel.mach
+++ b/src/sync/cancel.mach
@@ -15,6 +15,7 @@ pub val ACTIVE:    Reason = 0;
 pub val CANCELLED: Reason = 1;
 pub val TIMED_OUT: Reason = 2;
 pub val DESTROYED: Reason = 3;
+pub val INVALID:   Reason = 4;
 
 pub def CancelFun: fun(ptr, Reason);
 
@@ -22,6 +23,7 @@ val REG_UNUSED:    i64 = 0;
 val REG_ACTIVE:    i64 = 1;
 val REG_CANCELLED: i64 = 2;
 val REG_COMPLETED: i64 = 3;
+val CLOSING:       i64 = 5;
 
 pub rec Registration {
     root: *Scope;
@@ -46,6 +48,7 @@ pub rec Scope {
     has_deadline: bool;
     state: i64;
     waiters: i64;
+    entries: i64;
     callback_count: usize;
     lock: mutex.Mutex;
 }
@@ -55,7 +58,8 @@ fun valid_deadline(has_deadline: bool, deadline: time.Time) bool {
     ret deadline.sec >= 0 && deadline.nsec >= 0 && deadline.nsec < 1000000000;
 }
 
-# scopes are fixed in memory from initialization through destruction
+# scopes are fixed in memory and own no target handle or allocation
+# callers stop starting new calls before reclaiming a destroyed scope
 pub fun make_root(scope: *Scope, has_deadline: bool, deadline: time.Time) bool {
     if (scope == nil || !valid_deadline(has_deadline, deadline)) { ret false; }
     scope.root = scope;
@@ -70,19 +74,35 @@ pub fun make_root(scope: *Scope, has_deadline: bool, deadline: time.Time) bool {
     if (has_deadline) { scope.deadline_owner = scope; }
     scope.state = ACTIVE;
     scope.waiters = 0;
+    scope.entries = 0;
     scope.callback_count = 0;
     scope.lock = mutex.make();
     ret true;
 }
 
 # child deadlines inherit the earliest absolute monotonic ancestor deadline
+fun scope_enter(scope: *Scope) bool {
+    if (scope == nil) { ret false; }
+    atomic.fetch_add(?scope.entries, 1);
+    val state: Reason = atomic.load(?scope.state);
+    if (state == DESTROYED || state == CLOSING) {
+        atomic.fetch_sub(?scope.entries, 1);
+        ret false;
+    }
+    ret true;
+}
+
+fun scope_leave(scope: *Scope) {
+    atomic.fetch_sub(?scope.entries, 1);
+}
+
 pub fun make_child(scope: *Scope, parent: *Scope, has_deadline: bool, deadline: time.Time) bool {
-    if (scope == nil || parent == nil || scope == parent || !valid_deadline(has_deadline, deadline)) { ret false; }
+    if (scope == nil || parent == nil || scope == parent || !valid_deadline(has_deadline, deadline) || !scope_enter(parent)) { ret false; }
     val root: *Scope = parent.root;
-    if (root == nil) { ret false; }
     mutex.lock(?root.lock);
     if (atomic.load(?parent.state) == DESTROYED) {
         mutex.unlock(?root.lock);
+        scope_leave(parent);
         ret false;
     }
     scope.root = root;
@@ -105,9 +125,25 @@ pub fun make_child(scope: *Scope, parent: *Scope, has_deadline: bool, deadline: 
     }
     scope.state = atomic.load(?parent.state);
     scope.waiters = 0;
+    scope.entries = 0;
     scope.callback_count = 0;
     scope.lock = mutex.make();
     mutex.unlock(?root.lock);
+    scope_leave(parent);
+    ret true;
+}
+
+# initialization is valid before first attachment or after terminal completion
+pub fun init_registration(registration: *Registration) bool {
+    if (registration == nil) { ret false; }
+    registration.root = nil;
+    registration.scope = nil;
+    registration.prev = nil;
+    registration.next = nil;
+    registration.callback = (0::usize)::CancelFun;
+    registration.context = nil;
+    registration.reason = ACTIVE;
+    registration.state = REG_UNUSED;
     ret true;
 }
 
@@ -123,13 +159,21 @@ fun registration_remove(registration: *Registration) {
 
 # successful registration is the ownership linearization point
 pub fun attach(scope: *Scope, registration: *Registration, callback: CancelFun, context: ptr) Reason {
-    if (scope == nil || registration == nil || callback::usize == 0 || scope.root == nil) { ret DESTROYED; }
+    if (scope == nil || registration == nil || callback::usize == 0) { ret INVALID; }
+    if (!scope_enter(scope)) { ret DESTROYED; }
     val root: *Scope = scope.root;
     mutex.lock(?root.lock);
     val state: Reason = atomic.load(?scope.state);
     if (state != ACTIVE) {
         mutex.unlock(?root.lock);
+        scope_leave(scope);
         ret state;
+    }
+    val registration_state: i64 = atomic.load(?registration.state);
+    if (registration_state != REG_UNUSED && registration_state != REG_COMPLETED) {
+        mutex.unlock(?root.lock);
+        scope_leave(scope);
+        ret INVALID;
     }
     registration.root = root;
     registration.scope = scope;
@@ -139,9 +183,10 @@ pub fun attach(scope: *Scope, registration: *Registration, callback: CancelFun, 
     registration.callback = callback;
     registration.context = context;
     registration.reason = ACTIVE;
-    registration.state = REG_ACTIVE;
+    atomic.store(?registration.state, REG_ACTIVE);
     scope.first_registration = registration;
     mutex.unlock(?root.lock);
+    scope_leave(scope);
     ret ACTIVE;
 }
 
@@ -150,7 +195,7 @@ pub fun unregister(registration: *Registration) bool {
     if (registration == nil || registration.root == nil) { ret false; }
     val root: *Scope = registration.root;
     mutex.lock(?root.lock);
-    if (registration.state != REG_ACTIVE) {
+    if (atomic.load(?registration.state) != REG_ACTIVE) {
         mutex.unlock(?root.lock);
         ret false;
     }
@@ -158,7 +203,7 @@ pub fun unregister(registration: *Registration) bool {
     registration.scope = nil;
     registration.root = nil;
     registration.reason = ACTIVE;
-    registration.state = REG_COMPLETED;
+    atomic.store(?registration.state, REG_COMPLETED);
     mutex.unlock(?root.lock);
     ret true;
 }
@@ -186,7 +231,7 @@ fun mark_tree_locked(scope: *Scope, reason: Reason, callbacks: **Registration, c
                 registration.next = @callbacks;
                 registration.scope = nil;
                 registration.reason = reason;
-                registration.state = REG_CANCELLED;
+                atomic.store(?registration.state, REG_CANCELLED);
                 @callbacks = registration;
                 @callback_count = @callback_count + 1;
                 registration = next;
@@ -204,13 +249,14 @@ fun mark_tree_locked(scope: *Scope, reason: Reason, callbacks: **Registration, c
 }
 
 fun transition(scope: *Scope, reason: Reason) bool {
-    if (scope == nil || scope.root == nil || reason == ACTIVE || reason == DESTROYED) { ret false; }
+    if (scope == nil || reason == ACTIVE || reason == DESTROYED || reason == INVALID || !scope_enter(scope)) { ret false; }
     val root: *Scope = scope.root;
     var callbacks: *Registration = nil;
     var callback_count: usize = 0;
     mutex.lock(?root.lock);
     if (atomic.load(?scope.state) != ACTIVE) {
         mutex.unlock(?root.lock);
+        scope_leave(scope);
         ret false;
     }
     mark_tree_locked(scope, reason, ?callbacks, ?callback_count);
@@ -220,13 +266,19 @@ fun transition(scope: *Scope, reason: Reason) bool {
     var registration: *Registration = callbacks;
     for (registration != nil) {
         val next: *Registration = registration.next;
-        registration.callback(registration.context, registration.reason);
+        val callback: CancelFun = registration.callback;
+        val context: ptr = registration.context;
+        val callback_reason: Reason = registration.reason;
+        registration.root = nil;
+        atomic.store(?registration.state, REG_COMPLETED);
+        callback(context, callback_reason);
         registration = next;
     }
 
     mutex.lock(?root.lock);
     root.callback_count = root.callback_count - callback_count;
     mutex.unlock(?root.lock);
+    scope_leave(scope);
     ret true;
 }
 
@@ -240,28 +292,43 @@ pub fun timeout(scope: *Scope) bool {
 
 # callers without a runtime may drive absolute deadlines explicitly
 pub fun expire(scope: *Scope, now: time.Time) bool {
-    if (scope == nil || !scope.has_deadline || time.time_before(now, scope.deadline)) { ret false; }
-    ret timeout(scope.deadline_owner);
+    if (scope == nil || !scope_enter(scope)) { ret false; }
+    val has_deadline: bool = scope.has_deadline;
+    val deadline: time.Time = scope.deadline;
+    val owner: *Scope = scope.deadline_owner;
+    scope_leave(scope);
+    if (!has_deadline || time.time_before(now, deadline)) { ret false; }
+    ret timeout(owner);
 }
 
 # returns the effective deadline and the ancestor that owns it
 pub fun get_deadline(scope: *Scope, deadline: *time.Time, owner: **Scope) bool {
-    if (scope == nil || deadline == nil || owner == nil || !scope.has_deadline) { ret false; }
+    if (scope == nil || deadline == nil || owner == nil || !scope_enter(scope)) { ret false; }
+    if (!scope.has_deadline) {
+        scope_leave(scope);
+        ret false;
+    }
     @deadline = scope.deadline;
     @owner = scope.deadline_owner;
+    scope_leave(scope);
     ret true;
 }
 
 pub fun reason(scope: *Scope) Reason {
-    if (scope == nil) { ret DESTROYED; }
-    ret atomic.load(?scope.state);
+    if (scope == nil || !scope_enter(scope)) { ret DESTROYED; }
+    val state: Reason = atomic.load(?scope.state);
+    scope_leave(scope);
+    ret state;
 }
 
 pub fun wait(scope: *Scope) Reason {
-    if (scope == nil) { ret DESTROYED; }
+    if (scope == nil || !scope_enter(scope)) { ret DESTROYED; }
     for (true) {
         val observed: Reason = atomic.load(?scope.state);
-        if (observed != ACTIVE) { ret observed; }
+        if (observed != ACTIVE) {
+            scope_leave(scope);
+            ret observed;
+        }
         atomic.fetch_add(?scope.waiters, 1);
         if (atomic.load(?scope.state) == ACTIVE) { os.thread_wait(?scope.state, ACTIVE); }
         atomic.fetch_sub(?scope.waiters, 1);
@@ -270,8 +337,10 @@ pub fun wait(scope: *Scope) Reason {
 }
 
 pub fun waiter_count(scope: *Scope) i64 {
-    if (scope == nil) { ret 0; }
-    ret atomic.load(?scope.waiters);
+    if (scope == nil || !scope_enter(scope)) { ret 0; }
+    val count: i64 = atomic.load(?scope.waiters);
+    scope_leave(scope);
+    ret count;
 }
 
 # destruction rejects children, live registrations, waiters, and callbacks
@@ -279,7 +348,14 @@ pub fun destroy(scope: *Scope) bool {
     if (scope == nil || scope.root == nil) { ret false; }
     val root: *Scope = scope.root;
     mutex.lock(?root.lock);
-    if (atomic.load(?scope.state) == DESTROYED || scope.first_child != nil || scope.first_registration != nil || atomic.load(?scope.waiters) != 0 || root.callback_count != 0) {
+    val prior_state: Reason = atomic.load(?scope.state);
+    if (prior_state == DESTROYED || prior_state == CLOSING || scope.first_child != nil || scope.first_registration != nil || atomic.load(?scope.waiters) != 0 || root.callback_count != 0) {
+        mutex.unlock(?root.lock);
+        ret false;
+    }
+    atomic.store(?scope.state, CLOSING);
+    if (atomic.load(?scope.entries) != 0) {
+        atomic.store(?scope.state, prior_state);
         mutex.unlock(?root.lock);
         ret false;
     }
@@ -293,8 +369,6 @@ pub fun destroy(scope: *Scope) bool {
     }
     atomic.store(?scope.state, DESTROYED);
     mutex.unlock(?root.lock);
-    scope.root = nil;
-    scope.parent = nil;
     ret true;
 }
 
@@ -324,6 +398,9 @@ test "cancel scope: parent cancellation reaches every descendant once" {
     callbacks[0] = TestCallback{count: ?counts[0], reason: ?reasons[0]};
     callbacks[1] = TestCallback{count: ?counts[1], reason: ?reasons[1]};
     callbacks[2] = TestCallback{count: ?counts[2], reason: ?reasons[2]};
+    init_registration(?registrations[0]);
+    init_registration(?registrations[1]);
+    init_registration(?registrations[2]);
     if (attach(?root, ?registrations[0], test_callback, (?callbacks[0])::ptr) != ACTIVE) { ret 1; }
     if (attach(?child, ?registrations[1], test_callback, (?callbacks[1])::ptr) != ACTIVE) { ret 1; }
     if (attach(?grandchild, ?registrations[2], test_callback, (?callbacks[2])::ptr) != ACTIVE) { ret 1; }
@@ -346,9 +423,28 @@ test "cancel scope: registration and destruction have one owner" {
     var why: i64 = ACTIVE;
     var callback: TestCallback = TestCallback{count: ?count, reason: ?why};
     var registration: Registration;
+    init_registration(?registration);
     if (attach(?scope, ?registration, test_callback, (?callback)::ptr) != ACTIVE) { ret 1; }
     if (destroy(?scope) || !unregister(?registration) || unregister(?registration)) { ret 1; }
     if (!destroy(?scope) || atomic.load(?count) != 0) { ret 1; }
+    ret 0;
+}
+
+test "cancel scope: active registrations cannot be attached twice" {
+    var root: Scope;
+    var other: Scope;
+    val none: time.Time = time.Time{sec: 0, nsec: 0};
+    if (!make_root(?root, false, none) || !make_root(?other, false, none)) { ret 1; }
+    var count: i64 = 0;
+    var why: i64 = ACTIVE;
+    var callback: TestCallback = TestCallback{count: ?count, reason: ?why};
+    var registration: Registration;
+    init_registration(?registration);
+    if (attach(?root, ?registration, test_callback, (?callback)::ptr) != ACTIVE) { ret 1; }
+    if (attach(?root, ?registration, test_callback, (?callback)::ptr) != INVALID) { ret 1; }
+    if (attach(?other, ?registration, test_callback, (?callback)::ptr) != INVALID) { ret 1; }
+    if (!cancel(?root) || atomic.load(?count) != 1 || atomic.load(?why) != CANCELLED) { ret 1; }
+    if (!destroy(?root) || !destroy(?other)) { ret 1; }
     ret 0;
 }
 
@@ -385,6 +481,7 @@ test "cancel scope: native wait observes cancellation without spinning" {
     thread.spawn_with(wait_worker, (?context)::*u8, ?worker);
     if (worker.tid < 0) { ret 1; }
     for (waiter_count(?scope) == 0) { atomic.spin_hint(); }
+    if (destroy(?scope)) { ret 1; }
     if (!cancel(?scope)) { ret 1; }
     thread.join(?worker);
     if (atomic.load(?result) != CANCELLED || waiter_count(?scope) != 0 || !destroy(?scope)) { ret 1; }

--- a/src/sync/cancel.mach
+++ b/src/sync/cancel.mach
@@ -1,0 +1,421 @@
+# caller-owned hierarchical cancellation
+
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.chrono.time;
+use std.sync.atomic;
+use std.sync.mutex;
+use std.sync.thread;
+use std.system.os;
+
+pub def Reason: i64;
+pub val ACTIVE:    Reason = 0;
+pub val CANCELLED: Reason = 1;
+pub val TIMED_OUT: Reason = 2;
+pub val DESTROYED: Reason = 3;
+
+pub def CancelFun: fun(ptr, Reason);
+
+val REG_UNUSED:    i64 = 0;
+val REG_ACTIVE:    i64 = 1;
+val REG_CANCELLED: i64 = 2;
+val REG_COMPLETED: i64 = 3;
+
+pub rec Registration {
+    root: *Scope;
+    scope: *Scope;
+    prev: *Registration;
+    next: *Registration;
+    callback: CancelFun;
+    context: ptr;
+    reason: Reason;
+    state: i64;
+}
+
+pub rec Scope {
+    root: *Scope;
+    parent: *Scope;
+    first_child: *Scope;
+    prev_sibling: *Scope;
+    next_sibling: *Scope;
+    first_registration: *Registration;
+    deadline: time.Time;
+    deadline_owner: *Scope;
+    has_deadline: bool;
+    state: i64;
+    waiters: i64;
+    callback_count: usize;
+    lock: mutex.Mutex;
+}
+
+fun valid_deadline(has_deadline: bool, deadline: time.Time) bool {
+    if (!has_deadline) { ret true; }
+    ret deadline.sec >= 0 && deadline.nsec >= 0 && deadline.nsec < 1000000000;
+}
+
+# scopes are fixed in memory from initialization through destruction
+pub fun make_root(scope: *Scope, has_deadline: bool, deadline: time.Time) bool {
+    if (scope == nil || !valid_deadline(has_deadline, deadline)) { ret false; }
+    scope.root = scope;
+    scope.parent = nil;
+    scope.first_child = nil;
+    scope.prev_sibling = nil;
+    scope.next_sibling = nil;
+    scope.first_registration = nil;
+    scope.deadline = deadline;
+    scope.deadline_owner = nil;
+    scope.has_deadline = has_deadline;
+    if (has_deadline) { scope.deadline_owner = scope; }
+    scope.state = ACTIVE;
+    scope.waiters = 0;
+    scope.callback_count = 0;
+    scope.lock = mutex.make();
+    ret true;
+}
+
+# child deadlines inherit the earliest absolute monotonic ancestor deadline
+pub fun make_child(scope: *Scope, parent: *Scope, has_deadline: bool, deadline: time.Time) bool {
+    if (scope == nil || parent == nil || scope == parent || !valid_deadline(has_deadline, deadline)) { ret false; }
+    val root: *Scope = parent.root;
+    if (root == nil) { ret false; }
+    mutex.lock(?root.lock);
+    if (atomic.load(?parent.state) == DESTROYED) {
+        mutex.unlock(?root.lock);
+        ret false;
+    }
+    scope.root = root;
+    scope.parent = parent;
+    scope.first_child = nil;
+    scope.prev_sibling = nil;
+    scope.next_sibling = parent.first_child;
+    if (parent.first_child != nil) { parent.first_child.prev_sibling = scope; }
+    parent.first_child = scope;
+    scope.first_registration = nil;
+    scope.has_deadline = has_deadline;
+    scope.deadline = deadline;
+    scope.deadline_owner = nil;
+    if (parent.has_deadline && (!has_deadline || !time.time_before(deadline, parent.deadline))) {
+        scope.has_deadline = true;
+        scope.deadline = parent.deadline;
+        scope.deadline_owner = parent.deadline_owner;
+    } or (has_deadline) {
+        scope.deadline_owner = scope;
+    }
+    scope.state = atomic.load(?parent.state);
+    scope.waiters = 0;
+    scope.callback_count = 0;
+    scope.lock = mutex.make();
+    mutex.unlock(?root.lock);
+    ret true;
+}
+
+fun registration_remove(registration: *Registration) {
+    val scope: *Scope = registration.scope;
+    if (registration.prev != nil) {
+        registration.prev.next = registration.next;
+    } or {
+        scope.first_registration = registration.next;
+    }
+    if (registration.next != nil) { registration.next.prev = registration.prev; }
+}
+
+# successful registration is the ownership linearization point
+pub fun attach(scope: *Scope, registration: *Registration, callback: CancelFun, context: ptr) Reason {
+    if (scope == nil || registration == nil || callback::usize == 0 || scope.root == nil) { ret DESTROYED; }
+    val root: *Scope = scope.root;
+    mutex.lock(?root.lock);
+    val state: Reason = atomic.load(?scope.state);
+    if (state != ACTIVE) {
+        mutex.unlock(?root.lock);
+        ret state;
+    }
+    registration.root = root;
+    registration.scope = scope;
+    registration.prev = nil;
+    registration.next = scope.first_registration;
+    if (scope.first_registration != nil) { scope.first_registration.prev = registration; }
+    registration.callback = callback;
+    registration.context = context;
+    registration.reason = ACTIVE;
+    registration.state = REG_ACTIVE;
+    scope.first_registration = registration;
+    mutex.unlock(?root.lock);
+    ret ACTIVE;
+}
+
+# completion wins only while the registration remains owned by its scope
+pub fun unregister(registration: *Registration) bool {
+    if (registration == nil || registration.root == nil) { ret false; }
+    val root: *Scope = registration.root;
+    mutex.lock(?root.lock);
+    if (registration.state != REG_ACTIVE) {
+        mutex.unlock(?root.lock);
+        ret false;
+    }
+    registration_remove(registration);
+    registration.scope = nil;
+    registration.root = nil;
+    registration.reason = ACTIVE;
+    registration.state = REG_COMPLETED;
+    mutex.unlock(?root.lock);
+    ret true;
+}
+
+fun wake_scope(scope: *Scope) {
+    val waiters: i64 = atomic.load(?scope.waiters);
+    var i: i64 = 0;
+    for (i < waiters) {
+        os.thread_wake(?scope.state);
+        i = i + 1;
+    }
+}
+
+fun mark_tree_locked(scope: *Scope, reason: Reason, callbacks: **Registration, callback_count: *usize) {
+    var current: *Scope = scope;
+    for (current != nil) {
+        if (atomic.load(?current.state) == ACTIVE) {
+            atomic.store(?current.state, reason);
+            wake_scope(current);
+            var registration: *Registration = current.first_registration;
+            current.first_registration = nil;
+            for (registration != nil) {
+                val next: *Registration = registration.next;
+                registration.prev = nil;
+                registration.next = @callbacks;
+                registration.scope = nil;
+                registration.reason = reason;
+                registration.state = REG_CANCELLED;
+                @callbacks = registration;
+                @callback_count = @callback_count + 1;
+                registration = next;
+            }
+        }
+
+        if (current.first_child != nil) {
+            current = current.first_child;
+        } or {
+            for (current != scope && current.next_sibling == nil) { current = current.parent; }
+            if (current == scope) { ret; }
+            current = current.next_sibling;
+        }
+    }
+}
+
+fun transition(scope: *Scope, reason: Reason) bool {
+    if (scope == nil || scope.root == nil || reason == ACTIVE || reason == DESTROYED) { ret false; }
+    val root: *Scope = scope.root;
+    var callbacks: *Registration = nil;
+    var callback_count: usize = 0;
+    mutex.lock(?root.lock);
+    if (atomic.load(?scope.state) != ACTIVE) {
+        mutex.unlock(?root.lock);
+        ret false;
+    }
+    mark_tree_locked(scope, reason, ?callbacks, ?callback_count);
+    root.callback_count = root.callback_count + callback_count;
+    mutex.unlock(?root.lock);
+
+    var registration: *Registration = callbacks;
+    for (registration != nil) {
+        val next: *Registration = registration.next;
+        registration.callback(registration.context, registration.reason);
+        registration = next;
+    }
+
+    mutex.lock(?root.lock);
+    root.callback_count = root.callback_count - callback_count;
+    mutex.unlock(?root.lock);
+    ret true;
+}
+
+pub fun cancel(scope: *Scope) bool {
+    ret transition(scope, CANCELLED);
+}
+
+pub fun timeout(scope: *Scope) bool {
+    ret transition(scope, TIMED_OUT);
+}
+
+# callers without a runtime may drive absolute deadlines explicitly
+pub fun expire(scope: *Scope, now: time.Time) bool {
+    if (scope == nil || !scope.has_deadline || time.time_before(now, scope.deadline)) { ret false; }
+    ret timeout(scope.deadline_owner);
+}
+
+# returns the effective deadline and the ancestor that owns it
+pub fun get_deadline(scope: *Scope, deadline: *time.Time, owner: **Scope) bool {
+    if (scope == nil || deadline == nil || owner == nil || !scope.has_deadline) { ret false; }
+    @deadline = scope.deadline;
+    @owner = scope.deadline_owner;
+    ret true;
+}
+
+pub fun reason(scope: *Scope) Reason {
+    if (scope == nil) { ret DESTROYED; }
+    ret atomic.load(?scope.state);
+}
+
+pub fun wait(scope: *Scope) Reason {
+    if (scope == nil) { ret DESTROYED; }
+    for (true) {
+        val observed: Reason = atomic.load(?scope.state);
+        if (observed != ACTIVE) { ret observed; }
+        atomic.fetch_add(?scope.waiters, 1);
+        if (atomic.load(?scope.state) == ACTIVE) { os.thread_wait(?scope.state, ACTIVE); }
+        atomic.fetch_sub(?scope.waiters, 1);
+    }
+    ret DESTROYED;
+}
+
+pub fun waiter_count(scope: *Scope) i64 {
+    if (scope == nil) { ret 0; }
+    ret atomic.load(?scope.waiters);
+}
+
+# destruction rejects children, live registrations, waiters, and callbacks
+pub fun destroy(scope: *Scope) bool {
+    if (scope == nil || scope.root == nil) { ret false; }
+    val root: *Scope = scope.root;
+    mutex.lock(?root.lock);
+    if (atomic.load(?scope.state) == DESTROYED || scope.first_child != nil || scope.first_registration != nil || atomic.load(?scope.waiters) != 0 || root.callback_count != 0) {
+        mutex.unlock(?root.lock);
+        ret false;
+    }
+    if (scope.parent != nil) {
+        if (scope.prev_sibling != nil) {
+            scope.prev_sibling.next_sibling = scope.next_sibling;
+        } or {
+            scope.parent.first_child = scope.next_sibling;
+        }
+        if (scope.next_sibling != nil) { scope.next_sibling.prev_sibling = scope.prev_sibling; }
+    }
+    atomic.store(?scope.state, DESTROYED);
+    mutex.unlock(?root.lock);
+    scope.root = nil;
+    scope.parent = nil;
+    ret true;
+}
+
+rec TestCallback {
+    count: *i64;
+    reason: *i64;
+}
+
+fun test_callback(context: ptr, why: Reason) {
+    val callback: *TestCallback = context::*TestCallback;
+    atomic.fetch_add(callback.count, 1);
+    atomic.store(callback.reason, why);
+}
+
+test "cancel scope: parent cancellation reaches every descendant once" {
+    var root: Scope;
+    var child: Scope;
+    var grandchild: Scope;
+    val none: time.Time = time.Time{sec: 0, nsec: 0};
+    if (!make_root(?root, false, none)) { ret 1; }
+    if (!make_child(?child, ?root, false, none)) { ret 1; }
+    if (!make_child(?grandchild, ?child, false, none)) { ret 1; }
+    var counts: [3]i64;
+    var reasons: [3]i64;
+    var callbacks: [3]TestCallback;
+    var registrations: [3]Registration;
+    callbacks[0] = TestCallback{count: ?counts[0], reason: ?reasons[0]};
+    callbacks[1] = TestCallback{count: ?counts[1], reason: ?reasons[1]};
+    callbacks[2] = TestCallback{count: ?counts[2], reason: ?reasons[2]};
+    if (attach(?root, ?registrations[0], test_callback, (?callbacks[0])::ptr) != ACTIVE) { ret 1; }
+    if (attach(?child, ?registrations[1], test_callback, (?callbacks[1])::ptr) != ACTIVE) { ret 1; }
+    if (attach(?grandchild, ?registrations[2], test_callback, (?callbacks[2])::ptr) != ACTIVE) { ret 1; }
+    if (!cancel(?root) || cancel(?root)) { ret 1; }
+    var i: usize = 0;
+    for (i < 3) {
+        if (atomic.load(?counts[i]) != 1 || atomic.load(?reasons[i]) != CANCELLED || unregister(?registrations[i])) { ret 1; }
+        i = i + 1;
+    }
+    if (destroy(?root) || destroy(?child)) { ret 1; }
+    if (!destroy(?grandchild) || !destroy(?child) || !destroy(?root)) { ret 1; }
+    ret 0;
+}
+
+test "cancel scope: registration and destruction have one owner" {
+    var scope: Scope;
+    val none: time.Time = time.Time{sec: 0, nsec: 0};
+    if (!make_root(?scope, false, none)) { ret 1; }
+    var count: i64 = 0;
+    var why: i64 = ACTIVE;
+    var callback: TestCallback = TestCallback{count: ?count, reason: ?why};
+    var registration: Registration;
+    if (attach(?scope, ?registration, test_callback, (?callback)::ptr) != ACTIVE) { ret 1; }
+    if (destroy(?scope) || !unregister(?registration) || unregister(?registration)) { ret 1; }
+    if (!destroy(?scope) || atomic.load(?count) != 0) { ret 1; }
+    ret 0;
+}
+
+test "cancel scope: inherited monotonic deadlines preserve the first reason" {
+    var root: Scope;
+    var child: Scope;
+    val parent_deadline: time.Time = time.Time{sec: 10, nsec: 0};
+    val child_deadline: time.Time = time.Time{sec: 20, nsec: 0};
+    if (!make_root(?root, true, parent_deadline)) { ret 1; }
+    if (!make_child(?child, ?root, true, child_deadline)) { ret 1; }
+    if (expire(?child, time.Time{sec: 9, nsec: 999999999})) { ret 1; }
+    if (!expire(?child, parent_deadline) || reason(?root) != TIMED_OUT || reason(?child) != TIMED_OUT) { ret 1; }
+    if (cancel(?root)) { ret 1; }
+    if (!destroy(?child) || !destroy(?root)) { ret 1; }
+    ret 0;
+}
+
+rec WaitContext {
+    scope: *Scope;
+    result: *i64;
+}
+
+fun wait_worker(arg: *u8) {
+    val context: *WaitContext = arg::*WaitContext;
+    atomic.store(context.result, wait(context.scope));
+}
+
+test "cancel scope: native wait observes cancellation without spinning" {
+    var scope: Scope;
+    if (!make_root(?scope, false, time.Time{sec: 0, nsec: 0})) { ret 1; }
+    var result: i64 = ACTIVE;
+    var context: WaitContext = WaitContext{scope: ?scope, result: ?result};
+    var worker: thread.Thread;
+    thread.spawn_with(wait_worker, (?context)::*u8, ?worker);
+    if (worker.tid < 0) { ret 1; }
+    for (waiter_count(?scope) == 0) { atomic.spin_hint(); }
+    if (!cancel(?scope)) { ret 1; }
+    thread.join(?worker);
+    if (atomic.load(?result) != CANCELLED || waiter_count(?scope) != 0 || !destroy(?scope)) { ret 1; }
+    ret 0;
+}
+
+test "cancel scope: native broadcast loses no waiters under stress" {
+    var round: usize = 0;
+    for (round < 16) {
+        var scope: Scope;
+        if (!make_root(?scope, false, time.Time{sec: 0, nsec: 0})) { ret 1; }
+        var results: [4]i64;
+        var contexts: [4]WaitContext;
+        var workers: [4]thread.Thread;
+        var i: usize = 0;
+        for (i < 4) {
+            contexts[i] = WaitContext{scope: ?scope, result: ?results[i]};
+            thread.spawn_with(wait_worker, (?contexts[i])::*u8, ?workers[i]);
+            if (workers[i].tid < 0) { ret 1; }
+            i = i + 1;
+        }
+        for (waiter_count(?scope) != 4) { atomic.spin_hint(); }
+        if (!cancel(?scope)) { ret 1; }
+        i = 0;
+        for (i < 4) {
+            thread.join(?workers[i]);
+            if (atomic.load(?results[i]) != CANCELLED) { ret 1; }
+            i = i + 1;
+        }
+        if (waiter_count(?scope) != 0 || !destroy(?scope)) { ret 1; }
+        round = round + 1;
+    }
+    ret 0;
+}

--- a/src/sync/cancel.mach
+++ b/src/sync/cancel.mach
@@ -23,6 +23,7 @@ val REG_UNUSED:    i64 = 0;
 val REG_ACTIVE:    i64 = 1;
 val REG_CANCELLED: i64 = 2;
 val REG_COMPLETED: i64 = 3;
+val REG_CLAIMING:  i64 = 4;
 val GATE_CLOSED:   i64 = -1;
 
 pub rec Registration {
@@ -161,19 +162,24 @@ fun registration_remove(registration: *Registration) {
 pub fun attach(scope: *Scope, registration: *Registration, callback: CancelFun, context: ptr) Reason {
     if (scope == nil || registration == nil || callback::usize == 0) { ret INVALID; }
     if (!scope_enter(scope)) { ret DESTROYED; }
+    val registration_state: i64 = atomic.load(?registration.state);
+    if (registration_state != REG_UNUSED && registration_state != REG_COMPLETED) {
+        scope_leave(scope);
+        ret INVALID;
+    }
+    var expected: i64 = registration_state;
+    if (!atomic.cas(?registration.state, ?expected, REG_CLAIMING)) {
+        scope_leave(scope);
+        ret INVALID;
+    }
     val root: *Scope = scope.root;
     mutex.lock(?root.lock);
     val state: Reason = atomic.load(?scope.state);
     if (state != ACTIVE) {
+        atomic.store(?registration.state, registration_state);
         mutex.unlock(?root.lock);
         scope_leave(scope);
         ret state;
-    }
-    val registration_state: i64 = atomic.load(?registration.state);
-    if (registration_state != REG_UNUSED && registration_state != REG_COMPLETED) {
-        mutex.unlock(?root.lock);
-        scope_leave(scope);
-        ret INVALID;
     }
     registration.root = root;
     registration.scope = scope;
@@ -296,9 +302,13 @@ pub fun expire(scope: *Scope, now: time.Time) bool {
     val has_deadline: bool = scope.has_deadline;
     val deadline: time.Time = scope.deadline;
     val owner: *Scope = scope.deadline_owner;
+    if (!has_deadline || time.time_before(now, deadline)) {
+        scope_leave(scope);
+        ret false;
+    }
+    val expired: bool = timeout(owner);
     scope_leave(scope);
-    if (!has_deadline || time.time_before(now, deadline)) { ret false; }
-    ret timeout(owner);
+    ret expired;
 }
 
 # returns the effective deadline and the ancestor that owns it
@@ -444,6 +454,56 @@ test "cancel scope: active registrations cannot be attached twice" {
     if (attach(?other, ?registration, test_callback, (?callback)::ptr) != INVALID) { ret 1; }
     if (!cancel(?root) || atomic.load(?count) != 1 || atomic.load(?why) != CANCELLED) { ret 1; }
     if (!destroy(?root) || !destroy(?other)) { ret 1; }
+    ret 0;
+}
+
+rec AttachRaceContext {
+    scope: *Scope;
+    registration: *Registration;
+    callback: *TestCallback;
+    ready: *i64;
+    go: *i64;
+    result: *i64;
+}
+
+fun attach_race_worker(arg: *u8) {
+    val context: *AttachRaceContext = arg::*AttachRaceContext;
+    atomic.fetch_add(context.ready, 1);
+    for (atomic.load(context.go) == 0) { atomic.spin_hint(); }
+    val attached: Reason = attach(context.scope, context.registration, test_callback, context.callback::ptr);
+    atomic.store(context.result, attached);
+}
+
+test "cancel scope: concurrent roots cannot claim one registration" {
+    var first: Scope;
+    var second: Scope;
+    val none: time.Time = time.Time{sec: 0, nsec: 0};
+    if (!make_root(?first, false, none) || !make_root(?second, false, none)) { ret 1; }
+    var count: i64 = 0;
+    var why: i64 = ACTIVE;
+    var callback: TestCallback = TestCallback{count: ?count, reason: ?why};
+    var registration: Registration;
+    init_registration(?registration);
+    var ready: i64 = 0;
+    var go: i64 = 0;
+    var results: [2]i64;
+    var contexts: [2]AttachRaceContext;
+    contexts[0] = AttachRaceContext{scope: ?first, registration: ?registration, callback: ?callback, ready: ?ready, go: ?go, result: ?results[0]};
+    contexts[1] = AttachRaceContext{scope: ?second, registration: ?registration, callback: ?callback, ready: ?ready, go: ?go, result: ?results[1]};
+    var workers: [2]thread.Thread;
+    thread.spawn_with(attach_race_worker, (?contexts[0])::*u8, ?workers[0]);
+    thread.spawn_with(attach_race_worker, (?contexts[1])::*u8, ?workers[1]);
+    if (workers[0].tid < 0 || workers[1].tid < 0) { ret 1; }
+    for (atomic.load(?ready) != 2) { atomic.spin_hint(); }
+    atomic.store(?go, 1);
+    thread.join(?workers[0]);
+    thread.join(?workers[1]);
+    val first_result: Reason = atomic.load(?results[0]);
+    val second_result: Reason = atomic.load(?results[1]);
+    if (!((first_result == ACTIVE && second_result == INVALID) || (first_result == INVALID && second_result == ACTIVE))) { ret 1; }
+    cancel(?first);
+    cancel(?second);
+    if (atomic.load(?count) != 1 || !destroy(?first) || !destroy(?second)) { ret 1; }
     ret 0;
 }
 

--- a/test/native/known-failures/windows-x86_64.txt
+++ b/test/native/known-failures/windows-x86_64.txt
@@ -4,7 +4,6 @@
 
 path: clean degenerate and root inputs
 path: clean preserves windows drive and UNC roots
-std.filesystem.write_bytes:read_string_roundtrip
 std.process.exec.resolve:finds_a_real_program_on_path
 std.types.path.join:single_separator
 std.types.path.resolve:abs_verbatim_rel_joined

--- a/test/relro/src/fault.mach
+++ b/test/relro/src/fault.mach
@@ -5,7 +5,7 @@
 # unhardened. The forced inputs never reach the mprotect, so no live mapping is touched.
 # verify.sh asserts the panic message on stderr and death by signal.
 use std.runtime;
-use reloc: std.runtime.linux.reloc;
+use std.runtime.linux.reloc;
 
 #[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {

--- a/test/sigpipe/src/main.mach
+++ b/test/sigpipe/src/main.mach
@@ -4,7 +4,7 @@
 # missing or broken ignore_sigpipe implementation kills this whole executable
 # before it can return, which verify.sh distinguishes from its normal exit.
 use std.runtime;
-use os: std.system.os;
+use std.system.os;
 
 #[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {

--- a/test/terminate-child/src/main.mach
+++ b/test/terminate-child/src/main.mach
@@ -7,8 +7,8 @@ use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
-use os: std.system.os;
-use exec: std.process.exec;
+use std.system.os;
+use std.process.exec;
 use R: std.types.result;
 
 fun spawn_blocker(program: *u8) i64 {


### PR DESCRIPTION
Closes #489

Adds caller-owned hierarchical cancellation scopes with inherited absolute monotonic deadlines, native blocking observation, intrusive runtime registrations, and exact-one arbitration across submission, completion, cancellation, timeout, and close.

Validation:
- `mach test .`
- scope suites under QEMU on Linux arm64 and riscv64
- scope suites under Wine on Windows x86-64
- `bash test/backends/verify.sh`