### PR TITLE
test: isolate platform rollback and batch checks

### DIFF
--- a/src/net/async/darwin.mach
+++ b/src/net/async/darwin.mach
@@ -1227,21 +1227,44 @@ test "async darwin: UDP batch preserves boundaries and metadata" {
 
     var receive_token: types.Token;
     var send_token: types.Token;
-    val receive_submitted: i64 = submit_receive_batch(?backend, receiver, ?incoming[0], 3, 81, ?receive_token);
-    val send_submitted: i64 = submit_send_batch(?backend, sender, ?outgoing[0], 3, 82, ?send_token);
-    var saw_receive: bool = false;
-    var saw_send: bool = false;
+    var receive_submitted: i64 = submit_receive_batch(?backend, receiver, ?incoming[0], 3, 81, ?receive_token);
+    var send_submitted: i64 = submit_send_batch(?backend, sender, ?outgoing[0], 3, 82, ?send_token);
+    var receive_items: usize = 0;
+    var receive_bytes: usize = 0;
+    var send_items: usize = 0;
+    var send_bytes: usize = 0;
+    var failed: bool = receive_submitted < 0 || send_submitted < 0;
     var attempts: usize = 0;
-    for (attempts < 6 && (!saw_receive || !saw_send)) {
+    for (attempts < 12 && !failed && (receive_items < 3 || send_items < 3)) {
         val count: i64 = poll(?backend, 1000);
-        if (count < 0) { attempts = 6; }
+        if (count < 0) { failed = true; }
         or {
             i = 0;
             for (i < count::usize) {
                 var native: types.NativeCompletion;
                 completion(?backend, i, ?native);
-                if (native.context == 81 && native.kind == runtime.RECEIVE_FROM && native.status == 0 && native.bytes == 7 && native.items == 3) { saw_receive = true; }
-                if (native.context == 82 && native.kind == runtime.SEND_TO && native.status == 0 && native.bytes == 11 && native.items == 3) { saw_send = true; }
+                if (native.context == 81) {
+                    if (native.kind != runtime.RECEIVE_FROM || native.status != 0 || native.items == 0 || native.items > 3 - receive_items) { failed = true; }
+                    or {
+                        receive_items = receive_items + native.items;
+                        receive_bytes = receive_bytes + native.bytes;
+                        if (receive_items < 3) {
+                            receive_submitted = submit_receive_batch(?backend, receiver, ?incoming[receive_items], 3 - receive_items, 81, ?receive_token);
+                            if (receive_submitted < 0) { failed = true; }
+                        }
+                    }
+                }
+                if (native.context == 82) {
+                    if (native.kind != runtime.SEND_TO || native.status != 0 || native.items == 0 || native.items > 3 - send_items) { failed = true; }
+                    or {
+                        send_items = send_items + native.items;
+                        send_bytes = send_bytes + native.bytes;
+                        if (send_items < 3) {
+                            send_submitted = submit_send_batch(?backend, sender, ?outgoing[send_items], 3 - send_items, 82, ?send_token);
+                            if (send_submitted < 0) { failed = true; }
+                        }
+                    }
+                }
                 i = i + 1;
             }
             attempts = attempts + 1;
@@ -1250,7 +1273,7 @@ test "async darwin: UDP batch preserves boundaries and metadata" {
     val peer_valid: bool = incoming[0].peer.port == sender_endpoint.port && incoming[1].peer.port == sender_endpoint.port && incoming[2].peer.port == sender_endpoint.port;
     val metadata_valid: bool = incoming[0].has_local_destination && incoming[0].local_destination.is_v6 == 0 && incoming[0].local_destination.v4.octets[0] == 127 && incoming[0].local_destination.v4.octets[3] == 1 && incoming[0].interface_index != 0;
     val boundaries_valid: bool = incoming[0].length == 3 && !incoming[0].zero_length && !incoming[0].truncated && first_in[0] == 'o' && first_in[2] == 'e' && incoming[1].length == 0 && incoming[1].zero_length && !incoming[1].truncated && incoming[2].length == 4 && !incoming[2].zero_length && incoming[2].truncated && third_in[0] == 1 && third_in[3] == 4;
-    val valid: bool = receive_submitted == 0 && send_submitted == 0 && saw_receive && saw_send && peer_valid && metadata_valid && boundaries_valid && backend.live == 0 && backend.resource_count == 0;
+    val valid: bool = !failed && receive_items == 3 && receive_bytes == 7 && send_items == 3 && send_bytes == 11 && peer_valid && metadata_valid && boundaries_valid && backend.live == 0 && backend.resource_count == 0;
     darwin.sock_close(sender); darwin.sock_close(receiver);
     val destroyed: i64 = destroy(?backend);
     darwin.io_queue_close(?queue);

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -303,13 +303,7 @@ ext fun GetCurrentThread() isize;
 #[library("kernel32.dll")]
 ext fun GetCurrentThreadId() u32;
 #[library("kernel32.dll")]
-ext fun GetCurrentProcess() isize;
-#[library("kernel32.dll")]
-ext fun GetProcessHandleCount(p0: isize, p1: *u32) i32;
-#[library("kernel32.dll")]
 ext fun LocalFree(p0: ptr) ptr;
-#[library("kernel32.dll")]
-ext fun VirtualQuery(p0: ptr, p1: ptr, p2: usize) usize;
 
 # WaitOnAddress / WakeByAddressSingle live in the synch apiset DLL, not kernel32
 # real windows' kernel32 does not export them (only wine's does), so without
@@ -2646,37 +2640,7 @@ pub fun thread_current_name(name: *u8, cap: usize) i64 {
     ret n::i64;
 }
 
-rec TestMemoryBasicInformation {
-    base:               ptr;
-    allocation_base:    ptr;
-    allocation_protect: u32;
-    padding0:           u32;
-    region_size:        usize;
-    state:              u32;
-    protect:            u32;
-    typ:                u32;
-    padding1:           u32;
-}
-
 test "std.system.os.windows: injected startup and native name failures release resources" {
-    var address: usize = 0;
-    var allocations_before: u64 = 0;
-    for (address < (-1)::usize - 65535) {
-        var info: TestMemoryBasicInformation;
-        if (VirtualQuery(address::ptr, (?info)::ptr, 48) == 0) {
-            address = (-1)::usize;
-            cnt;
-        }
-        if (info.typ == 0x20000) {
-            allocations_before = allocations_before + info.region_size::u64;
-        }
-        val next: usize = info.base::usize + info.region_size;
-        if (next <= address) { ret 1; }
-        address = next;
-    }
-    var handles_before: u32 = 0;
-    if (GetProcessHandleCount(GetCurrentProcess(), ?handles_before) == 0) { ret 1; }
-
     val failed_start_mem: ptr = allocate(THREAD_START_SIZE);
     if (failed_start_mem == nil) { ret 1; }
     val injected: i64 = -125;
@@ -2715,25 +2679,6 @@ test "std.system.os.windows: injected startup and native name failures release r
     }
     deallocate(owner, 4096);
     if (atomic.load(?reclaimable) != 1) { ret 1; }
-
-    address = 0;
-    var allocations_after: u64 = 0;
-    for (address < (-1)::usize - 65535) {
-        var info: TestMemoryBasicInformation;
-        if (VirtualQuery(address::ptr, (?info)::ptr, 48) == 0) {
-            address = (-1)::usize;
-            cnt;
-        }
-        if (info.typ == 0x20000) {
-            allocations_after = allocations_after + info.region_size::u64;
-        }
-        val next: usize = info.base::usize + info.region_size;
-        if (next <= address) { ret 1; }
-        address = next;
-    }
-    var handles_after: u32 = 0;
-    if (GetProcessHandleCount(GetCurrentProcess(), ?handles_after) == 0) { ret 1; }
-    if (allocations_after != allocations_before || handles_after != handles_before) { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Closes #520
Closes #522

## Summary

- remove process-wide memory and handle census from the concurrent Windows native suite
- retain direct allocation rollback, aborted trampoline quiescence, native handle close, and caller ownership assertions
- accumulate valid partial Darwin UDP send and receive batches before checking boundaries and metadata

## Validation

- `bash test/backends/verify.sh`
- `mach build . --all-targets`