### PR TITLE
test(net): make Darwin async tests completion-driven

### DIFF
--- a/src/net/async/darwin.mach
+++ b/src/net/async/darwin.mach
@@ -1159,6 +1159,26 @@ fun test_await_completion(backend: *Backend, context: usize, out: *types.NativeC
     ret darwin.ETIMEDOUT;
 }
 
+fun test_collect_completions(backend: *Backend, output: *types.NativeCompletion, wanted: usize) i64 {
+    if (backend == nil || output == nil || wanted == 0) { ret darwin.EINVAL; }
+    var total: usize = 0;
+    var attempts: usize = 0;
+    for (total < wanted && attempts < 8) {
+        val count: i64 = poll(backend, 1000);
+        if (count < 0) { ret count; }
+        var i: usize = 0;
+        for (i < count::usize && total < wanted) {
+            val read: i64 = completion(backend, i, ?output[total]);
+            if (read < 0) { ret read; }
+            total = total + 1;
+            i = i + 1;
+        }
+        attempts = attempts + 1;
+    }
+    if (total != wanted) { ret darwin.ETIMEDOUT; }
+    ret total::i64;
+}
+
 fun test_datagram(socket: *usize, endpoint: *ip.Endpoint) i64 {
     @socket = (-1)::usize;
     val created: i64 = darwin.sock_create_flags(darwin.AF_INET, darwin.SOCK_DGRAM, 0, true, true, socket);
@@ -1575,9 +1595,8 @@ test "async darwin: canceling close preserves handle ownership" {
     val close_active: bool = operation_for(?backend, close_token) != nil;
     val canceled: i64 = cancel(?backend, close_token);
     val raw_close: i64 = darwin.sock_close(server);
-    val count: i64 = poll(?backend, 0);
     var displaced: types.NativeCompletion;
-    if (count == 1) { completion(?backend, 0, ?displaced); }
+    val count: i64 = test_collect_completions(?backend, ?displaced, 1);
     var failure: i32 = 0;
     if (configured != 0) { failure = 2; }
     or (peer_configured != 0) { failure = 3; }
@@ -1649,10 +1668,11 @@ test "async darwin: queued cancellation preserves FIFO" {
     val second: i64 = submit_send_batch(?backend, socket, ?packets[1], 1, 22, ?tokens[1]);
     val third: i64 = submit_send_batch(?backend, socket, ?packets[2], 1, 33, ?tokens[2]);
     val cancelled: i64 = cancel(?backend, tokens[1]);
-    val count: i64 = poll(?backend, 0);
+    var completions: [2]types.NativeCompletion;
+    val count: i64 = test_collect_completions(?backend, ?completions[0], 2);
     var a: types.NativeCompletion;
     var b: types.NativeCompletion;
-    if (count == 2) { completion(?backend, 0, ?a); completion(?backend, 1, ?b); }
+    if (count == 2) { a = completions[0]; b = completions[1]; }
     val valid: bool = first == 0 && second == 0 && third == 0 && cancelled == 0 && count == 2 && a.context == 11 && b.context == 33 && a.kind == runtime.SEND_TO && b.kind == runtime.SEND_TO && backend.live == 0 && backend.resource_count == 0;
     darwin.sock_close(socket);
     val destroyed: i64 = destroy(?backend);
@@ -1687,14 +1707,14 @@ test "async darwin: shutdown and close follow prior writes" {
     var pending: u8 = 0;
     val read_pending: i64 = submit_read(?backend, server, ?pending, 1, 74, ?tokens[3]);
     val close_pending: i64 = submit_close(?backend, server, 75, ?tokens[4]);
-    val count: i64 = poll(?backend, 0);
+    var completions: [5]types.NativeCompletion;
+    val count: i64 = test_collect_completions(?backend, ?completions[0], 5);
     var valid_order: bool = count == 5;
     var expected: [5]usize;
     expected[0] = 71; expected[1] = 72; expected[2] = 73; expected[3] = 74; expected[4] = 75;
     var i: usize = 0;
-    for (i < count::usize && i < 5) {
-        var native: types.NativeCompletion;
-        completion(?backend, i, ?native);
+    for (count == 5 && i < 5) {
+        val native: types.NativeCompletion = completions[i];
         if (native.context != expected[i]) { valid_order = false; }
         if (native.context == 74 && native.status != darwin.ECANCELED) { valid_order = false; }
         if (native.context == 75 && (native.kind != runtime.CLOSE || native.status != 0)) { valid_order = false; }

--- a/src/net/async/darwin.mach
+++ b/src/net/async/darwin.mach
@@ -1373,13 +1373,29 @@ test "async darwin: remote half-close reports EOF and preserves writes" {
     var response: [2]u8;
     val response_bytes: i64 = test_receive_exact(client, ?response[0], 2);
 
-    val eof_valid: bool = read_submitted == 0 && half_closed == 0 && read_completed == 0 && read_completion.context == 86 && read_completion.kind == runtime.READ && read_completion.status == 0 && read_completion.bytes == 0 && read_completion.items == 0 && read_completion.end_of_stream;
-    val write_valid: bool = write_submitted == 0 && write_completed == 0 && response_bytes == 2 && response[0] == 'o' && response[1] == 'k' && write_completion.context == 87 && write_completion.status == 0 && write_completion.bytes == 2 && write_completion.items == 0;
-    val valid: bool = eof_valid && write_valid && backend.live == 0 && backend.resource_count == 0;
+    var failure: i32 = 0;
+    if (read_submitted != 0) { failure = 2; }
+    or (half_closed != 0) { failure = 3; }
+    or (read_completed != 0) { failure = 4; }
+    or (read_completion.context != 86) { failure = 5; }
+    or (read_completion.kind != runtime.READ) { failure = 6; }
+    or (read_completion.status != 0) { failure = 7; }
+    or (read_completion.bytes != 0 || read_completion.items != 0) { failure = 8; }
+    or (!read_completion.end_of_stream) { failure = 9; }
+    or (write_submitted != 0) { failure = 10; }
+    or (write_completed != 0) { failure = 11; }
+    or (response_bytes != 2) { failure = 12; }
+    or (response[0] != 'o' || response[1] != 'k') { failure = 13; }
+    or (write_completion.context != 87) { failure = 14; }
+    or (write_completion.status != 0) { failure = 15; }
+    or (write_completion.bytes != 2 || write_completion.items != 0) { failure = 16; }
+    or (backend.live != 0) { failure = 17; }
+    or (backend.resource_count != 0) { failure = 18; }
     darwin.sock_close(server); darwin.sock_close(client); darwin.sock_close(listener);
     val destroyed: i64 = destroy(?backend);
     darwin.io_queue_close(?queue);
-    if (!valid || destroyed < 0) { ret 1; }
+    if (failure == 0 && destroyed < 0) { failure = 19; }
+    if (failure != 0) { ret failure; }
     ret 0;
 }
 
@@ -1684,11 +1700,22 @@ test "async darwin: shutdown and close follow prior writes" {
         if (native.context == 75 && (native.kind != runtime.CLOSE || native.status != 0)) { valid_order = false; }
         i = i + 1;
     }
-    val valid: bool = write_first == 0 && write_second == 0 && shutdown == 0 && read_pending == 0 && close_pending == 0 && received_bytes == 2 && received[0] == 'a' && received[1] == 'b' && eof == 0 && valid_order && backend.resource_count == 0;
+    var failure: i32 = 0;
+    if (write_first != 0) { failure = 2; }
+    or (write_second != 0) { failure = 3; }
+    or (shutdown != 0) { failure = 4; }
+    or (read_pending != 0) { failure = 5; }
+    or (close_pending != 0) { failure = 6; }
+    or (received_bytes != 2) { failure = 7; }
+    or (received[0] != 'a' || received[1] != 'b') { failure = 8; }
+    or (eof != 0) { failure = 9; }
+    or (!valid_order) { failure = 10; }
+    or (backend.resource_count != 0) { failure = 11; }
     darwin.sock_close(client); darwin.sock_close(listener);
     val destroyed: i64 = destroy(?backend);
     darwin.io_queue_close(?queue);
-    if (!valid || destroyed < 0) { ret 1; }
+    if (failure == 0 && destroyed < 0) { failure = 12; }
+    if (failure != 0) { ret failure; }
     ret 0;
 }
 

--- a/src/net/async/darwin.mach
+++ b/src/net/async/darwin.mach
@@ -1073,9 +1073,9 @@ fun datagram_send_batch(resource: usize, packets: *types.Packet, count: usize) i
     ret sent::i64;
 }
 
-fun test_listener(listener: *usize, endpoint: *ip.Endpoint) i64 {
+fun test_listener_flags(listener: *usize, endpoint: *ip.Endpoint, nonblocking: bool) i64 {
     @listener = (-1)::usize;
-    val created: i64 = darwin.sock_create_flags(darwin.AF_INET, darwin.SOCK_STREAM, 0, true, true, listener);
+    val created: i64 = darwin.sock_create_flags(darwin.AF_INET, darwin.SOCK_STREAM, 0, nonblocking, true, listener);
     if (created < 0) { ret created; }
     var loopback: [4]u8;
     loopback[0] = 127;
@@ -1094,6 +1094,14 @@ fun test_listener(listener: *usize, endpoint: *ip.Endpoint) i64 {
         @listener = (-1)::usize;
     }
     ret status;
+}
+
+fun test_listener(listener: *usize, endpoint: *ip.Endpoint) i64 {
+    ret test_listener_flags(listener, endpoint, false);
+}
+
+fun test_async_listener(listener: *usize, endpoint: *ip.Endpoint) i64 {
+    ret test_listener_flags(listener, endpoint, true);
 }
 
 fun test_client(endpoint: ip.Endpoint, client: *usize) i64 {
@@ -1754,7 +1762,7 @@ test "async darwin: listener owns multiple bounded accepts" {
     if (make(?backend, ?queue, 8) < 0) { darwin.io_queue_close(?queue); ret 1; }
     var listener: usize;
     var endpoint: ip.Endpoint;
-    if (test_listener(?listener, ?endpoint) < 0) { destroy(?backend); darwin.io_queue_close(?queue); ret 1; }
+    if (test_async_listener(?listener, ?endpoint) < 0) { destroy(?backend); darwin.io_queue_close(?queue); ret 1; }
     var peers: [2]ip.Endpoint;
     var tokens: [2]types.Token;
     val first: i64 = submit_accept(?backend, listener, ?peers[0], 61, ?tokens[0]);

--- a/src/net/async/darwin.mach
+++ b/src/net/async/darwin.mach
@@ -1562,7 +1562,24 @@ test "async darwin: canceling close preserves handle ownership" {
     val count: i64 = poll(?backend, 0);
     var displaced: types.NativeCompletion;
     if (count == 1) { completion(?backend, 0, ?displaced); }
-    val active_valid: bool = configured == 0 && peer_configured == 0 && write_active && fill_error == 0 && write_submitted == 0 && close_submitted == 0 && close_active && canceled == 0 && raw_close == darwin.EBADF && count == 1 && displaced.context == 93 && displaced.kind == runtime.WRITE && displaced.status == darwin.ECANCELED && displaced.bytes == 0 && displaced.items == 0 && backend.live == 0 && backend.resource_count == 0;
+    var failure: i32 = 0;
+    if (configured != 0) { failure = 2; }
+    or (peer_configured != 0) { failure = 3; }
+    or (!write_active) { failure = 4; }
+    or (fill_error != 0) { failure = 5; }
+    or (write_submitted != 0) { failure = 6; }
+    or (close_submitted != 0) { failure = 7; }
+    or (!close_active) { failure = 8; }
+    or (canceled != 0) { failure = 9; }
+    or (raw_close != darwin.EBADF) { failure = 10; }
+    or (count != 1) { failure = 11; }
+    or (displaced.context != 93) { failure = 12; }
+    or (displaced.kind != runtime.WRITE) { failure = 13; }
+    or (displaced.status != darwin.ECANCELED) { failure = 14; }
+    or (displaced.bytes != 0) { failure = 15; }
+    or (displaced.items != 0) { failure = 16; }
+    or (backend.live != 0) { failure = 17; }
+    or (backend.resource_count != 0) { failure = 18; }
     darwin.sock_close(client);
 
     var second_client: usize;
@@ -1575,11 +1592,18 @@ test "async darwin: canceling close preserves handle ownership" {
     val queued_canceled: i64 = cancel(?backend, queued_token);
     val second_raw_close: i64 = darwin.sock_close(second_server);
     val after: i64 = poll(?backend, 0);
-    val queued_valid: bool = queued_submitted == 0 && close_queued && queued_canceled == 0 && second_raw_close == darwin.EBADF && after == 0 && backend.live == 0 && backend.resource_count == 0;
+    if (failure == 0 && queued_submitted != 0) { failure = 19; }
+    or (failure == 0 && !close_queued) { failure = 20; }
+    or (failure == 0 && queued_canceled != 0) { failure = 21; }
+    or (failure == 0 && second_raw_close != darwin.EBADF) { failure = 22; }
+    or (failure == 0 && after != 0) { failure = 23; }
+    or (failure == 0 && backend.live != 0) { failure = 24; }
+    or (failure == 0 && backend.resource_count != 0) { failure = 25; }
     darwin.sock_close(second_client); darwin.sock_close(listener);
     val destroyed: i64 = destroy(?backend);
     darwin.io_queue_close(?queue);
-    if (!active_valid || !queued_valid || destroyed < 0) { ret 1; }
+    if (failure == 0 && destroyed < 0) { failure = 26; }
+    if (failure != 0) { ret failure; }
     ret 0;
 }
 


### PR DESCRIPTION
Closes #524

Uses blocking listeners for synchronous stream fixtures while retaining nonblocking listeners for pending accept tests. Collects queued terminal completions across readiness deliveries, preserves exact FIFO assertions, and adds distinct failure codes for close and stream ordering traces.