### PR TITLE
test(net): make Darwin close cancellation deterministic

### DIFF
--- a/src/net/async/darwin.mach
+++ b/src/net/async/darwin.mach
@@ -710,21 +710,28 @@ pub fun submit_shutdown_write(backend: *Backend, native: usize, context: usize, 
     ret 0;
 }
 
-pub fun submit_close(backend: *Backend, native: usize, context: usize, token: *types.Token) i64 {
-    if (backend == nil || token == nil) { ret invalid(); }
-    mutex.lock(?backend.lock);
-    var resource: *Resource;
+fun begin_close_locked(backend: *Backend, native: usize, context: usize, token: *types.Token, resource_out: **Resource) i64 {
     var operation: *Operation;
-    val status: i64 = begin(backend, native, runtime.CLOSE, context, LANE_NONE, token, ?resource, ?operation);
-    if (status < 0) {
-        mutex.unlock(?backend.lock);
-        ret status;
-    }
+    val status: i64 = begin(backend, native, runtime.CLOSE, context, LANE_NONE, token, resource_out, ?operation);
+    if (status < 0) { ret status; }
+    val resource: *Resource = @resource_out;
     resource.closing = true;
     resource.close_index = operation_index(backend, operation);
     for (resource.read_head != NONE) {
         val read_operation: *Operation = ?backend.operations[resource.read_head::usize];
         finish(backend, resource, read_operation, darwin.ECANCELED, 0, 0, native, false);
+    }
+    ret 0;
+}
+
+pub fun submit_close(backend: *Backend, native: usize, context: usize, token: *types.Token) i64 {
+    if (backend == nil || token == nil) { ret invalid(); }
+    mutex.lock(?backend.lock);
+    var resource: *Resource;
+    val status: i64 = begin_close_locked(backend, native, context, token, ?resource);
+    if (status < 0) {
+        mutex.unlock(?backend.lock);
+        ret status;
     }
     submission_done(backend, resource);
     ret 0;
@@ -1559,62 +1566,42 @@ test "async darwin: canceling close preserves handle ownership" {
     var server: usize = (-1)::usize;
     if (stream_accept(listener, nil, ?server) < 0) { darwin.sock_close(client); darwin.sock_close(listener); destroy(?backend); darwin.io_queue_close(?queue); ret 1; }
 
-    var send_buffer: i32 = 4096;
-    val configured: i64 = darwin.sock_setopt(server, darwin.SOL_SOCKET, darwin.SO_SNDBUF, (?send_buffer)::*u8, 4);
-    var receive_buffer: i32 = 4096;
-    val peer_configured: i64 = darwin.sock_setopt(client, darwin.SOL_SOCKET, darwin.SO_RCVBUF, (?receive_buffer)::*u8, 4);
-    var fill: [4096]u8;
-    var fill_error: i64 = 0;
     var pending_byte: u8 = 'z';
     var write_token: types.Token;
     var write_submitted: i64 = darwin.EIO;
-    var write_active: bool = false;
-    var pending_attempts: usize = 0;
-    for (pending_attempts < 64 && !write_active && fill_error == 0) {
-        var blocked: bool = false;
-        for (!blocked && fill_error == 0) {
-            val result: i64 = darwin.sock_send(server, ?fill[0], 4096);
-            if (result == darwin.EAGAIN) { blocked = true; }
-            or (result <= 0) {
-                fill_error = result;
-                if (result == 0) { fill_error = darwin.EIO; }
-            }
-        }
-        if (fill_error == 0) {
-            write_submitted = submit_write(?backend, server, ?pending_byte, 1, 93, ?write_token);
-            if (write_submitted < 0) { fill_error = write_submitted; }
-            or {
-                write_active = operation_for(?backend, write_token) != nil;
-                if (!write_active && poll(?backend, 0) != 1) { fill_error = darwin.EIO; }
-            }
-        }
-        pending_attempts = pending_attempts + 1;
-    }
     var close_token: types.Token;
-    val close_submitted: i64 = submit_close(?backend, server, 94, ?close_token);
-    val close_active: bool = operation_for(?backend, close_token) != nil;
+    var close_submitted: i64 = darwin.EIO;
+    var close_active: bool = false;
+    mutex.lock(?backend.lock);
+    var write_resource: *Resource;
+    var write_operation: *Operation;
+    write_submitted = begin(?backend, server, runtime.WRITE, 93, LANE_WRITE, ?write_token, ?write_resource, ?write_operation);
+    if (write_submitted == 0) {
+        write_operation.buffer = ?pending_byte;
+        write_operation.length = 1;
+        var close_resource: *Resource;
+        close_submitted = begin_close_locked(?backend, server, 94, ?close_token, ?close_resource);
+        close_active = close_submitted == 0 && operation_for(?backend, close_token) != nil;
+    }
+    mutex.unlock(?backend.lock);
     val canceled: i64 = cancel(?backend, close_token);
     val raw_close: i64 = darwin.sock_close(server);
     var displaced: types.NativeCompletion;
     val count: i64 = test_collect_completions(?backend, ?displaced, 1);
     var failure: i32 = 0;
-    if (configured != 0) { failure = 2; }
-    or (peer_configured != 0) { failure = 3; }
-    or (!write_active) { failure = 4; }
-    or (fill_error != 0) { failure = 5; }
-    or (write_submitted != 0) { failure = 6; }
-    or (close_submitted != 0) { failure = 7; }
-    or (!close_active) { failure = 8; }
-    or (canceled != 0) { failure = 9; }
-    or (raw_close != darwin.EBADF) { failure = 10; }
-    or (count != 1) { failure = 11; }
-    or (displaced.context != 93) { failure = 12; }
-    or (displaced.kind != runtime.WRITE) { failure = 13; }
-    or (displaced.status != darwin.ECANCELED) { failure = 14; }
-    or (displaced.bytes != 0) { failure = 15; }
-    or (displaced.items != 0) { failure = 16; }
-    or (backend.live != 0) { failure = 17; }
-    or (backend.resource_count != 0) { failure = 18; }
+    if (write_submitted != 0) { failure = 2; }
+    or (close_submitted != 0) { failure = 3; }
+    or (!close_active) { failure = 4; }
+    or (canceled != 0) { failure = 5; }
+    or (raw_close != darwin.EBADF) { failure = 6; }
+    or (count != 1) { failure = 7; }
+    or (displaced.context != 93) { failure = 8; }
+    or (displaced.kind != runtime.WRITE) { failure = 9; }
+    or (displaced.status != darwin.ECANCELED) { failure = 10; }
+    or (displaced.bytes != 0) { failure = 11; }
+    or (displaced.items != 0) { failure = 12; }
+    or (backend.live != 0) { failure = 13; }
+    or (backend.resource_count != 0) { failure = 14; }
     darwin.sock_close(client);
 
     var second_client: usize;
@@ -1627,17 +1614,17 @@ test "async darwin: canceling close preserves handle ownership" {
     val queued_canceled: i64 = cancel(?backend, queued_token);
     val second_raw_close: i64 = darwin.sock_close(second_server);
     val after: i64 = poll(?backend, 0);
-    if (failure == 0 && queued_submitted != 0) { failure = 19; }
-    or (failure == 0 && !close_queued) { failure = 20; }
-    or (failure == 0 && queued_canceled != 0) { failure = 21; }
-    or (failure == 0 && second_raw_close != darwin.EBADF) { failure = 22; }
-    or (failure == 0 && after != 0) { failure = 23; }
-    or (failure == 0 && backend.live != 0) { failure = 24; }
-    or (failure == 0 && backend.resource_count != 0) { failure = 25; }
+    if (failure == 0 && queued_submitted != 0) { failure = 15; }
+    or (failure == 0 && !close_queued) { failure = 16; }
+    or (failure == 0 && queued_canceled != 0) { failure = 17; }
+    or (failure == 0 && second_raw_close != darwin.EBADF) { failure = 18; }
+    or (failure == 0 && after != 0) { failure = 19; }
+    or (failure == 0 && backend.live != 0) { failure = 20; }
+    or (failure == 0 && backend.resource_count != 0) { failure = 21; }
     darwin.sock_close(second_client); darwin.sock_close(listener);
     val destroyed: i64 = destroy(?backend);
     darwin.io_queue_close(?queue);
-    if (failure == 0 && destroyed < 0) { failure = 26; }
+    if (failure == 0 && destroyed < 0) { failure = 22; }
     if (failure != 0) { ret failure; }
     ret 0;
 }


### PR DESCRIPTION
Closes #527

Separates the locked close state transition from readiness execution, then drives the active close cancellation path directly in the module test. This removes TCP buffer timing from the ownership assertion while preserving public immediate progress.