### PR TITLE
feat(io): expose complete owned-region alias queries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
       - name: Run the test suite on riscv64
         run: mach test . --target linux-riscv64 --runner qemu-riscv64
 
+      - name: Run optimized ownership tests on riscv64
+        run: mach test . --target linux-riscv64 --runner qemu-riscv64 -O1 --filter 'ownership query'
+
       - name: Run the deterministic fault verifier on riscv64
         run: bash test/fault/verify.sh mach linux-riscv64 qemu-riscv64
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Mach Standard Library
 
-This repository contains the cannonical standard library for the Mach programming language.
+This repository contains the canonical standard library for the Mach programming language.
 
 ## Installation
 
@@ -32,10 +32,11 @@ The documentation for the Mach Standard Library can be found in the [doc](./doc)
 owner descriptor or any backing storage reachable through it. Network driver
 queries include the selected platform backend and the borrowed runtime.
 
-The queries are read-only and allocation-free. The owner and all range
-descriptors must remain immutable for the duration of a query. A caller may
-query while ordinary operations are active because backing addresses and
-capacities do not change, but must synchronize initialization and destruction.
+The queries are read-only and allocation-free. Ownership-defining pointers and
+capacities, plus the queried range descriptor, must remain immutable for the
+duration of a query. A caller may query while ordinary operations are active
+because those fields do not change, but must synchronize initialization and
+destruction.
 
 A non-empty malformed range, uninitialized owner, partially initialized owner,
 partially torn-down owner, or destroyed owner reports overlap. An empty range

--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ The documentation for the Mach Standard Library can be found in the [doc](./doc)
 > NOTE: The documentation is currently a work in progress and the API is rapidly changing.
 > Please refer to the source code for the most up-to-date information.
 
+### I/O ownership queries
+
+`std.io.runtime.aliases`, `std.net.async.aliases`, and
+`std.net.async.local.aliases` report whether a public byte range overlaps an
+owner descriptor or any backing storage reachable through it. Network driver
+queries include the selected platform backend and the borrowed runtime.
+
+The queries are read-only and allocation-free. The owner and all range
+descriptors must remain immutable for the duration of a query. A caller may
+query while ordinary operations are active because backing addresses and
+capacities do not change, but must synchronize initialization and destruction.
+
+A non-empty malformed range, uninitialized owner, partially initialized owner,
+partially torn-down owner, or destroyed owner reports overlap. An empty range
+owns no bytes and reports no overlap. Range validation uses inclusive endpoints,
+so a one-byte range at `usize::MAX` is valid while any range extending beyond it
+is malformed and reports overlap.
+
 ## Contributing
 
 Contributions are welcome! If you find a bug or have a feature request, please open an issue on GitHub. If you'd like to contribute code, please fork the repository and submit a pull request.

--- a/src/io/runtime.mach
+++ b/src/io/runtime.mach
@@ -182,6 +182,38 @@ pub rec Runtime {
     native_lock: mutex.Mutex;
 }
 
+# the caller excludes concurrent destruction while querying stable ownership
+pub fun aliases(runtime: *Runtime, data: *u8, len: usize) bool {
+    if (!memory.range_valid(data, len)) { ret true; }
+    if (len == 0) { ret false; }
+    if (runtime == nil || runtime.capacity == 0 || runtime.destroyed) { ret true; }
+    if (memory.ranges_overlap(runtime::*u8, $size_of(Runtime), data, len)) {
+        ret true;
+    }
+    var slot_bytes: usize = 0;
+    var completion_bytes: usize = 0;
+    var timer_capacity: usize = 0;
+    var timer_bytes: usize = 0;
+    var source_bytes: usize = 0;
+    var native_event_bytes: usize = 0;
+    if (!memory.range_scaled(runtime.capacity, $size_of(Slot), ?slot_bytes) ||
+        !memory.range_scaled(runtime.capacity, $size_of(Completion),
+            ?completion_bytes) ||
+        !memory.range_scaled(runtime.capacity, 2, ?timer_capacity) ||
+        !memory.range_scaled(timer_capacity, $size_of(TimerEntry),
+            ?timer_bytes) ||
+        !memory.range_scaled(runtime.capacity, $size_of(Source), ?source_bytes) ||
+        !memory.range_scaled(runtime.capacity, $size_of(NativeEvent),
+            ?native_event_bytes)) { ret true; }
+    ret memory.ranges_overlap(runtime.slots::*u8, slot_bytes, data, len) ||
+        memory.ranges_overlap(runtime.completions::*u8, completion_bytes,
+            data, len) ||
+        memory.ranges_overlap(runtime.timers::*u8, timer_bytes, data, len) ||
+        memory.ranges_overlap(runtime.sources::*u8, source_bytes, data, len) ||
+        memory.ranges_overlap(runtime.native_events::*u8, native_event_bytes,
+            data, len);
+}
+
 fun invalid(operation: io_error.Operation) io_error.Error {
     ret io_error.from_code(os.EINVAL, operation);
 }
@@ -1356,6 +1388,26 @@ pub fun snapshot(runtime: *Runtime) lifecycle.Snapshot {
 
 fun test_operation(kind: Kind, context: usize) Operation {
     ret Operation{kind: kind, resource: 0, buffer: nil, length: 0, offset: 0, context: context};
+}
+
+test "runtime: ownership query covers every backing allocation" {
+    var runtime: Runtime;
+    var external: [8]u8;
+    if (!aliases(?runtime, ?external[0], 1) || aliases(nil, nil, 0)) { ret 1; }
+    if (is_err[bool, io_error.Error](make(?runtime, 2))) { ret 2; }
+    if (!aliases(?runtime, (?runtime)::*u8, $size_of(Runtime)) ||
+        !aliases(?runtime, runtime.slots::*u8, $size_of(Slot) * 2) ||
+        !aliases(?runtime, runtime.completions::*u8, $size_of(Completion) * 2) ||
+        !aliases(?runtime, runtime.timers::*u8, $size_of(TimerEntry) * 4) ||
+        !aliases(?runtime, runtime.sources::*u8, $size_of(Source) * 2) ||
+        !aliases(?runtime, runtime.native_events::*u8,
+            $size_of(NativeEvent) * 2) ||
+        aliases(?runtime, ?external[0], 8) ||
+        !aliases(?runtime, (~(0::usize) - 1)::*u8, 3)) { ret 3; }
+    if (is_err[bool, io_error.Error](close(?runtime)) ||
+        is_err[bool, io_error.Error](destroy(?runtime)) ||
+        !aliases(?runtime, ?external[0], 1)) { ret 4; }
+    ret 0;
 }
 
 test "runtime: bounded submission preserves caller ownership" {

--- a/src/io/runtime.mach
+++ b/src/io/runtime.mach
@@ -186,7 +186,8 @@ pub rec Runtime {
 pub fun aliases(runtime: *Runtime, data: *u8, len: usize) bool {
     if (!memory.range_valid(data, len)) { ret true; }
     if (len == 0) { ret false; }
-    if (runtime == nil || runtime.capacity == 0 || runtime.destroyed) { ret true; }
+    if (!memory.range_valid(runtime::*u8, $size_of(Runtime)) ||
+        runtime.capacity == 0 || runtime.destroyed) { ret true; }
     if (memory.ranges_overlap(runtime::*u8, $size_of(Runtime), data, len)) {
         ret true;
     }
@@ -1393,7 +1394,8 @@ fun test_operation(kind: Kind, context: usize) Operation {
 test "runtime: ownership query covers every backing allocation" {
     var runtime: Runtime;
     var external: [8]u8;
-    if (!aliases(?runtime, ?external[0], 1) || aliases(nil, nil, 0)) { ret 1; }
+    if (!aliases(?runtime, ?external[0], 1) || aliases(nil, nil, 0) ||
+        !aliases((~(0::usize) - 1)::*Runtime, ?external[0], 1)) { ret 1; }
     if (is_err[bool, io_error.Error](make(?runtime, 2))) { ret 2; }
     if (!aliases(?runtime, (?runtime)::*u8, $size_of(Runtime)) ||
         !aliases(?runtime, runtime.slots::*u8, $size_of(Slot) * 2) ||

--- a/src/memory.mach
+++ b/src/memory.mach
@@ -5,6 +5,33 @@ use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
 
+# validate a public byte range without forming an exclusive end
+pub fun range_valid(data: *u8, len: usize) bool {
+    if (len == 0) { ret true; }
+    if (data == nil) { ret false; }
+    ret len - 1 <= ~(0::usize) - data::usize;
+}
+
+# calculate a byte count without multiplication overflow
+pub fun range_scaled(count: usize, item_size: usize, output: *usize) bool {
+    if (output == nil ||
+        (count != 0 && item_size > ~(0::usize) / count)) { ret false; }
+    @output = count * item_size;
+    ret true;
+}
+
+# conservatively reject malformed ranges and compare inclusive ends
+pub fun ranges_overlap(first: *u8, first_len: usize, second: *u8,
+    second_len: usize) bool {
+    if (first_len == 0 || second_len == 0) { ret false; }
+    if (!range_valid(first, first_len) ||
+        !range_valid(second, second_len)) { ret true; }
+    val first_start: usize = first::usize;
+    val second_start: usize = second::usize;
+    ret first_start <= second_start + second_len - 1 &&
+        second_start <= first_start + first_len - 1;
+}
+
 # fill a block of raw memory with a byte value
 #
 # byte-fills a head prologue to word alignment, stores the value splatted
@@ -581,5 +608,17 @@ test "std.memory.equal:typed_array" {
 
     val p: *i64 = nil;
     if (!equal[i64](p, p, 0)) { ret 1; }
+    ret 0;
+}
+
+test "std.memory.ranges:checked inclusive endpoints" {
+    val maximum: usize = ~(0::usize);
+    if (!range_valid(1::*u8, maximum) ||
+        !ranges_overlap(1::*u8, maximum, maximum::*u8, 1) ||
+        ranges_overlap(1::*u8, 1, maximum::*u8, 1) ||
+        range_valid(maximum::*u8, 2)) { ret 1; }
+    var bytes: usize = 0;
+    if (range_scaled(maximum, 2, ?bytes) ||
+        !range_scaled(maximum, 1, ?bytes) || bytes != maximum) { ret 2; }
     ret 0;
 }

--- a/src/memory.mach
+++ b/src/memory.mach
@@ -14,7 +14,7 @@ pub fun range_valid(data: *u8, len: usize) bool {
 
 # calculate a byte count without multiplication overflow
 pub fun range_scaled(count: usize, item_size: usize, output: *usize) bool {
-    if (output == nil ||
+    if (!range_valid(output::*u8, $size_of(usize)) ||
         (count != 0 && item_size > ~(0::usize) / count)) { ret false; }
     @output = count * item_size;
     ret true;
@@ -619,6 +619,7 @@ test "std.memory.ranges:checked inclusive endpoints" {
         range_valid(maximum::*u8, 2)) { ret 1; }
     var bytes: usize = 0;
     if (range_scaled(maximum, 2, ?bytes) ||
-        !range_scaled(maximum, 1, ?bytes) || bytes != maximum) { ret 2; }
+        !range_scaled(maximum, 1, ?bytes) || bytes != maximum ||
+        range_scaled(1, 1, (maximum - 1)::*usize)) { ret 2; }
     ret 0;
 }

--- a/src/memory.mach
+++ b/src/memory.mach
@@ -28,8 +28,8 @@ pub fun ranges_overlap(first: *u8, first_len: usize, second: *u8,
         !range_valid(second, second_len)) { ret true; }
     val first_start: usize = first::usize;
     val second_start: usize = second::usize;
-    ret first_start <= second_start + second_len - 1 &&
-        second_start <= first_start + first_len - 1;
+    ret first_start <= second_start + (second_len - 1) &&
+        second_start <= first_start + (first_len - 1);
 }
 
 # fill a block of raw memory with a byte value

--- a/src/net/async.mach
+++ b/src/net/async.mach
@@ -12,6 +12,7 @@ use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 use std.system.os;
 use std.system.panic;
+use std.memory;
 use std.chrono.time;
 use std.sync.cancel;
 use std.sync.mutex;
@@ -63,6 +64,22 @@ pub rec Driver {
     capacity: usize;
     backend_destroyed: bool;
     lock: mutex.Mutex;
+}
+
+# the caller excludes concurrent destruction while querying stable ownership
+pub fun aliases(driver: *Driver, data: *u8, len: usize) bool {
+    if (!memory.range_valid(data, len)) { ret true; }
+    if (len == 0) { ret false; }
+    if (driver == nil || driver.runtime == nil || driver.capacity == 0 ||
+        driver.backend_destroyed) { ret true; }
+    var slot_bytes: usize = 0;
+    if (!memory.range_scaled(driver.capacity, $size_of(Slot), ?slot_bytes)) {
+        ret true;
+    }
+    ret memory.ranges_overlap(driver::*u8, $size_of(Driver), data, len) ||
+        memory.ranges_overlap(driver.slots::*u8, slot_bytes, data, len) ||
+        io_runtime.aliases(driver.runtime, data, len) ||
+        impl.aliases(?driver.backend, data, len);
 }
 
 fun invalid(operation: io_error.Operation) io_error.Error {
@@ -616,6 +633,49 @@ pub fun destroy(driver: *Driver) Result[bool, io_error.Error] {
         ret err[bool, io_error.Error](io_error.from_code(released, io_error.OP_CLOSE));
     }
     ret ok[bool, io_error.Error](true);
+}
+
+test "async network: ownership query includes driver backend and runtime" {
+    var runtime: io_runtime.Runtime;
+    var external: [8]u8;
+    var empty: Driver;
+    if (!aliases(?empty, ?external[0], 1) ||
+        is_err[bool, io_error.Error](io_runtime.make(?runtime, 2))) { ret 1; }
+    var partial: impl.Backend;
+    partial.queue = ?runtime.queue;
+    partial.capacity = 2;
+    $if ($mach.build.os == $mach.os.linux || $mach.build.os == $mach.os.darwin) {
+        partial.map_capacity = 4;
+    }
+    if (!impl.aliases(?partial, ?external[0], 1)) { ret 2; }
+    var driver: Driver;
+    if (is_err[bool, io_error.Error](make(?driver, ?runtime))) { ret 3; }
+    if (!aliases(?driver, (?driver)::*u8, $size_of(Driver)) ||
+        !aliases(?driver, driver.slots::*u8, $size_of(Slot) * 2) ||
+        !aliases(?driver, (?driver.backend)::*u8, $size_of(impl.Backend)) ||
+        !aliases(?driver, driver.backend.operations::*u8, 1) ||
+        !aliases(?driver, runtime.slots::*u8, 1) ||
+        aliases(?driver, ?external[0], 8) ||
+        aliases(?driver, (~(0::usize))::*u8, 1) ||
+        !aliases(?driver, (~(0::usize) - 1)::*u8, 3)) { ret 4; }
+    $if ($mach.build.os == $mach.os.linux || $mach.build.os == $mach.os.darwin) {
+        if (!aliases(?driver, driver.backend.resources::*u8, 1) ||
+            !aliases(?driver, driver.backend.resource_map::*u8, 1) ||
+            !aliases(?driver, driver.backend.native::*u8, 1) ||
+            !aliases(?driver, driver.backend.queued::*u8, 1) ||
+            !aliases(?driver, driver.backend.ready::*u8, 1)) { ret 5; }
+    }
+    $or {
+        if (!aliases(?driver, driver.backend.attached::*u8, 1) ||
+            !aliases(?driver, driver.backend.native::*u8, 1) ||
+            !aliases(?driver, driver.backend.preserved::*u8, 1) ||
+            !aliases(?driver, driver.backend.completions::*u8, 1)) { ret 5; }
+    }
+    if (is_err[bool, io_error.Error](destroy(?driver)) ||
+        !aliases(?driver, ?external[0], 1) ||
+        is_err[bool, io_error.Error](io_runtime.close(?runtime)) ||
+        is_err[bool, io_error.Error](io_runtime.destroy(?runtime))) { ret 6; }
+    ret 0;
 }
 
 test "async network: graceful and abortive stream close traces are distinct" {

--- a/src/net/async.mach
+++ b/src/net/async.mach
@@ -70,7 +70,8 @@ pub rec Driver {
 pub fun aliases(driver: *Driver, data: *u8, len: usize) bool {
     if (!memory.range_valid(data, len)) { ret true; }
     if (len == 0) { ret false; }
-    if (driver == nil || driver.runtime == nil || driver.capacity == 0 ||
+    if (!memory.range_valid(driver::*u8, $size_of(Driver)) ||
+        driver.runtime == nil || driver.capacity == 0 ||
         driver.backend_destroyed) { ret true; }
     var slot_bytes: usize = 0;
     if (!memory.range_scaled(driver.capacity, $size_of(Slot), ?slot_bytes)) {
@@ -640,6 +641,7 @@ test "async network: ownership query includes driver backend and runtime" {
     var external: [8]u8;
     var empty: Driver;
     if (!aliases(?empty, ?external[0], 1) ||
+        !aliases((~(0::usize) - 1)::*Driver, ?external[0], 1) ||
         is_err[bool, io_error.Error](io_runtime.make(?runtime, 2))) { ret 1; }
     var partial: impl.Backend;
     partial.queue = ?runtime.queue;
@@ -647,7 +649,9 @@ test "async network: ownership query includes driver backend and runtime" {
     $if ($mach.build.os == $mach.os.linux || $mach.build.os == $mach.os.darwin) {
         partial.map_capacity = 4;
     }
-    if (!impl.aliases(?partial, ?external[0], 1)) { ret 2; }
+    if (!impl.aliases(?partial, ?external[0], 1) ||
+        !impl.aliases((~(0::usize) - 1)::*impl.Backend,
+            ?external[0], 1)) { ret 2; }
     var driver: Driver;
     if (is_err[bool, io_error.Error](make(?driver, ?runtime))) { ret 3; }
     if (!aliases(?driver, (?driver)::*u8, $size_of(Driver)) ||

--- a/src/net/async/darwin.mach
+++ b/src/net/async/darwin.mach
@@ -10,6 +10,7 @@ use std.types.bool.false;
 use std.types.size.usize;
 use std.system.os.darwin;
 use std.system.os.shared;
+use std.memory;
 use std.net.ip;
 use std.net.async.types;
 use std.io.runtime;
@@ -83,6 +84,42 @@ pub rec Backend {
     ready_count: usize;
     sequence: u64;
     lock: mutex.Mutex;
+}
+
+pub fun aliases(backend: *Backend, data: *u8, len: usize) bool {
+    if (!memory.range_valid(data, len)) { ret true; }
+    if (len == 0) { ret false; }
+    if (backend == nil || backend.queue == nil || backend.capacity == 0 ||
+        backend.map_capacity == 0) { ret true; }
+    var operation_bytes: usize = 0;
+    var resource_bytes: usize = 0;
+    var map_bytes: usize = 0;
+    var native_bytes: usize = 0;
+    var queued_bytes: usize = 0;
+    var ready_bytes: usize = 0;
+    if (!memory.range_scaled(backend.capacity, $size_of(Operation),
+            ?operation_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(Resource),
+            ?resource_bytes) ||
+        !memory.range_scaled(backend.map_capacity, $size_of(u32), ?map_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(darwin.IoCompletion),
+            ?native_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(QueuedCompletion),
+            ?queued_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(types.NativeCompletion),
+            ?ready_bytes)) { ret true; }
+    ret memory.ranges_overlap(backend::*u8, $size_of(Backend), data, len) ||
+        memory.ranges_overlap(backend.queue::*u8, $size_of(shared.IoQueue),
+            data, len) ||
+        memory.ranges_overlap(backend.operations::*u8, operation_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.resources::*u8, resource_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.resource_map::*u8, map_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.native::*u8, native_bytes, data, len) ||
+        memory.ranges_overlap(backend.queued::*u8, queued_bytes, data, len) ||
+        memory.ranges_overlap(backend.ready::*u8, ready_bytes, data, len);
 }
 
 val SLOT_FREE: u8 = 0;

--- a/src/net/async/darwin.mach
+++ b/src/net/async/darwin.mach
@@ -89,7 +89,8 @@ pub rec Backend {
 pub fun aliases(backend: *Backend, data: *u8, len: usize) bool {
     if (!memory.range_valid(data, len)) { ret true; }
     if (len == 0) { ret false; }
-    if (backend == nil || backend.queue == nil || backend.capacity == 0 ||
+    if (!memory.range_valid(backend::*u8, $size_of(Backend)) ||
+        backend.queue == nil || backend.capacity == 0 ||
         backend.map_capacity == 0) { ret true; }
     var operation_bytes: usize = 0;
     var resource_bytes: usize = 0;

--- a/src/net/async/linux.mach
+++ b/src/net/async/linux.mach
@@ -10,6 +10,7 @@ use std.types.bool.false;
 use std.types.size.usize;
 use std.system.os.linux;
 use std.system.os.shared;
+use std.memory;
 use std.net.ip;
 use std.net.async.types;
 use std.io.runtime;
@@ -83,6 +84,42 @@ pub rec Backend {
     ready_count: usize;
     sequence: u64;
     lock: mutex.Mutex;
+}
+
+pub fun aliases(backend: *Backend, data: *u8, len: usize) bool {
+    if (!memory.range_valid(data, len)) { ret true; }
+    if (len == 0) { ret false; }
+    if (backend == nil || backend.queue == nil || backend.capacity == 0 ||
+        backend.map_capacity == 0) { ret true; }
+    var operation_bytes: usize = 0;
+    var resource_bytes: usize = 0;
+    var map_bytes: usize = 0;
+    var native_bytes: usize = 0;
+    var queued_bytes: usize = 0;
+    var ready_bytes: usize = 0;
+    if (!memory.range_scaled(backend.capacity, $size_of(Operation),
+            ?operation_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(Resource),
+            ?resource_bytes) ||
+        !memory.range_scaled(backend.map_capacity, $size_of(u32), ?map_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(linux.IoCompletion),
+            ?native_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(QueuedCompletion),
+            ?queued_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(types.NativeCompletion),
+            ?ready_bytes)) { ret true; }
+    ret memory.ranges_overlap(backend::*u8, $size_of(Backend), data, len) ||
+        memory.ranges_overlap(backend.queue::*u8, $size_of(shared.IoQueue),
+            data, len) ||
+        memory.ranges_overlap(backend.operations::*u8, operation_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.resources::*u8, resource_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.resource_map::*u8, map_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.native::*u8, native_bytes, data, len) ||
+        memory.ranges_overlap(backend.queued::*u8, queued_bytes, data, len) ||
+        memory.ranges_overlap(backend.ready::*u8, ready_bytes, data, len);
 }
 
 val SLOT_FREE: u8 = 0;

--- a/src/net/async/linux.mach
+++ b/src/net/async/linux.mach
@@ -89,7 +89,8 @@ pub rec Backend {
 pub fun aliases(backend: *Backend, data: *u8, len: usize) bool {
     if (!memory.range_valid(data, len)) { ret true; }
     if (len == 0) { ret false; }
-    if (backend == nil || backend.queue == nil || backend.capacity == 0 ||
+    if (!memory.range_valid(backend::*u8, $size_of(Backend)) ||
+        backend.queue == nil || backend.capacity == 0 ||
         backend.map_capacity == 0) { ret true; }
     var operation_bytes: usize = 0;
     var resource_bytes: usize = 0;

--- a/src/net/async/local.mach
+++ b/src/net/async/local.mach
@@ -109,7 +109,8 @@ pub rec Driver {
 pub fun aliases(driver: *Driver, data: *u8, len: usize) bool {
     if (!memory.range_valid(data, len)) { ret true; }
     if (len == 0) { ret false; }
-    if (driver == nil || driver.runtime == nil || driver.capacity == 0 ||
+    if (!memory.range_valid(driver::*u8, $size_of(Driver)) ||
+        driver.runtime == nil || driver.capacity == 0 ||
         driver.backend_destroyed) { ret true; }
     var slot_bytes: usize = 0;
     var listener_bytes: usize = 0;
@@ -1251,6 +1252,7 @@ test "async local: ownership query includes driver backend and runtime" {
     var external: [8]u8;
     var empty: Driver;
     if (!aliases(?empty, ?external[0], 1) ||
+        !aliases((~(0::usize) - 1)::*Driver, ?external[0], 1) ||
         is_err[bool, io_error.Error](io_runtime.make(?runtime, 2))) { ret 1; }
     var partial: impl.Backend;
     partial.queue = ?runtime.queue;
@@ -1261,7 +1263,9 @@ test "async local: ownership query includes driver backend and runtime" {
     $or {
         partial.attached_capacity = 4;
     }
-    if (!impl.aliases(?partial, ?external[0], 1)) { ret 2; }
+    if (!impl.aliases(?partial, ?external[0], 1) ||
+        !impl.aliases((~(0::usize) - 1)::*impl.Backend,
+            ?external[0], 1)) { ret 2; }
     var driver: Driver;
     if (is_err[bool, io_error.Error](make(?driver, ?runtime))) { ret 3; }
     if (!aliases(?driver, (?driver)::*u8, $size_of(Driver)) ||

--- a/src/net/async/local.mach
+++ b/src/net/async/local.mach
@@ -12,6 +12,7 @@ use std.types.result.unwrap_ok;
 use std.types.result.unwrap_err;
 use std.system.os;
 use std.system.panic;
+use std.memory;
 use std.chrono.time;
 use std.sync.cancel;
 use std.sync.atomic;
@@ -102,6 +103,29 @@ pub rec Driver {
     cleanup_code: i64;
     instance: u64;
     lock: mutex.Mutex;
+}
+
+# the caller excludes concurrent destruction while querying stable ownership
+pub fun aliases(driver: *Driver, data: *u8, len: usize) bool {
+    if (!memory.range_valid(data, len)) { ret true; }
+    if (len == 0) { ret false; }
+    if (driver == nil || driver.runtime == nil || driver.capacity == 0 ||
+        driver.backend_destroyed) { ret true; }
+    var slot_bytes: usize = 0;
+    var listener_bytes: usize = 0;
+    var stream_bytes: usize = 0;
+    if (!memory.range_scaled(driver.capacity, $size_of(Slot), ?slot_bytes) ||
+        !memory.range_scaled(driver.capacity, $size_of(ListenerEntry),
+            ?listener_bytes) ||
+        !memory.range_scaled(driver.capacity, $size_of(StreamEntry),
+            ?stream_bytes)) { ret true; }
+    ret memory.ranges_overlap(driver::*u8, $size_of(Driver), data, len) ||
+        memory.ranges_overlap(driver.slots::*u8, slot_bytes, data, len) ||
+        memory.ranges_overlap(driver.listeners::*u8, listener_bytes,
+            data, len) ||
+        memory.ranges_overlap(driver.streams::*u8, stream_bytes, data, len) ||
+        io_runtime.aliases(driver.runtime, data, len) ||
+        impl.aliases(?driver.backend, data, len);
 }
 
 fun invalid(operation: io_error.Operation) io_error.Error {
@@ -1220,6 +1244,54 @@ pub fun destroy(driver: *Driver) Result[bool, io_error.Error] {
     }
     if (cleanup_code < 0) { ret err[bool, io_error.Error](io_error.from_code(cleanup_code, io_error.OP_CLOSE)); }
     ret ok[bool, io_error.Error](true);
+}
+
+test "async local: ownership query includes driver backend and runtime" {
+    var runtime: io_runtime.Runtime;
+    var external: [8]u8;
+    var empty: Driver;
+    if (!aliases(?empty, ?external[0], 1) ||
+        is_err[bool, io_error.Error](io_runtime.make(?runtime, 2))) { ret 1; }
+    var partial: impl.Backend;
+    partial.queue = ?runtime.queue;
+    partial.capacity = 2;
+    $if ($mach.build.os == $mach.os.linux || $mach.build.os == $mach.os.darwin) {
+        partial.map_capacity = 4;
+    }
+    $or {
+        partial.attached_capacity = 4;
+    }
+    if (!impl.aliases(?partial, ?external[0], 1)) { ret 2; }
+    var driver: Driver;
+    if (is_err[bool, io_error.Error](make(?driver, ?runtime))) { ret 3; }
+    if (!aliases(?driver, (?driver)::*u8, $size_of(Driver)) ||
+        !aliases(?driver, driver.slots::*u8, $size_of(Slot) * 2) ||
+        !aliases(?driver, driver.listeners::*u8, $size_of(ListenerEntry) * 2) ||
+        !aliases(?driver, driver.streams::*u8, $size_of(StreamEntry) * 2) ||
+        !aliases(?driver, (?driver.backend)::*u8, $size_of(impl.Backend)) ||
+        !aliases(?driver, driver.backend.operations::*u8, 1) ||
+        !aliases(?driver, runtime.slots::*u8, 1) ||
+        aliases(?driver, ?external[0], 8) ||
+        aliases(?driver, (~(0::usize))::*u8, 1) ||
+        !aliases(?driver, (~(0::usize) - 1)::*u8, 3)) { ret 4; }
+    $if ($mach.build.os == $mach.os.linux || $mach.build.os == $mach.os.darwin) {
+        if (!aliases(?driver, driver.backend.resources::*u8, 1) ||
+            !aliases(?driver, driver.backend.resource_map::*u8, 1) ||
+            !aliases(?driver, driver.backend.native::*u8, 1) ||
+            !aliases(?driver, driver.backend.queued::*u8, 1) ||
+            !aliases(?driver, driver.backend.ready::*u8, 1)) { ret 5; }
+    }
+    $or {
+        if (!aliases(?driver, driver.backend.attached::*u8, 1) ||
+            !aliases(?driver, driver.backend.native::*u8, 1) ||
+            !aliases(?driver, driver.backend.preserved::*u8, 1) ||
+            !aliases(?driver, driver.backend.completions::*u8, 1)) { ret 5; }
+    }
+    if (is_err[bool, io_error.Error](destroy(?driver)) ||
+        !aliases(?driver, ?external[0], 1) ||
+        is_err[bool, io_error.Error](io_runtime.close(?runtime)) ||
+        is_err[bool, io_error.Error](io_runtime.destroy(?runtime))) { ret 6; }
+    ret 0;
 }
 
 test "async local: managed listener tokens are distinct from raw listeners" {

--- a/src/net/async/local/unix.mach
+++ b/src/net/async/local/unix.mach
@@ -10,6 +10,7 @@ use std.types.bool.false;
 use std.types.size.usize;
 use std.system.os;
 use std.system.os.shared;
+use std.memory;
 use std.net.local.endpoint;
 use local_types: std.net.local.types;
 use std.net.async.types;
@@ -86,6 +87,42 @@ pub rec Backend {
     ready_count: usize;
     sequence: u64;
     lock: mutex.Mutex;
+}
+
+pub fun aliases(backend: *Backend, data: *u8, len: usize) bool {
+    if (!memory.range_valid(data, len)) { ret true; }
+    if (len == 0) { ret false; }
+    if (backend == nil || backend.queue == nil || backend.capacity == 0 ||
+        backend.map_capacity == 0) { ret true; }
+    var operation_bytes: usize = 0;
+    var resource_bytes: usize = 0;
+    var map_bytes: usize = 0;
+    var native_bytes: usize = 0;
+    var queued_bytes: usize = 0;
+    var ready_bytes: usize = 0;
+    if (!memory.range_scaled(backend.capacity, $size_of(Operation),
+            ?operation_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(Resource),
+            ?resource_bytes) ||
+        !memory.range_scaled(backend.map_capacity, $size_of(u32), ?map_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(native.IoCompletion),
+            ?native_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(QueuedCompletion),
+            ?queued_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(types.NativeCompletion),
+            ?ready_bytes)) { ret true; }
+    ret memory.ranges_overlap(backend::*u8, $size_of(Backend), data, len) ||
+        memory.ranges_overlap(backend.queue::*u8, $size_of(shared.IoQueue),
+            data, len) ||
+        memory.ranges_overlap(backend.operations::*u8, operation_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.resources::*u8, resource_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.resource_map::*u8, map_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.native::*u8, native_bytes, data, len) ||
+        memory.ranges_overlap(backend.queued::*u8, queued_bytes, data, len) ||
+        memory.ranges_overlap(backend.ready::*u8, ready_bytes, data, len);
 }
 
 val SLOT_FREE: u8 = 0;

--- a/src/net/async/local/unix.mach
+++ b/src/net/async/local/unix.mach
@@ -92,7 +92,8 @@ pub rec Backend {
 pub fun aliases(backend: *Backend, data: *u8, len: usize) bool {
     if (!memory.range_valid(data, len)) { ret true; }
     if (len == 0) { ret false; }
-    if (backend == nil || backend.queue == nil || backend.capacity == 0 ||
+    if (!memory.range_valid(backend::*u8, $size_of(Backend)) ||
+        backend.queue == nil || backend.capacity == 0 ||
         backend.map_capacity == 0) { ret true; }
     var operation_bytes: usize = 0;
     var resource_bytes: usize = 0;

--- a/src/net/async/local/windows.mach
+++ b/src/net/async/local/windows.mach
@@ -72,7 +72,8 @@ pub rec Backend {
 pub fun aliases(backend: *Backend, data: *u8, len: usize) bool {
     if (!memory.range_valid(data, len)) { ret true; }
     if (len == 0) { ret false; }
-    if (backend == nil || backend.queue == nil || backend.capacity == 0 ||
+    if (!memory.range_valid(backend::*u8, $size_of(Backend)) ||
+        backend.queue == nil || backend.capacity == 0 ||
         backend.attached_capacity == 0) { ret true; }
     var operation_bytes: usize = 0;
     var attached_bytes: usize = 0;

--- a/src/net/async/local/windows.mach
+++ b/src/net/async/local/windows.mach
@@ -10,6 +10,7 @@ use std.types.bool.false;
 use std.types.size.usize;
 use std.system.os.windows;
 use std.system.os.shared;
+use std.memory;
 use std.net.local.endpoint;
 use local_types: std.net.local.types;
 use local_impl: std.net.local.windows;
@@ -66,6 +67,36 @@ pub rec Backend {
     attached_count: usize;
     lock: mutex.Mutex;
     io_lock: mutex.Mutex;
+}
+
+pub fun aliases(backend: *Backend, data: *u8, len: usize) bool {
+    if (!memory.range_valid(data, len)) { ret true; }
+    if (len == 0) { ret false; }
+    if (backend == nil || backend.queue == nil || backend.capacity == 0 ||
+        backend.attached_capacity == 0) { ret true; }
+    var operation_bytes: usize = 0;
+    var attached_bytes: usize = 0;
+    var native_bytes: usize = 0;
+    var completion_bytes: usize = 0;
+    if (!memory.range_scaled(backend.capacity, $size_of(Operation),
+            ?operation_bytes) ||
+        !memory.range_scaled(backend.attached_capacity, $size_of(usize),
+            ?attached_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(windows.IoCompletion),
+            ?native_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(types.NativeCompletion),
+            ?completion_bytes)) { ret true; }
+    ret memory.ranges_overlap(backend::*u8, $size_of(Backend), data, len) ||
+        memory.ranges_overlap(backend.queue::*u8, $size_of(shared.IoQueue),
+            data, len) ||
+        memory.ranges_overlap(backend.operations::*u8, operation_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.attached::*u8, attached_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.native::*u8, native_bytes, data, len) ||
+        memory.ranges_overlap(backend.preserved::*u8, native_bytes, data, len) ||
+        memory.ranges_overlap(backend.completions::*u8, completion_bytes,
+            data, len);
 }
 
 val SLOT_FREE: u8 = 0;

--- a/src/net/async/windows.mach
+++ b/src/net/async/windows.mach
@@ -96,7 +96,8 @@ pub rec Backend {
 pub fun aliases(backend: *Backend, data: *u8, len: usize) bool {
     if (!memory.range_valid(data, len)) { ret true; }
     if (len == 0) { ret false; }
-    if (backend == nil || backend.queue == nil || backend.capacity == 0) {
+    if (!memory.range_valid(backend::*u8, $size_of(Backend)) ||
+        backend.queue == nil || backend.capacity == 0) {
         ret true;
     }
     var operation_bytes: usize = 0;

--- a/src/net/async/windows.mach
+++ b/src/net/async/windows.mach
@@ -11,6 +11,7 @@ use std.types.size.usize;
 use std.types.size.isize;
 use std.system.os.windows;
 use std.system.os.shared;
+use std.memory;
 use std.net.ip;
 use std.net.async.types;
 use std.io.runtime;
@@ -90,6 +91,37 @@ pub rec Backend {
     attached_count: usize;
     lock: mutex.Mutex;
     io_lock: mutex.Mutex;
+}
+
+pub fun aliases(backend: *Backend, data: *u8, len: usize) bool {
+    if (!memory.range_valid(data, len)) { ret true; }
+    if (len == 0) { ret false; }
+    if (backend == nil || backend.queue == nil || backend.capacity == 0) {
+        ret true;
+    }
+    var operation_bytes: usize = 0;
+    var attached_bytes: usize = 0;
+    var native_bytes: usize = 0;
+    var completion_bytes: usize = 0;
+    if (!memory.range_scaled(backend.capacity, $size_of(Operation),
+            ?operation_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(usize),
+            ?attached_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(windows.IoCompletion),
+            ?native_bytes) ||
+        !memory.range_scaled(backend.capacity, $size_of(types.NativeCompletion),
+            ?completion_bytes)) { ret true; }
+    ret memory.ranges_overlap(backend::*u8, $size_of(Backend), data, len) ||
+        memory.ranges_overlap(backend.queue::*u8, $size_of(shared.IoQueue),
+            data, len) ||
+        memory.ranges_overlap(backend.operations::*u8, operation_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.attached::*u8, attached_bytes,
+            data, len) ||
+        memory.ranges_overlap(backend.native::*u8, native_bytes, data, len) ||
+        memory.ranges_overlap(backend.preserved::*u8, native_bytes, data, len) ||
+        memory.ranges_overlap(backend.completions::*u8, completion_bytes,
+            data, len);
 }
 
 val SLOT_FREE: u8 = 0;

--- a/test/backends/mach.toml
+++ b/test/backends/mach.toml
@@ -34,6 +34,11 @@ opt = 0
 debug = true
 simd = "scalarize"
 
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
 [artifact.backends]
 kind = "bin"
 entry = "main.mach"

--- a/test/backends/src/main.mach
+++ b/test/backends/src/main.mach
@@ -1,11 +1,15 @@
-# imports the top-level os and filesystem surfaces so target-gated backend
-# modules are instantiated for cross-builds and native artifact checks.
+# imports target-gated backends for cross-builds and native artifact checks
 use std.runtime;
 use std.system.os;
 use std.filesystem;
+use net_async: std.net.async;
+use async_local: std.net.async.local;
 
 #[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
+    if ($size_of(net_async.Driver) == 0 || $size_of(async_local.Driver) == 0) {
+        ret 1;
+    }
     var c: u8 = 'k'::u8;
     os.write(1, ?c, 1);
     ret 0;

--- a/test/backends/verify.sh
+++ b/test/backends/verify.sh
@@ -19,22 +19,27 @@ mkdir -p dep
 ln -sfn "$(cd ../.. && pwd)" dep/std
 
 targets=(windows-x86_64 darwin-x86_64 darwin-aarch64)
+profiles=(debug release)
 
 for target in "${targets[@]}"; do
-    echo "cross-compiling the backend smoke test for $target with $mach"
     rm -rf "out/$target"
-    log="$("$mach" build . --target "$target" --profile debug -vv 2>&1)" \
-        || { echo "$log" >&2; fail "$target failed to compile"; }
+    for profile in "${profiles[@]}"; do
+        echo "cross-compiling the $profile backend smoke test for $target with $mach"
+        log="$("$mach" build . --target "$target" --profile "$profile" \
+            --emit-ir --emit-asm --verify-ir -vv 2>&1)" \
+            || { echo "$log" >&2; fail "$target $profile failed to compile"; }
 
-    exe="$(find "out/$target" -name backends -type f -print -quit)"
-    [ -n "$exe" ] || fail "$target: no backends binary produced"
+        exe="$(find "out/$target/$profile" -name backends -type f -print -quit)"
+        [ -n "$exe" ] || fail "$target $profile: no backends binary produced"
 
-    # confirm the backend's shared module was actually compiled, not skipped
-    # as a target-gated dead branch.
-    echo "$log" | grep -q "skipped .* target-gated modules" \
-        && fail "$target: target-gated modules were skipped"
-    echo "$log" | grep -q "std.system.os.${target%%-*}.shared" \
-        || fail "$target: std.system.os.${target%%-*}.shared was never compiled"
+        # confirm the backend's shared module was actually compiled
+        echo "$log" | grep -q "skipped .* target-gated modules" \
+            && fail "$target $profile: target-gated modules were skipped"
+        echo "$log" | grep -q "std.system.os.${target%%-*}.shared" \
+            || fail "$target $profile: os backend was never compiled"
+        echo "$log" | grep -q "std.net.async.${target%%-*}" \
+            || fail "$target $profile: network backend was never compiled"
 
-    echo "OK: $target backend compiles ($exe)"
+        echo "OK: $target $profile backends compile ($exe)"
+    done
 done

--- a/test/native/verify.sh
+++ b/test/native/verify.sh
@@ -36,9 +36,11 @@ required=(
     'src/process/exec.mach'
     'src/filesystem.mach'
     'src/io/file/tests.mach'
+    'src/io/runtime.mach'
     'src/net/tcp.mach'
     'src/net/udp.mach'
     'src/net/local.mach'
+    'src/net/async.mach'
     'src/net/async/local.mach'
     'src/chrono/time.mach'
     'src/sync/channel.mach'
@@ -89,3 +91,11 @@ fi
 expected_count="$(wc -l < "$expected_file" | tr -d '[:space:]')"
 echo "OK: $target ran the complete native suite with $expected_count known failures"
 echo "OK: thread, process, file, socket, and timer coverage is present"
+
+release_result="$here/results/$target-ownership-release.log"
+"$mach" test . --target "$target" --profile release --include-deps \
+    --filter 'ownership query' 2>&1 | tee "$release_result" \
+    || fail "$target release ownership suite failed"
+grep -qE '[0-9]+ passed, 0 failed, [0-9]+ total' "$release_result" \
+    || fail "$target release ownership suite produced no clean result"
+echo "OK: $target release ownership tests passed"


### PR DESCRIPTION
Closes #542

## Summary

- add maximum-address-safe range and scaled-size primitives
- expose fail-closed ownership queries for completion runtimes and all async network drivers
- cover Linux, Darwin, Windows, and local backend allocations
- document synchronization and fail-closed behavior
- compile target-gated backends in debug and release with IR verification

## Verification

- `mach test . --verify-ir`
- `mach test . -O1 --verify-ir`
- `mach build . --all-targets -O0 --emit-ir --emit-asm --verify-ir`
- `mach build . --all-targets -O1 --emit-ir --emit-asm --verify-ir`
- `bash test/backends/verify.sh`