### PR TITLE
feat(system): add secret-welded storage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Install object inspection tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y llvm
+
       - name: Seed mach
         uses: ./.github/actions/seed-mach
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,9 @@ jobs:
       - name: std.derive comptime refusals
         run: bash test/derive/verify.sh
 
+      - name: Secret-welded pointer refusals
+        run: bash test/secret/verify.sh
+
       - name: Retain native evidence
         if: always()
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### system: secret-welded storage primitives
+
+- `std.system.os.secret_allocate`, `secret_deallocate`, and
+  `secret_random_fill` preserve `*^u8` from zero-initialized native allocation
+  through failure-atomic entropy initialization and wipe-before-release without
+  constructing a public pointer alias (#546).
+- Linux uses direct native syscalls without libc, Darwin uses supported
+  libSystem entry points, and Windows uses VirtualAlloc, VirtualFree, and
+  BCryptGenRandom (#546).
+- The existing Windows `std.system.os.random_fill` now uses checked,
+  chunked BCryptGenRandom calls instead of a mismatched legacy BOOLEAN ABI
+  declaration (#546).
+- Native lifecycle tests, compile-time pointer-erasure refusals, and six-target
+  debug and release IR and assembly gates cover the new boundary (#546).
+
 ## [0.32.0] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -44,6 +44,27 @@ owns no bytes and reports no overlap. Range validation uses inclusive endpoints,
 so a one-byte range at `usize::MAX` is valid while any range extending beyond it
 is malformed and reports overlap.
 
+### Secret-welded operating-system storage
+
+`std.system.os.secret_allocate`, `secret_deallocate`, and
+`secret_random_fill` keep storage typed as `*^u8` across the complete native
+boundary. They never create a public pointer or integer alias to the secret
+bytes. Linux uses direct syscalls without libc, Darwin uses libSystem, and
+Windows uses the stable virtual-memory and system-entropy APIs.
+The Windows entropy boundary requires Vista SP2 or later for
+`BCRYPT_USE_SYSTEM_PREFERRED_RNG`.
+
+Allocation returns zero-initialized storage, or nil for zero bytes or failure.
+Deallocation wipes the complete logical span before native release and returns
+zero only after releasing the original allocation, except that `(nil, 0)` is a
+successful no-op. A failed release leaves zeroed storage owned by the caller.
+Random fill returns zero only after initializing the complete requested range
+and wipes that complete range before returning any error.
+
+The `^` qualifier enforces secret data flow. These primitives do not lock pages,
+exclude them from swap or process dumps, isolate them across process creation,
+add guard pages, or resist a debugger with process access.
+
 ## Contributing
 
 Contributions are welcome! If you find a bug or have a feature request, please open an issue on GitHub. If you'd like to contribute code, please fork the repository and submit a pull request.

--- a/mach.toml
+++ b/mach.toml
@@ -61,9 +61,9 @@ isa = ["*"]
 abi = ["*"]
 export = true
 
-[link.advapi32]
+[link.bcrypt]
 source = "system"
-name = "advapi32.dll"
+name = "bcrypt.dll"
 os = ["windows"]
 isa = ["*"]
 abi = ["*"]
@@ -82,5 +82,5 @@ kind = "static"
 entry = "lib/libstd.mach"
 out = "lib/std"
 targets = ["*"]
-link = ["kernel32", "ws2_32", "advapi32", "synch", "libsystem"]
+link = ["kernel32", "ws2_32", "bcrypt", "synch", "libsystem"]
 need = []

--- a/src/lib/libstd.mach
+++ b/src/lib/libstd.mach
@@ -55,7 +55,6 @@ fwd std.print;
 fwd std.input;
 fwd std.terminal;
 fwd std.runtime;
-use secret_os: std.system.os.secret;
 fwd std.text.parse;
 fwd std.text.utf8;
 fwd std.chrono.duration;

--- a/src/lib/libstd.mach
+++ b/src/lib/libstd.mach
@@ -55,6 +55,7 @@ fwd std.print;
 fwd std.input;
 fwd std.terminal;
 fwd std.runtime;
+use secret_os: std.system.os.secret;
 fwd std.text.parse;
 fwd std.text.utf8;
 fwd std.chrono.duration;

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -121,8 +121,14 @@ fwd impl.ECANCELED;
 fwd impl.allocate;
 fwd impl.deallocate;
 fwd impl.reallocate;
-fwd secret_allocate: secret_os.allocate;
-fwd secret_deallocate: secret_os.deallocate;
+
+pub fun secret_allocate(size: usize) *^u8 {
+    ret secret_os.allocate(size);
+}
+
+pub fun secret_deallocate(data: *^u8, size: usize) i64 {
+    ret secret_os.deallocate(data, size);
+}
 fwd impl.heap_region_base;
 fwd impl.heap_region_extend;
 fwd impl.protect;
@@ -252,7 +258,10 @@ fwd impl.DNS_HOSTS_PATH;
 
 # random
 fwd impl.random_fill;
-fwd secret_random_fill: secret_os.random_fill;
+
+pub fun secret_random_fill(data: *^u8, len: usize) i64 {
+    ret secret_os.random_fill(data, len);
+}
 
 # threads
 fwd impl.thread_spawn;

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -9,6 +9,7 @@ use std.types.string.str;
 use std.types.string.str_len;
 
 use std.system.os.shared;
+use secret_os: std.system.os.secret;
 
 $if ($mach.build.os == $mach.os.linux) {
     use impl: std.system.os.linux;
@@ -120,6 +121,8 @@ fwd impl.ECANCELED;
 fwd impl.allocate;
 fwd impl.deallocate;
 fwd impl.reallocate;
+fwd secret_allocate: secret_os.allocate;
+fwd secret_deallocate: secret_os.deallocate;
 fwd impl.heap_region_base;
 fwd impl.heap_region_extend;
 fwd impl.protect;
@@ -249,6 +252,7 @@ fwd impl.DNS_HOSTS_PATH;
 
 # random
 fwd impl.random_fill;
+fwd secret_random_fill: secret_os.random_fill;
 
 # threads
 fwd impl.thread_spawn;

--- a/src/system/os/secret.mach
+++ b/src/system/os/secret.mach
@@ -11,6 +11,8 @@ val EINTR:  i64 = -4;
 val EFAULT: i64 = -14;
 val EINVAL: i64 = -22;
 
+val EINTR_MAX_RETRIES: usize = 8;
+
 def FillFun: fun(ptr, *^u8, usize) i64;
 def ReleaseFun: fun(ptr, *^u8, usize) i64;
 
@@ -33,11 +35,19 @@ fun fill_all(context: ptr, data: *^u8, len: usize, max_chunk: usize,
     }
 
     var filled: usize = 0;
+    var interruptions: usize = 0;
     for (filled < len) {
         var chunk: usize = len - filled;
         if (chunk > max_chunk) { chunk = max_chunk; }
         val count: i64 = fill_fn(context, ?data[filled], chunk);
-        if (count != EINTR) {
+        if (count == EINTR) {
+            interruptions = interruptions + 1;
+            if (interruptions >= EINTR_MAX_RETRIES) {
+                wipe(data, len);
+                ret EINTR;
+            }
+        }
+        or {
             if (count < 0) {
                 wipe(data, len);
                 ret count;
@@ -47,6 +57,7 @@ fun fill_all(context: ptr, data: *^u8, len: usize, max_chunk: usize,
                 ret EIO;
             }
             filled = filled + count::usize;
+            interruptions = 0;
         }
     }
     ret 0;
@@ -206,14 +217,14 @@ $if ($mach.build.os == $mach.os.linux) {
 $or ($mach.build.os == $mach.os.darwin) {
     use darwin_system: std.system.os.darwin.libsystem;
 
-    #[library("libSystem")] #[symbol("calloc")]
-    ext fun darwin_allocate(count: usize, size: usize) *^u8;
+    #[library("libSystem")]
+    ext fun calloc(count: usize, size: usize) *^u8;
 
-    #[library("libSystem")] #[symbol("free")]
-    ext fun darwin_deallocate(data: *^u8);
+    #[library("libSystem")]
+    ext fun free(data: *^u8);
 
-    #[library("libSystem")] #[symbol("getentropy")]
-    ext fun darwin_getentropy(data: *^u8, len: usize) i32;
+    #[library("libSystem")]
+    ext fun getentropy(data: *^u8, len: usize) i32;
 }
 $or ($mach.build.os == $mach.os.windows) {
     #[library("kernel32.dll")] #[symbol("VirtualAlloc")]
@@ -228,12 +239,12 @@ $or ($mach.build.os == $mach.os.windows) {
 
 $if ($mach.build.os == $mach.os.darwin) {
     fun darwin_release(context: ptr, data: *^u8, size: usize) i64 {
-        darwin_deallocate(data);
+        free(data);
         ret 0;
     }
 
     fun darwin_fill(context: ptr, data: *^u8, len: usize) i64 {
-        if (darwin_getentropy(data, len) != 0) { ret darwin_system.fail_errno(); }
+        if (getentropy(data, len) != 0) { ret darwin_system.fail_errno(); }
         ret len::i64;
     }
 }
@@ -264,7 +275,7 @@ pub fun allocate(size: usize) *^u8 {
         ret linux_allocate(size);
     }
     $or ($mach.build.os == $mach.os.darwin) {
-        ret darwin_allocate(1, size);
+        ret calloc(1, size);
     }
     $or ($mach.build.os == $mach.os.windows) {
         ret windows_allocate(nil, size, 0x3000, 4);
@@ -340,6 +351,28 @@ fun all_zero(data: *^u8, len: usize) i64 {
     ret 1;
 }
 
+rec InterruptProbe {
+    calls: usize;
+    byte:  u8;
+}
+
+fun reset_probe_fill(context: ptr, data: *^u8, len: usize) i64 {
+    val probe: *InterruptProbe = context::*InterruptProbe;
+    probe.calls = probe.calls + 1;
+    if (probe.calls == EINTR_MAX_RETRIES ||
+        probe.calls == EINTR_MAX_RETRIES * 2) {
+        data[0] = probe.byte;
+        ret 1;
+    }
+    ret EINTR;
+}
+
+fun interrupted_fill(context: ptr, data: *^u8, len: usize) i64 {
+    val probe: *InterruptProbe = context::*InterruptProbe;
+    probe.calls = probe.calls + 1;
+    ret EINTR;
+}
+
 rec ReleaseProbe {
     calls:    usize;
     saw_zero: i64;
@@ -392,6 +425,24 @@ test "std.system.os.secret: fill retries partial and interrupted providers" {
         if (data[i]:^ != 0xA5) { ret 1; }
         i = i + 1;
     }
+    ret 0;
+}
+
+test "std.system.os.secret: fill resets its interruption budget after progress" {
+    var data: [2]^u8 = [2]^u8{ 0, 0 };
+    var probe: InterruptProbe = InterruptProbe{calls: 0, byte: 0xA5};
+    if (fill_all(?probe, ?data[0], 2, 2, reset_probe_fill) != 0) { ret 1; }
+    if (probe.calls != EINTR_MAX_RETRIES * 2) { ret 1; }
+    if (data[0]:^ != 0xA5 || data[1]:^ != 0xA5) { ret 1; }
+    ret 0;
+}
+
+test "std.system.os.secret: fill bounds repeated interruptions and wipes" {
+    var data: [4]^u8 = [4]^u8{ 0xA5, 0xA5, 0xA5, 0xA5 };
+    var probe: InterruptProbe = InterruptProbe{calls: 0, byte: 0};
+    if (fill_all(?probe, ?data[0], 4, 4, interrupted_fill) != EINTR) { ret 1; }
+    if (probe.calls != EINTR_MAX_RETRIES) { ret 1; }
+    if (all_zero(?data[0], 4) == 0) { ret 1; }
     ret 0;
 }
 

--- a/src/system/os/secret.mach
+++ b/src/system/os/secret.mach
@@ -318,6 +318,7 @@ pub fun random_fill(data: *^u8, len: usize) i64 {
     }
 }
 
+# generic fixtures instantiate only in test builds
 rec FillScript {
     results: [4]i64;
     len:     usize;
@@ -325,7 +326,7 @@ rec FillScript {
     byte:    u8;
 }
 
-fun scripted_fill(context: ptr, data: *^u8, len: usize) i64 {
+fun scripted_fill[T](context: ptr, data: *^u8, len: usize) i64 {
     val script: *FillScript = context::*FillScript;
     if (script.next >= script.len) { ret EIO; }
     val result: i64 = script.results[script.next];
@@ -342,7 +343,7 @@ fun scripted_fill(context: ptr, data: *^u8, len: usize) i64 {
     ret result;
 }
 
-fun all_zero(data: *^u8, len: usize) i64 {
+fun all_zero[T](data: *^u8, len: usize) i64 {
     var i: usize = 0;
     for (i < len) {
         if (data[i]:^ != 0) { ret 0; }
@@ -356,7 +357,7 @@ rec InterruptProbe {
     byte:  u8;
 }
 
-fun reset_probe_fill(context: ptr, data: *^u8, len: usize) i64 {
+fun reset_probe_fill[T](context: ptr, data: *^u8, len: usize) i64 {
     val probe: *InterruptProbe = context::*InterruptProbe;
     probe.calls = probe.calls + 1;
     if (probe.calls == EINTR_MAX_RETRIES ||
@@ -367,7 +368,7 @@ fun reset_probe_fill(context: ptr, data: *^u8, len: usize) i64 {
     ret EINTR;
 }
 
-fun interrupted_fill(context: ptr, data: *^u8, len: usize) i64 {
+fun interrupted_fill[T](context: ptr, data: *^u8, len: usize) i64 {
     val probe: *InterruptProbe = context::*InterruptProbe;
     probe.calls = probe.calls + 1;
     ret EINTR;
@@ -379,10 +380,10 @@ rec ReleaseProbe {
     result:   i64;
 }
 
-fun probe_release(context: ptr, data: *^u8, size: usize) i64 {
+fun probe_release[T](context: ptr, data: *^u8, size: usize) i64 {
     val probe: *ReleaseProbe = context::*ReleaseProbe;
     probe.calls = probe.calls + 1;
-    probe.saw_zero = all_zero(data, size);
+    probe.saw_zero = all_zero[T](data, size);
     ret probe.result;
 }
 
@@ -397,7 +398,7 @@ test "std.system.os.secret: lifecycle preserves welded storage" {
     val data: *^u8 = allocate(size);
     if (data == nil) { ret 1; }
     var failed: i64 = 0;
-    if (all_zero(data, size) == 0) { failed = 1; }
+    if (all_zero[u8](data, size) == 0) { failed = 1; }
     if (deallocate(data, 0) != EINVAL) {
         failed = 1;
     }
@@ -418,7 +419,7 @@ test "std.system.os.secret: fill retries partial and interrupted providers" {
     var script: FillScript = FillScript{
         results: [4]i64{ EINTR, 2, 2, 0 }, len: 3, next: 0, byte: 0xA5,
     };
-    if (fill_all(?script, ?data[0], 4, 4, scripted_fill) != 0) { ret 1; }
+    if (fill_all(?script, ?data[0], 4, 4, scripted_fill[u8]) != 0) { ret 1; }
     if (script.next != 3) { ret 1; }
     var i: usize = 0;
     for (i < 4) {
@@ -431,7 +432,7 @@ test "std.system.os.secret: fill retries partial and interrupted providers" {
 test "std.system.os.secret: fill resets its interruption budget after progress" {
     var data: [2]^u8 = [2]^u8{ 0, 0 };
     var probe: InterruptProbe = InterruptProbe{calls: 0, byte: 0xA5};
-    if (fill_all(?probe, ?data[0], 2, 2, reset_probe_fill) != 0) { ret 1; }
+    if (fill_all(?probe, ?data[0], 2, 2, reset_probe_fill[u8]) != 0) { ret 1; }
     if (probe.calls != EINTR_MAX_RETRIES * 2) { ret 1; }
     if (data[0]:^ != 0xA5 || data[1]:^ != 0xA5) { ret 1; }
     ret 0;
@@ -440,9 +441,9 @@ test "std.system.os.secret: fill resets its interruption budget after progress" 
 test "std.system.os.secret: fill bounds repeated interruptions and wipes" {
     var data: [4]^u8 = [4]^u8{ 0xA5, 0xA5, 0xA5, 0xA5 };
     var probe: InterruptProbe = InterruptProbe{calls: 0, byte: 0};
-    if (fill_all(?probe, ?data[0], 4, 4, interrupted_fill) != EINTR) { ret 1; }
+    if (fill_all(?probe, ?data[0], 4, 4, interrupted_fill[u8]) != EINTR) { ret 1; }
     if (probe.calls != EINTR_MAX_RETRIES) { ret 1; }
-    if (all_zero(?data[0], 4) == 0) { ret 1; }
+    if (all_zero[u8](?data[0], 4) == 0) { ret 1; }
     ret 0;
 }
 
@@ -451,36 +452,36 @@ test "std.system.os.secret: fill failures wipe the complete destination" {
     var failed: FillScript = FillScript{
         results: [4]i64{ 2, EIO, 0, 0 }, len: 2, next: 0, byte: 0x5A,
     };
-    if (fill_all(?failed, ?data[0], 4, 4, scripted_fill) != EIO ||
-        all_zero(?data[0], 4) == 0) { ret 1; }
+    if (fill_all(?failed, ?data[0], 4, 4, scripted_fill[u8]) != EIO ||
+        all_zero[u8](?data[0], 4) == 0) { ret 1; }
 
     data = [4]^u8{ 0xA5, 0xA5, 0xA5, 0xA5 };
     var stalled: FillScript = FillScript{
         results: [4]i64{ 0, 0, 0, 0 }, len: 1, next: 0, byte: 0x5A,
     };
-    if (fill_all(?stalled, ?data[0], 4, 4, scripted_fill) != EIO ||
-        all_zero(?data[0], 4) == 0) { ret 1; }
+    if (fill_all(?stalled, ?data[0], 4, 4, scripted_fill[u8]) != EIO ||
+        all_zero[u8](?data[0], 4) == 0) { ret 1; }
 
     data = [4]^u8{ 0xA5, 0xA5, 0xA5, 0xA5 };
     var oversized: FillScript = FillScript{
         results: [4]i64{ 5, 0, 0, 0 }, len: 1, next: 0, byte: 0x5A,
     };
-    if (fill_all(?oversized, ?data[0], 4, 4, scripted_fill) != EIO ||
-        all_zero(?data[0], 4) == 0) { ret 1; }
+    if (fill_all(?oversized, ?data[0], 4, 4, scripted_fill[u8]) != EIO ||
+        all_zero[u8](?data[0], 4) == 0) { ret 1; }
     ret 0;
 }
 
 test "std.system.os.secret: release wipes before success or failure" {
     var data: [4]^u8 = [4]^u8{ 0xA5, 0xA5, 0xA5, 0xA5 };
     var failed: ReleaseProbe = ReleaseProbe{calls: 0, saw_zero: 0, result: EIO};
-    if (release_all(?failed, ?data[0], 4, probe_release) != EIO ||
-        failed.calls != 1 || failed.saw_zero == 0 || all_zero(?data[0], 4) == 0) {
+    if (release_all(?failed, ?data[0], 4, probe_release[u8]) != EIO ||
+        failed.calls != 1 || failed.saw_zero == 0 || all_zero[u8](?data[0], 4) == 0) {
         ret 1;
     }
 
     data = [4]^u8{ 0x5A, 0x5A, 0x5A, 0x5A };
     var succeeded: ReleaseProbe = ReleaseProbe{calls: 0, saw_zero: 0, result: 0};
-    if (release_all(?succeeded, ?data[0], 4, probe_release) != 0 ||
+    if (release_all(?succeeded, ?data[0], 4, probe_release[u8]) != 0 ||
         succeeded.calls != 1 || succeeded.saw_zero == 0) { ret 1; }
     ret 0;
 }

--- a/src/system/os/secret.mach
+++ b/src/system/os/secret.mach
@@ -1,0 +1,435 @@
+# portable operating-system primitives for secret-welded storage
+#
+# these functions preserve `*^u8` across every native boundary. they provide
+# secrecy-typed ownership, not memory locking or protection from process dumps.
+
+use std.types.size.isize;
+use std.types.size.usize;
+
+val EIO:    i64 = -5;
+val EINTR:  i64 = -4;
+val EFAULT: i64 = -14;
+val EINVAL: i64 = -22;
+
+def FillFun: fun(ptr, *^u8, usize) i64;
+def ReleaseFun: fun(ptr, *^u8, usize) i64;
+
+#[oblivious]
+fun wipe(data: *^u8, len: usize) {
+    var i: usize = 0;
+    for (i < len) {
+        data[i] = 0;
+        i = i + 1;
+    }
+}
+
+fun fill_all(context: ptr, data: *^u8, len: usize, max_chunk: usize,
+    fill_fn: FillFun) i64 {
+    if (len == 0) { ret 0; }
+    if (data == nil) { ret EFAULT; }
+    if (max_chunk == 0) {
+        wipe(data, len);
+        ret EINVAL;
+    }
+
+    var filled: usize = 0;
+    for (filled < len) {
+        var chunk: usize = len - filled;
+        if (chunk > max_chunk) { chunk = max_chunk; }
+        val count: i64 = fill_fn(context, ?data[filled], chunk);
+        if (count != EINTR) {
+            if (count < 0) {
+                wipe(data, len);
+                ret count;
+            }
+            if (count == 0 || count::usize > chunk) {
+                wipe(data, len);
+                ret EIO;
+            }
+            filled = filled + count::usize;
+        }
+    }
+    ret 0;
+}
+
+fun release_all(context: ptr, data: *^u8, size: usize, release_fn: ReleaseFun) i64 {
+    if (data == nil && size == 0) { ret 0; }
+    if (data == nil || size == 0) { ret EINVAL; }
+    wipe(data, size);
+    ret release_fn(context, data, size);
+}
+
+$if ($mach.build.os == $mach.os.linux) {
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        val SYS_MMAP:      usize = 9;
+        val SYS_MUNMAP:    usize = 11;
+        val SYS_GETRANDOM: usize = 318;
+    }
+    $or ($mach.build.arch == $mach.arch.aarch64 || $mach.build.arch == $mach.arch.riscv64) {
+        val SYS_MMAP:      usize = 222;
+        val SYS_MUNMAP:    usize = 215;
+        val SYS_GETRANDOM: usize = 278;
+    }
+    $or {
+        $error("std.system.os.secret: unsupported linux architecture");
+    }
+
+    fun linux_allocate(size: usize) *^u8 {
+        val syscall_number: usize = SYS_MMAP;
+        val protection: usize = 3;
+        val flags: usize = 0x22;
+        val descriptor: usize = (-1)::isize::usize;
+        val error_floor: usize = (-4095)::isize::usize;
+        var out: *^u8 = nil;
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov rax, {syscall_number}
+                xor rdi, rdi
+                mov rsi, {size}
+                mov rdx, {protection}
+                mov r10, {flags}
+                mov r8, {descriptor}
+                xor r9, r9
+                syscall
+                cmp rax, {error_floor}
+                jb 1f
+                xor rax, rax
+                1:
+                mov {out}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                ldr x8, {syscall_number}
+                mov x0, 0
+                ldr x1, {size}
+                ldr x2, {protection}
+                ldr x3, {flags}
+                ldr x4, {descriptor}
+                mov x5, 0
+                svc 0
+                cmp x0, 0
+                b.ge 1f
+                mov x0, 0
+                1:
+                str x0, {out}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                ld a7, {syscall_number}
+                li a0, 0
+                ld a1, {size}
+                ld a2, {protection}
+                ld a3, {flags}
+                ld a4, {descriptor}
+                li a5, 0
+                ecall
+                bgez a0, 1f
+                li a0, 0
+                1:
+                sd a0, {out}
+            }
+        }
+        ret out;
+    }
+
+    fun linux_deallocate(context: ptr, data: *^u8, size: usize) i64 {
+        val syscall_number: usize = SYS_MUNMAP;
+        var out: i64 = 0;
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov rax, {syscall_number}
+                mov rdi, {data}
+                mov rsi, {size}
+                syscall
+                mov {out}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                ldr x8, {syscall_number}
+                ldr x0, {data}
+                ldr x1, {size}
+                svc 0
+                str x0, {out}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                ld a7, {syscall_number}
+                ld a0, {data}
+                ld a1, {size}
+                ecall
+                sd a0, {out}
+            }
+        }
+        ret out;
+    }
+
+    fun linux_random_fill(context: ptr, data: *^u8, len: usize) i64 {
+        val syscall_number: usize = SYS_GETRANDOM;
+        var out: i64 = 0;
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov rax, {syscall_number}
+                mov rdi, {data}
+                mov rsi, {len}
+                xor rdx, rdx
+                syscall
+                mov {out}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                ldr x8, {syscall_number}
+                ldr x0, {data}
+                ldr x1, {len}
+                mov x2, 0
+                svc 0
+                str x0, {out}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                ld a7, {syscall_number}
+                ld a0, {data}
+                ld a1, {len}
+                li a2, 0
+                ecall
+                sd a0, {out}
+            }
+        }
+        ret out;
+    }
+}
+$or ($mach.build.os == $mach.os.darwin) {
+    use darwin_system: std.system.os.darwin.libsystem;
+
+    #[library("libSystem")] #[symbol("calloc")]
+    ext fun darwin_allocate(count: usize, size: usize) *^u8;
+
+    #[library("libSystem")] #[symbol("free")]
+    ext fun darwin_deallocate(data: *^u8);
+
+    #[library("libSystem")] #[symbol("getentropy")]
+    ext fun darwin_getentropy(data: *^u8, len: usize) i32;
+}
+$or ($mach.build.os == $mach.os.windows) {
+    #[library("kernel32.dll")] #[symbol("VirtualAlloc")]
+    ext fun windows_allocate(address: ptr, size: usize, allocation_type: u32, protection: u32) *^u8;
+
+    #[library("kernel32.dll")] #[symbol("VirtualFree")]
+    ext fun windows_deallocate(data: *^u8, size: usize, free_type: u32) i32;
+
+    #[library("bcrypt.dll")] #[symbol("BCryptGenRandom")]
+    ext fun windows_bcrypt_random(algorithm: isize, data: *^u8, len: u32, flags: u32) i32;
+}
+
+$if ($mach.build.os == $mach.os.darwin) {
+    fun darwin_release(context: ptr, data: *^u8, size: usize) i64 {
+        darwin_deallocate(data);
+        ret 0;
+    }
+
+    fun darwin_fill(context: ptr, data: *^u8, len: usize) i64 {
+        if (darwin_getentropy(data, len) != 0) { ret darwin_system.fail_errno(); }
+        ret len::i64;
+    }
+}
+$or ($mach.build.os == $mach.os.windows) {
+    fun windows_release(context: ptr, data: *^u8, size: usize) i64 {
+        if (windows_deallocate(data, 0, 0x8000) != 0) { ret 0; }
+        ret EIO;
+    }
+
+    fun windows_fill(context: ptr, data: *^u8, len: usize) i64 {
+        if (windows_bcrypt_random(0, data, len::u32, 2) != 0) { ret EIO; }
+        ret len::i64;
+    }
+}
+$or ($mach.build.os == $mach.os.linux) {
+}
+$or {
+    $error("std.system.os.secret: unsupported target");
+}
+
+# allocate one zero-initialized secret-welded byte region
+# ---
+# size: number of addressable bytes
+# ret:  logical span owner, or nil for zero size or failure
+pub fun allocate(size: usize) *^u8 {
+    if (size == 0) { ret nil; }
+    $if ($mach.build.os == $mach.os.linux) {
+        ret linux_allocate(size);
+    }
+    $or ($mach.build.os == $mach.os.darwin) {
+        ret darwin_allocate(1, size);
+    }
+    $or ($mach.build.os == $mach.os.windows) {
+        ret windows_allocate(nil, size, 0x3000, 4);
+    }
+}
+
+# release one secret-welded byte region
+# ---
+# data: allocation returned by allocate
+# size: original nonzero allocation size
+# ret:  zero after wipe and release, or a negative error with zeroed ownership retained
+pub fun deallocate(data: *^u8, size: usize) i64 {
+    $if ($mach.build.os == $mach.os.linux) {
+        ret release_all(nil, data, size, linux_deallocate);
+    }
+    $or ($mach.build.os == $mach.os.darwin) {
+        ret release_all(nil, data, size, darwin_release);
+    }
+    $or ($mach.build.os == $mach.os.windows) {
+        ret release_all(nil, data, size, windows_release);
+    }
+}
+
+# initialize every requested byte from the operating-system csprng
+# ---
+# data: destination secret storage
+# len:  number of bytes to initialize
+# ret:  zero after complete initialization, or a negative error after a complete wipe
+pub fun random_fill(data: *^u8, len: usize) i64 {
+    if (len == 0) { ret 0; }
+    if (data == nil) { ret EFAULT; }
+    $if ($mach.build.os == $mach.os.linux) {
+        ret fill_all(nil, data, len, 0xFFFFFFFFFFFFFFFF, linux_random_fill);
+    }
+    $or ($mach.build.os == $mach.os.darwin) {
+        ret fill_all(nil, data, len, 256, darwin_fill);
+    }
+    $or ($mach.build.os == $mach.os.windows) {
+        ret fill_all(nil, data, len, 0xFFFFFFFF, windows_fill);
+    }
+}
+
+rec FillScript {
+    results: [4]i64;
+    len:     usize;
+    next:    usize;
+    byte:    u8;
+}
+
+fun scripted_fill(context: ptr, data: *^u8, len: usize) i64 {
+    val script: *FillScript = context::*FillScript;
+    if (script.next >= script.len) { ret EIO; }
+    val result: i64 = script.results[script.next];
+    script.next = script.next + 1;
+    if (result > 0) {
+        var count: usize = result::usize;
+        if (count > len) { count = len; }
+        var i: usize = 0;
+        for (i < count) {
+            data[i] = script.byte;
+            i = i + 1;
+        }
+    }
+    ret result;
+}
+
+fun all_zero(data: *^u8, len: usize) i64 {
+    var i: usize = 0;
+    for (i < len) {
+        if (data[i]:^ != 0) { ret 0; }
+        i = i + 1;
+    }
+    ret 1;
+}
+
+rec ReleaseProbe {
+    calls:    usize;
+    saw_zero: i64;
+    result:   i64;
+}
+
+fun probe_release(context: ptr, data: *^u8, size: usize) i64 {
+    val probe: *ReleaseProbe = context::*ReleaseProbe;
+    probe.calls = probe.calls + 1;
+    probe.saw_zero = all_zero(data, size);
+    ret probe.result;
+}
+
+test "std.system.os.secret: lifecycle preserves welded storage" {
+    if (allocate(0) != nil) { ret 1; }
+    if (deallocate(nil, 0) != 0) { ret 1; }
+    if (deallocate(nil, 1) != EINVAL) { ret 1; }
+    if (random_fill(nil, 0) != 0) { ret 1; }
+    if (random_fill(nil, 1) != EFAULT) { ret 1; }
+
+    val size: usize = 513;
+    val data: *^u8 = allocate(size);
+    if (data == nil) { ret 1; }
+    var failed: i64 = 0;
+    if (all_zero(data, size) == 0) { failed = 1; }
+    if (deallocate(data, 0) != EINVAL) {
+        failed = 1;
+    }
+    data[0] = 0xA5;
+    data[size - 1] = 0x5A;
+    if (data[0]:^ != 0xA5 || data[size - 1]:^ != 0x5A) {
+        failed = 1;
+    }
+    if (random_fill(data, size) != 0) {
+        failed = 1;
+    }
+    if (deallocate(data, size) != 0) { ret 1; }
+    ret failed::i32;
+}
+
+test "std.system.os.secret: fill retries partial and interrupted providers" {
+    var data: [4]^u8 = [4]^u8{ 0, 0, 0, 0 };
+    var script: FillScript = FillScript{
+        results: [4]i64{ EINTR, 2, 2, 0 }, len: 3, next: 0, byte: 0xA5,
+    };
+    if (fill_all(?script, ?data[0], 4, 4, scripted_fill) != 0) { ret 1; }
+    if (script.next != 3) { ret 1; }
+    var i: usize = 0;
+    for (i < 4) {
+        if (data[i]:^ != 0xA5) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+test "std.system.os.secret: fill failures wipe the complete destination" {
+    var data: [4]^u8 = [4]^u8{ 0xA5, 0xA5, 0xA5, 0xA5 };
+    var failed: FillScript = FillScript{
+        results: [4]i64{ 2, EIO, 0, 0 }, len: 2, next: 0, byte: 0x5A,
+    };
+    if (fill_all(?failed, ?data[0], 4, 4, scripted_fill) != EIO ||
+        all_zero(?data[0], 4) == 0) { ret 1; }
+
+    data = [4]^u8{ 0xA5, 0xA5, 0xA5, 0xA5 };
+    var stalled: FillScript = FillScript{
+        results: [4]i64{ 0, 0, 0, 0 }, len: 1, next: 0, byte: 0x5A,
+    };
+    if (fill_all(?stalled, ?data[0], 4, 4, scripted_fill) != EIO ||
+        all_zero(?data[0], 4) == 0) { ret 1; }
+
+    data = [4]^u8{ 0xA5, 0xA5, 0xA5, 0xA5 };
+    var oversized: FillScript = FillScript{
+        results: [4]i64{ 5, 0, 0, 0 }, len: 1, next: 0, byte: 0x5A,
+    };
+    if (fill_all(?oversized, ?data[0], 4, 4, scripted_fill) != EIO ||
+        all_zero(?data[0], 4) == 0) { ret 1; }
+    ret 0;
+}
+
+test "std.system.os.secret: release wipes before success or failure" {
+    var data: [4]^u8 = [4]^u8{ 0xA5, 0xA5, 0xA5, 0xA5 };
+    var failed: ReleaseProbe = ReleaseProbe{calls: 0, saw_zero: 0, result: EIO};
+    if (release_all(?failed, ?data[0], 4, probe_release) != EIO ||
+        failed.calls != 1 || failed.saw_zero == 0 || all_zero(?data[0], 4) == 0) {
+        ret 1;
+    }
+
+    data = [4]^u8{ 0x5A, 0x5A, 0x5A, 0x5A };
+    var succeeded: ReleaseProbe = ReleaseProbe{calls: 0, saw_zero: 0, result: 0};
+    if (release_all(?succeeded, ?data[0], 4, probe_release) != 0 ||
+        succeeded.calls != 1 || succeeded.saw_zero == 0) { ret 1; }
+    ret 0;
+}

--- a/src/system/os/windows/shared.mach
+++ b/src/system/os/windows/shared.mach
@@ -2,7 +2,7 @@
 #
 # windows has no stable syscall interface. all OS interaction goes through
 # kernel32.dll and ntdll.dll via ext fun declarations, plus ws2_32.dll for
-# sockets, advapi32.dll for RtlGenRandom, and api-ms-win-core-synch-l1-2-0.dll
+# sockets, bcrypt.dll for system entropy, and api-ms-win-core-synch-l1-2-0.dll
 # for the wait-on-address family. every import carries an explicit `#[library]`
 # decorator naming its providing DLL, so the PE import directory attributes each
 # to the right DLL rather than the first dependency. a HANDLE-to-fd mapping table
@@ -414,9 +414,8 @@ ext fun ws2_recv(p0: usize, p1: *u8, p2: i32, p3: i32) i32;
 #[library("ws2_32.dll")]
 ext fun closesocket(p0: usize) i32;
 
-# advapi32.dll
-#[library("advapi32.dll")]
-ext fun SystemFunction036(p0: *u8, p1: u32) i32;
+#[library("bcrypt.dll")]
+ext fun BCryptGenRandom(p0: isize, p1: *u8, p2: u32, p3: u32) i32;
 
 #[library("kernel32.dll")]
 ext fun GetCurrentProcessId() u32;
@@ -3970,15 +3969,22 @@ pub val DNS_HOSTS_PATH: str = "C:/Windows/System32/drivers/etc/hosts";
 
 # random
 
-# fill a buffer with cryptographic random bytes via RtlGenRandom
+# fill a buffer with cryptographic random bytes via BCryptGenRandom
 # ---
 # buf:  destination buffer
 # len:  number of bytes to fill
 # ret:  0 on success, or negative errno
 pub fun random_fill(buf: *u8, len: usize) i64 {
     if (len == 0) { ret 0; }
-    if (SystemFunction036(buf, len::u32) != 0) { ret 0; }
-    ret EIO;
+    if (buf == nil) { ret EFAULT; }
+    var filled: usize = 0;
+    for (filled < len) {
+        var chunk: usize = len - filled;
+        if (chunk > 0xFFFFFFFF) { chunk = 0xFFFFFFFF; }
+        if (BCryptGenRandom(0, ?buf[filled], chunk::u32, 2) != 0) { ret EIO; }
+        filled = filled + chunk;
+    }
+    ret 0;
 }
 
 # time

--- a/test/backends/mach.toml
+++ b/test/backends/mach.toml
@@ -14,6 +14,11 @@ isa = "aarch64"
 os  = "linux"
 abi = "aapcs64"
 
+[target.linux-riscv64]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64"
+
 [target.windows-x86_64]
 isa = "x86_64"
 os  = "windows"

--- a/test/backends/verify.sh
+++ b/test/backends/verify.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # cross-compile a program that references std.system.os (and, through it,
-# std.runtime) for the windows and darwin targets, against this checkout's
-# std. proves the target-gated backend modules actually compile instead of
-# being skipped as dead $if branches -- see #426. compile only; nothing here
-# is run.
+# std.runtime) for every supported target against this checkout's std. proves
+# target-gated backend modules compile instead of being skipped as dead $if
+# branches. compile only; nothing here is run.
 #
 # usage: verify.sh [path-to-mach]   (defaults to `mach` on PATH)
 set -euo pipefail
@@ -18,7 +17,14 @@ fail() { echo "FAIL: $1" >&2; exit 1; }
 mkdir -p dep
 ln -sfn "$(cd ../.. && pwd)" dep/std
 
-targets=(windows-x86_64 darwin-x86_64 darwin-aarch64)
+targets=(
+    linux-x86_64
+    linux-arm64
+    linux-riscv64
+    windows-x86_64
+    darwin-x86_64
+    darwin-aarch64
+)
 profiles=(debug release)
 
 for target in "${targets[@]}"; do
@@ -39,6 +45,76 @@ for target in "${targets[@]}"; do
             || fail "$target $profile: os backend was never compiled"
         echo "$log" | grep -q "std.net.async.${target%%-*}" \
             || fail "$target $profile: network backend was never compiled"
+
+        secret_ir="out/$target/$profile/ir/std/system/os/secret.ir"
+        secret_asm="out/$target/$profile/asm/std/system/os/secret.s"
+        [ -f "$secret_ir" ] || fail "$target $profile: secret OS IR missing"
+        [ -f "$secret_asm" ] || fail "$target $profile: secret OS assembly missing"
+        grep -q 'fn @std.system.os.secret.allocate' "$secret_ir" \
+            || fail "$target $profile: secret allocation boundary missing"
+        grep -q 'fn @std.system.os.secret.deallocate' "$secret_ir" \
+            || fail "$target $profile: secret release boundary missing"
+        grep -q 'fn @std.system.os.secret.random_fill' "$secret_ir" \
+            || fail "$target $profile: secret entropy boundary missing"
+        if grep -Eq 'ptrtoint|inttoptr' "$secret_ir"; then
+            fail "$target $profile: secret boundary materialized an integer pointer alias"
+        fi
+        release_ir="$(sed -n '/fn @std.system.os.secret.release_all/,/^  fn /p' "$secret_ir")"
+        if [ "$profile" = debug ]; then
+            wipe_ir_line="$(echo "$release_ir" | grep -n -m1 'call void @std.system.os.secret.wipe' | cut -d: -f1 || true)"
+        else
+            wipe_ir_line="$(echo "$release_ir" | grep -n -m1 'store 0: i8' | cut -d: -f1 || true)"
+        fi
+        release_ir_line="$(echo "$release_ir" | grep -n -m1 'call i64 %p3' | cut -d: -f1 || true)"
+        [ -n "$wipe_ir_line" ] || fail "$target $profile: secret release wipe missing from IR"
+        [ -n "$release_ir_line" ] || fail "$target $profile: native release call missing from IR"
+        [ "$wipe_ir_line" -lt "$release_ir_line" ] \
+            || fail "$target $profile: native release call precedes secret wipe in IR"
+        case "$target" in
+            linux-*)
+                grep -q 'syscall\|ecall\|svc' "$secret_asm" \
+                    || fail "$target $profile: secret boundary omitted native syscalls"
+                if grep -Eq 'malloc|free|getrandom' "$secret_asm"; then
+                    fail "$target $profile: secret boundary gained a libc dependency"
+                fi
+                ;;
+            darwin-*)
+                grep -q 'calloc' "$secret_asm" \
+                    || fail "$target $profile: secret allocator omitted libSystem calloc"
+                grep -q 'getentropy' "$secret_asm" \
+                    || fail "$target $profile: secret entropy omitted libSystem getentropy"
+                grep -q 'free' "$secret_asm" \
+                    || fail "$target $profile: secret release omitted libSystem free"
+                ;;
+            windows-*)
+                grep -q 'VirtualAlloc' "$secret_asm" \
+                    || fail "$target $profile: secret allocator omitted VirtualAlloc"
+                grep -q 'BCryptGenRandom' "$secret_asm" \
+                    || fail "$target $profile: secret entropy omitted BCryptGenRandom"
+                if llvm-readobj --coff-imports "$exe" | grep -q 'SystemFunction036'; then
+                    fail "$target $profile: legacy RtlGenRandom import remains"
+                fi
+                ;;
+        esac
+        if [ "$profile" = release ]; then
+            release_body="$(sed -n '/std.system.os.secret.deallocate:/,/std.system.os.secret.random_fill:/p' "$secret_asm")"
+            wipe_line="$(echo "$release_body" | grep -n -m1 -E 'mov byte \[[^]]+\], 0|strb wzr|sb zero' | cut -d: -f1 || true)"
+            case "$target" in
+                linux-*)
+                    release_line="$(echo "$release_body" | grep -n -m1 -E 'syscall|ecall|svc' | cut -d: -f1 || true)"
+                    ;;
+                darwin-*)
+                    release_line="$(echo "$release_body" | grep -n -m1 'free' | cut -d: -f1 || true)"
+                    ;;
+                windows-*)
+                    release_line="$(echo "$release_body" | grep -n -m1 'VirtualFree' | cut -d: -f1 || true)"
+                    ;;
+            esac
+            [ -n "$wipe_line" ] || fail "$target release: secret release wipe missing from assembly"
+            [ -n "$release_line" ] || fail "$target release: native release missing from assembly"
+            [ "$wipe_line" -lt "$release_line" ] \
+                || fail "$target release: native release precedes secret wipe in assembly"
+        fi
 
         echo "OK: $target $profile backends compile ($exe)"
     done

--- a/test/backends/verify.sh
+++ b/test/backends/verify.sh
@@ -79,12 +79,22 @@ for target in "${targets[@]}"; do
                 fi
                 ;;
             darwin-*)
-                grep -q 'calloc' "$secret_asm" \
+                grep -q '_calloc' "$secret_asm" \
                     || fail "$target $profile: secret allocator omitted libSystem calloc"
-                grep -q 'getentropy' "$secret_asm" \
+                grep -q '_getentropy' "$secret_asm" \
                     || fail "$target $profile: secret entropy omitted libSystem getentropy"
-                grep -q 'free' "$secret_asm" \
+                grep -q '_free' "$secret_asm" \
                     || fail "$target $profile: secret release omitted libSystem free"
+                undefined="$(llvm-nm -u "$exe")"
+                echo "$undefined" | grep -Eq '(^|[[:space:]])_calloc$' \
+                    || fail "$target $profile: Mach-O calloc import is misspelled"
+                echo "$undefined" | grep -Eq '(^|[[:space:]])_getentropy$' \
+                    || fail "$target $profile: Mach-O getentropy import is misspelled"
+                echo "$undefined" | grep -Eq '(^|[[:space:]])_free$' \
+                    || fail "$target $profile: Mach-O free import is misspelled"
+                if echo "$undefined" | grep -Eq '(^|[[:space:]])(calloc|getentropy|free)$'; then
+                    fail "$target $profile: unprefixed Mach-O secret import remains"
+                fi
                 ;;
             windows-*)
                 grep -q 'VirtualAlloc' "$secret_asm" \
@@ -104,7 +114,7 @@ for target in "${targets[@]}"; do
                     release_line="$(echo "$release_body" | grep -n -m1 -E 'syscall|ecall|svc' | cut -d: -f1 || true)"
                     ;;
                 darwin-*)
-                    release_line="$(echo "$release_body" | grep -n -m1 'free' | cut -d: -f1 || true)"
+                    release_line="$(echo "$release_body" | grep -n -m1 '_free' | cut -d: -f1 || true)"
                     ;;
                 windows-*)
                     release_line="$(echo "$release_body" | grep -n -m1 'VirtualFree' | cut -d: -f1 || true)"

--- a/test/backends/verify.sh
+++ b/test/backends/verify.sh
@@ -13,6 +13,9 @@ cd "$here"
 
 fail() { echo "FAIL: $1" >&2; exit 1; }
 
+command -v llvm-nm >/dev/null || fail "llvm-nm is required"
+command -v llvm-readobj >/dev/null || fail "llvm-readobj is required"
+
 # vendor this checkout's std as the path dependency (dep/std -> repo root).
 mkdir -p dep
 ln -sfn "$(cd ../.. && pwd)" dep/std
@@ -58,6 +61,9 @@ for target in "${targets[@]}"; do
             || fail "$target $profile: secret entropy boundary missing"
         if grep -Eq 'ptrtoint|inttoptr' "$secret_ir"; then
             fail "$target $profile: secret boundary materialized an integer pointer alias"
+        fi
+        if grep -Eq 'std[.]system[.]os[.]secret[.](scripted_fill|all_zero|reset_probe_fill|interrupted_fill|probe_release)' "$secret_ir"; then
+            fail "$target $profile: secret test-only inspection entered the production artifact"
         fi
         release_ir="$(sed -n '/fn @std.system.os.secret.release_all/,/^  fn /p' "$secret_ir")"
         if [ "$profile" = debug ]; then

--- a/test/native/verify.sh
+++ b/test/native/verify.sh
@@ -32,6 +32,7 @@ trap 'rm -f "$expected_file" "$actual_file"' EXIT
     || fail "$target suite could not be listed"
 
 required=(
+    'src/system/os/secret.mach'
     'src/sync/thread.mach'
     'src/process/exec.mach'
     'src/filesystem.mach'

--- a/test/secret/mach.toml
+++ b/test/secret/mach.toml
@@ -1,0 +1,21 @@
+[project]
+id = "secret-refusals"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.linux-x86_64]
+isa = "x86_64"
+os = "linux"
+abi = "sysv64"
+
+[artifact.refusals]
+kind = "bin"
+entry = "refusals.mach"
+out = "bin/refusals"
+targets = ["*"]
+link = []
+need = []
+
+[dep.std]
+path = "dep/std"

--- a/test/secret/src/refusals.mach
+++ b/test/secret/src/refusals.mach
@@ -1,0 +1,15 @@
+use std.system.os;
+use std.types.size.usize;
+
+fun erase_pointer() ptr {
+    ret os.secret_allocate(1);
+}
+
+fun erase_integer() usize {
+    ret os.secret_allocate(1)::usize;
+}
+
+#[symbol("main")]
+fun main(argc: i64, argv: **u8) i64 {
+    ret 0;
+}

--- a/test/secret/verify.sh
+++ b/test/secret/verify.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mach="${1:-mach}"
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root="$(cd "$here/../.." && pwd)"
+
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+mkdir -p "$here/dep"
+ln -sfn "$root" "$here/dep/std"
+
+cd "$here"
+set +e
+log="$("$mach" build . 2>&1)"
+code=$?
+set -e
+[ "$code" -ne 0 ] || fail "refusals unexpectedly erased secret-welded pointers"
+echo "$log" | grep -q 'expected ptr, found \*\^u8' \
+    || { echo "$log" >&2; fail "pointer erasure failed for the wrong reason"; }
+echo "$log" | grep -q 'cannot add or drop the secret qualifier' \
+    || { echo "$log" >&2; fail "integer erasure failed for the wrong reason"; }
+echo "OK: pointer and integer erasures preserve the welded-pointer boundary"


### PR DESCRIPTION
## Summary

- add portable secret-welded allocation, release, and entropy primitives
- guarantee zero-initialized allocation, wipe-before-release, bounded interruption handling, and failure-atomic entropy fill
- preserve `*^u8` through Linux syscalls, Darwin libSystem, and Windows system APIs
- move Windows public entropy from legacy RtlGenRandom to checked BCryptGenRandom calls
- keep injected providers and explicit declassification inspection test-only, with ordinary-artifact exclusion gates
- add native lifecycle, injected failure, compile-refusal, six-target IR, assembly, symbol, and dependency gates

## Verification

- `mach test . --verify-ir`: 1031/1031
- `mach test . -O1 --verify-ir`: 1031/1031
- `bash test/native/verify.sh mach linux-x86_64`: 1035/1035 plus optimized ownership tests
- `bash test/secret/verify.sh mach`
- `bash test/backends/verify.sh mach`: six targets in debug and release

Closes #546