### PR TITLE
chore(release): 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.33.0] - 2026-08-28
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -9,13 +9,13 @@ To use the standard library in your Mach project, you can include it as a depend
 ```toml
 [deps.mach-std]
 git = "https://github.com/briar-systems/mach-std"
-ref = "tag/v0.32.0"
+ref = "tag/v0.33.0"
 ```
 
 You can also use the Mach dependency manager to add it to your project:
 
 ```bash
-mach dep add mach-std --git https://github.com/briar-systems/mach-std --ref tag/v0.32.0
+mach dep add mach-std --git https://github.com/briar-systems/mach-std --ref tag/v0.33.0
 ```
 
 ## Documentation

--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.32.0"
+version = "0.33.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 


### PR DESCRIPTION
Release 0.33.0 with portable secret-welded allocation, entropy, and release primitives.

## Verification

- `mach test . --verify-ir`: 1031/1031
- `mach test . -O1 --verify-ir`: 1031/1031
- `bash test/native/verify.sh mach linux-x86_64`: 1035/1035 plus optimized ownership tests
- feature PR #547 passed all seven CI jobs and independent production review