### PR TITLE
Revert "fix(aarch64): use // for inline-asm comments, not #"

### DIFF
--- a/src/runtime/darwin/aarch64.mach
+++ b/src/runtime/darwin/aarch64.mach
@@ -43,8 +43,8 @@ fun _rt_init() {
 #[symbol("start")]
 pub fun _start() {
     asm aarch64 {
-        // dyld enters an LC_MAIN executable with main's arguments in registers:
-        //   x0 = argc, x1 = argv, x2 = envp
+        # dyld enters an LC_MAIN executable with main's arguments in registers:
+        #   x0 = argc, x1 = argv, x2 = envp
         adrp x11, _rt_argc
         str x0, [x11, :lo12:_rt_argc]
         adrp x11, _rt_argv
@@ -52,8 +52,8 @@ pub fun _start() {
         adrp x11, _rt_envp
         str x2, [x11, :lo12:_rt_envp]
 
-        // the stack dyld hands the LC_MAIN entry is already 16-byte aligned (an
-        // arm64 architectural invariant), so no realignment is needed.
+        # the stack dyld hands the LC_MAIN entry is already 16-byte aligned (an
+        # arm64 architectural invariant), so no realignment is needed.
         bl _rt_init
 
         adrp x11, _rt_argc
@@ -62,7 +62,7 @@ pub fun _start() {
         ldr x1, [x11, :lo12:_rt_argv]
         bl main
 
-        mov x16, 1           // SYS_exit
+        mov x16, 1           # SYS_exit
         svc 0x80
     }
 }

--- a/src/runtime/linux/aarch64.mach
+++ b/src/runtime/linux/aarch64.mach
@@ -66,14 +66,14 @@ fun _rt_init() {
 #[symbol("_start")]
 pub fun _start() {
     asm aarch64 {
-        mov x9, sp            // x9 = initial stack pointer (argc at [x9])
-        ldr x0, [x9]          // argc -> x0 (1st argument to main)
-        add x1, x9, 8         // argv -> x1 (2nd argument to main)
+        mov x9, sp            # x9 = initial stack pointer (argc at [x9])
+        ldr x0, [x9]          # argc -> x0 (1st argument to main)
+        add x1, x9, 8         # argv -> x1 (2nd argument to main)
 
-        // envp = argv + (argc + 1) * 8
+        # envp = argv + (argc + 1) * 8
         add x10, x0, 1
         lsl x10, x10, 3
-        add x10, x1, x10      // x10 = envp
+        add x10, x1, x10      # x10 = envp
 
         adrp x11, _rt_argc
         str x0, [x11, :lo12:_rt_argc]
@@ -82,8 +82,8 @@ pub fun _start() {
         adrp x11, _rt_envp
         str x10, [x11, :lo12:_rt_envp]
 
-        // sp is 16-byte aligned on kernel entry (AAPCS64 invariant), so no
-        // realignment is needed before the calls.
+        # sp is 16-byte aligned on kernel entry (AAPCS64 invariant), so no
+        # realignment is needed before the calls.
         bl _rt_init
 
         adrp x11, _rt_argc
@@ -92,8 +92,8 @@ pub fun _start() {
         ldr x1, [x11, :lo12:_rt_argv]
         bl main
 
-        // exit_group with main's return value (already in x0)
-        mov x8, 94           // SYS_exit_group
+        # exit_group with main's return value (already in x0)
+        mov x8, 94           # SYS_exit_group
         svc 0
     }
 }

--- a/src/system/os/linux/aarch64.mach
+++ b/src/system/os/linux/aarch64.mach
@@ -115,29 +115,29 @@ fun thread_trampoline() {
 
         mov x0, x19
         mov x1, x20
-        mov x8, 215           // SYS_munmap
+        mov x8, 215           # SYS_munmap
         svc 0
 
         cbnz x24, 1f
         mov x0, 1
         str x0, [x21]
         mov x0, x21
-        mov x1, 1             // FUTEX_WAKE
+        mov x1, 1             # FUTEX_WAKE
         mov x2, 1
         mov x3, 0
         mov x4, 0
         mov x5, 0
-        mov x8, 98            // SYS_futex
+        mov x8, 98            # SYS_futex
         svc 0
         b 2f
     1:
         mov x0, x22
         mov x1, x23
-        mov x8, 215           // SYS_munmap
+        mov x8, 215           # SYS_munmap
         svc 0
     2:
         mov x0, 0
-        mov x8, 93            // SYS_exit
+        mov x8, 93            # SYS_exit
         svc 0
     }
     asm aarch64 { brk 0 }
@@ -195,12 +195,12 @@ pub fun thread_spawn(
         mov x2, 0
         mov x3, 0
         mov x4, 0
-        mov x8, 220           // SYS_clone
+        mov x8, 220           # SYS_clone
         svc 0
-        cbnz x0, 1f           // parent (tid != 0): skip the child dispatch
-        b _std_thread_trampoline   // child (x0 == 0): branch to trampoline (no return)
+        cbnz x0, 1f           # parent (tid != 0): skip the child dispatch
+        b _std_thread_trampoline   # child (x0 == 0): branch to trampoline (no return)
     1:
-        str x0, {result}      // parent: tid, or negative errno on failure
+        str x0, {result}      # parent: tid, or negative errno on failure
     }
 
     if (result < 0) {

--- a/src/system/os/linux/shared.mach
+++ b/src/system/os/linux/shared.mach
@@ -1895,12 +1895,12 @@ fun spawn_redirected_in_impl(pathname: *u8, argv: **u8, envp: **u8, cwd: *u8, st
             mov x2, 0
             mov x3, 0
             mov x4, 0
-            mov x8, 220           // SYS_clone
+            mov x8, 220           # SYS_clone
             svc 0
-            cbnz x0, 1f           // parent (pid != 0): skip the child dispatch
-            b _std_spawn_trampoline    // child (x0 == 0): branch to trampoline (no return)
+            cbnz x0, 1f           # parent (pid != 0): skip the child dispatch
+            b _std_spawn_trampoline    # child (x0 == 0): branch to trampoline (no return)
         1:
-            str x0, {result}      // parent: pid, or negative errno on failure
+            str x0, {result}      # parent: pid, or negative errno on failure
         }
     }
     $or ($mach.build.arch == $mach.arch.riscv64) {

--- a/src/system/panic.mach
+++ b/src/system/panic.mach
@@ -65,13 +65,13 @@ $if ($mach.build.os == $mach.os.linux) {
         }
         $or ($mach.build.arch == $mach.arch.aarch64) {
             asm aarch64 {
-                mov x8, 64    // SYS_write (linux aarch64)
-                mov x0, 2     // fd = stderr
+                mov x8, 64    # SYS_write (linux aarch64)
+                mov x0, 2     # fd = stderr
                 ldr x1, {msg}
                 ldr x2, {len}
                 svc 0
-                mov x8, 94    // SYS_exit_group
-                mov x0, 255   // PANIC_EXIT
+                mov x8, 94    # SYS_exit_group
+                mov x0, 255   # PANIC_EXIT
                 svc 0
                 brk 0
             }
@@ -118,13 +118,13 @@ $or ($mach.build.os == $mach.os.darwin) {
         }
         $or ($mach.build.arch == $mach.arch.aarch64) {
             asm aarch64 {
-                mov x16, 4    // SYS_write (darwin aarch64)
-                mov x0, 2     // fd = stderr
+                mov x16, 4    # SYS_write (darwin aarch64)
+                mov x0, 2     # fd = stderr
                 ldr x1, {msg}
                 ldr x2, {len}
                 svc 0x80
-                mov x16, 1    // SYS_exit (darwin aarch64)
-                mov x0, 255   // PANIC_EXIT
+                mov x16, 1    # SYS_exit (darwin aarch64)
+                mov x0, 255   # PANIC_EXIT
                 svc 0x80
                 brk 0
             }


### PR DESCRIPTION
## Summary
Reverts #551.

The dialect change is correct but the cross-repo sequencing it depended on is circular: `mach-std`'s CI (including release.yml) builds against a downloaded, currently-published `mach` release rather than from source, so `dev` cannot go green here until a `mach` release understands `//` as an aarch64 comment - and that release doesn't exist and can't be cut from this remediation program.

Reverting to restore `#` and get `dev` green again immediately. The fix (branch `fix/aarch64-inline-asm-comment-dialect`, commit 5de36c4) is preserved and will be re-landed once the ordering is resolved (either a `mach` release ships the dialect change first, or `mach-std`'s CI is changed to build `mach` from source, removing the ordering constraint entirely).

## Test plan
- [ ] Confirm CI is green on `dev` after this merges.