### PR TITLE
feat(system): allocate deeply secret typed storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+#### system: deeply secret typed storage
+
+- `std.system.os.secret_allocate_typed[T]` and `secret_deallocate_typed[T]`
+  preserve the exact `*T` shape for records with deeply secret fields across
+  allocation, complete typed-layout wiping, and native release (#553).
+- Typed owners are zero-initialized and correctly aligned, including explicit
+  over-alignment. Checked element and allocation geometry rejects overflow, and
+  deallocation validates the original count before changing storage (#553).
+- Native lifecycle and compile-refusal tests plus six-target debug and release
+  IR and assembly gates cover Linux x86_64, aarch64, and riscv64, Darwin x86_64
+  and aarch64, and Windows x86_64 (#553).
+
 ## [0.33.0] - 2026-08-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ is malformed and reports overlap.
 `std.system.os.secret_allocate`, `secret_deallocate`, and
 `secret_random_fill` keep storage typed as `*^u8` across the complete native
 boundary. They never create a public pointer or integer alias to the secret
-bytes. Linux uses direct syscalls without libc, Darwin uses libSystem, and
-Windows uses the stable virtual-memory and system-entropy APIs.
+bytes. `secret_allocate_typed[T]` and `secret_deallocate_typed[T]` preserve the
+exact `*T` shape for records with deeply secret fields. Linux uses direct
+syscalls without libc, Darwin uses libSystem, and Windows uses the stable
+virtual-memory and system-entropy APIs.
 The Windows entropy boundary requires Vista SP2 or later for
 `BCRYPT_USE_SYSTEM_PREFERRED_RNG`.
 
@@ -60,6 +62,11 @@ zero only after releasing the original allocation, except that `(nil, 0)` is a
 successful no-op. A failed release leaves zeroed storage owned by the caller.
 Random fill returns zero only after initializing the complete requested range
 and wipes that complete range before returning any error.
+
+Typed allocation checks the complete `count * $size_of(T)` geometry and honors
+`$align_of(T)`, including over-aligned records. Typed deallocation requires the
+original element count, validates the stored allocation geometry, and wipes all
+bytes in every element, including padding, before native release.
 
 The `^` qualifier enforces secret data flow. These primitives do not lock pages,
 exclude them from swap or process dumps, isolate them across process creation,

--- a/src/system/os.mach
+++ b/src/system/os.mach
@@ -129,6 +129,14 @@ pub fun secret_allocate(size: usize) *^u8 {
 pub fun secret_deallocate(data: *^u8, size: usize) i64 {
     ret secret_os.deallocate(data, size);
 }
+
+pub fun secret_allocate_typed[T](count: usize) *T {
+    ret secret_os.allocate_typed[T](count);
+}
+
+pub fun secret_deallocate_typed[T](data: *T, count: usize) i64 {
+    ret secret_os.deallocate_typed[T](data, count);
+}
 fwd impl.heap_region_base;
 fwd impl.heap_region_extend;
 fwd impl.protect;

--- a/src/system/os/secret.mach
+++ b/src/system/os/secret.mach
@@ -1,10 +1,14 @@
 # portable operating-system primitives for secret-welded storage
 #
-# these functions preserve `*^u8` across every native boundary. they provide
-# secrecy-typed ownership, not memory locking or protection from process dumps.
+# these functions preserve each welded pointer shape across every native
+# boundary. they provide secrecy-typed ownership, not memory locking or
+# protection from process dumps.
 
 use std.types.size.isize;
 use std.types.size.usize;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
 
 val EIO:    i64 = -5;
 val EINTR:  i64 = -4;
@@ -12,9 +16,17 @@ val EFAULT: i64 = -14;
 val EINVAL: i64 = -22;
 
 val EINTR_MAX_RETRIES: usize = 8;
+val TYPED_HEADER_WORDS: usize = 3;
+val TYPED_HEADER_SIZE:  usize = TYPED_HEADER_WORDS * $size_of(usize);
 
 def FillFun: fun(ptr, *^u8, usize) i64;
 def ReleaseFun: fun(ptr, *^u8, usize) i64;
+
+rec TypedAllocation[T] {
+    base:  *T;
+    total: usize;
+    count: usize;
+}
 
 #[oblivious]
 fun wipe(data: *^u8, len: usize) {
@@ -70,6 +82,212 @@ fun release_all(context: ptr, data: *^u8, size: usize, release_fn: ReleaseFun) i
     ret release_fn(context, data, size);
 }
 
+fun wipe_typed[T](data: *T, count: usize) {
+    val bytes: usize = $size_of(T) * count;
+    var i: usize = 0;
+    for (i < bytes) {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov rax, {data}
+                mov rcx, {i}
+                add rax, rcx
+                mov byte [rax], 0
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                ldr x0, {data}
+                ldr x1, {i}
+                add x0, x0, x1
+                strb wzr, [x0]
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                ld t0, {data}
+                ld t1, {i}
+                add t0, t0, t1
+                sb zero, 0(t0)
+            }
+        }
+        i = i + 1;
+    }
+}
+
+fun typed_total[T](count: usize, total: *usize, alignment: *usize) bool {
+    if (count == 0 || $size_of(T) == 0) { ret false; }
+    if (count > ~(0::usize) / $size_of(T)) { ret false; }
+
+    var align: usize = $align_of(T);
+    if (align < $size_of(usize)) { align = $size_of(usize); }
+    val bytes: usize = $size_of(T) * count;
+    if (bytes > ~(0::usize) - TYPED_HEADER_SIZE) { ret false; }
+    val with_header: usize = bytes + TYPED_HEADER_SIZE;
+    if (with_header > ~(0::usize) - (align - 1)) { ret false; }
+    @total = with_header + align - 1;
+    @alignment = align;
+    ret true;
+}
+
+fun typed_aligned[T](data: *T, alignment: usize) bool {
+    var remainder: usize = 1;
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, {data}
+            mov rcx, {alignment}
+            dec rcx
+            and rax, rcx
+            mov {remainder}, rax
+        }
+    }
+    $or ($mach.build.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            ldr x0, {data}
+            ldr x1, {alignment}
+            sub x1, x1, 1
+            and x0, x0, x1
+            str x0, {remainder}
+        }
+    }
+    $or ($mach.build.arch == $mach.arch.riscv64) {
+        asm riscv64 {
+            ld t0, {data}
+            ld t1, {alignment}
+            addi t1, t1, -1
+            and t0, t0, t1
+            sd t0, {remainder}
+        }
+    }
+    ret remainder == 0;
+}
+
+fun align_typed[T](base: *T, total: usize, alignment: usize, count: usize) *T {
+    var out: *T = nil;
+    val header: usize = TYPED_HEADER_SIZE;
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, {base}
+            mov rcx, {alignment}
+            mov rdx, {header}
+            add rax, rdx
+            mov r8, rcx
+            dec r8
+            add rax, r8
+            neg rcx
+            and rax, rcx
+            mov r8, rax
+            sub r8, rdx
+            mov r9, {base}
+            mov [r8], r9
+            mov r9, {total}
+            mov [r8 + 8], r9
+            mov r9, {count}
+            mov [r8 + 16], r9
+            mov {out}, rax
+        }
+    }
+    $or ($mach.build.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            ldr x0, {base}
+            ldr x1, {alignment}
+            ldr x2, {header}
+            add x3, x0, x2
+            sub x4, x1, 1
+            add x3, x3, x4
+            sub x4, xzr, x1
+            and x3, x3, x4
+            sub x4, x3, x2
+            str x0, [x4]
+            ldr x5, {total}
+            str x5, [x4, 8]
+            ldr x5, {count}
+            str x5, [x4, 16]
+            str x3, {out}
+        }
+    }
+    $or ($mach.build.arch == $mach.arch.riscv64) {
+        asm riscv64 {
+            ld t0, {base}
+            ld t1, {alignment}
+            ld t2, {header}
+            add t3, t0, t2
+            addi t4, t1, -1
+            add t3, t3, t4
+            sub t4, zero, t1
+            and t3, t3, t4
+            sub t4, t3, t2
+            sd t0, 0(t4)
+            ld t5, {total}
+            sd t5, 8(t4)
+            ld t5, {count}
+            sd t5, 16(t4)
+            sd t3, {out}
+        }
+    }
+    ret out;
+}
+
+fun typed_allocation[T](data: *T) TypedAllocation[T] {
+    var base: *T = nil;
+    var total: usize = 0;
+    var count: usize = 0;
+    val header: usize = TYPED_HEADER_SIZE;
+    $if ($mach.build.arch == $mach.arch.x86_64) {
+        asm x86_64 {
+            mov rax, {data}
+            sub rax, {header}
+            mov rcx, [rax]
+            mov {base}, rcx
+            mov rcx, [rax + 8]
+            mov {total}, rcx
+            mov rcx, [rax + 16]
+            mov {count}, rcx
+        }
+    }
+    $or ($mach.build.arch == $mach.arch.aarch64) {
+        asm aarch64 {
+            ldr x0, {data}
+            ldr x1, {header}
+            sub x0, x0, x1
+            ldr x1, [x0]
+            str x1, {base}
+            ldr x1, [x0, 8]
+            str x1, {total}
+            ldr x1, [x0, 16]
+            str x1, {count}
+        }
+    }
+    $or ($mach.build.arch == $mach.arch.riscv64) {
+        asm riscv64 {
+            ld t0, {data}
+            ld t1, {header}
+            sub t0, t0, t1
+            ld t1, 0(t0)
+            sd t1, {base}
+            ld t1, 8(t0)
+            sd t1, {total}
+            ld t1, 16(t0)
+            sd t1, {count}
+        }
+    }
+    ret TypedAllocation[T]{base: base, total: total, count: count};
+}
+
+fun release_typed[T](context: ptr, data: *T, count: usize,
+    release_fn: fun(ptr, *T, *T, usize) i64) i64 {
+    if (data == nil && count == 0) { ret 0; }
+    if (data == nil || count == 0 || $size_of(T) == 0) { ret EINVAL; }
+    var expected_total: usize = 0;
+    var alignment: usize = 0;
+    if (!typed_total[T](count, ?expected_total, ?alignment) ||
+        !typed_aligned[T](data, alignment)) { ret EINVAL; }
+    val allocation: TypedAllocation[T] = typed_allocation[T](data);
+    if (allocation.base == nil || allocation.total != expected_total ||
+        allocation.count != count) { ret EINVAL; }
+    wipe_typed[T](data, count);
+    ret release_fn(context, data, allocation.base, allocation.total);
+}
+
 $if ($mach.build.os == $mach.os.linux) {
     $if ($mach.build.arch == $mach.arch.x86_64) {
         val SYS_MMAP:      usize = 9;
@@ -92,6 +310,66 @@ $if ($mach.build.os == $mach.os.linux) {
         val descriptor: usize = (-1)::isize::usize;
         val error_floor: usize = (-4095)::isize::usize;
         var out: *^u8 = nil;
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov rax, {syscall_number}
+                xor rdi, rdi
+                mov rsi, {size}
+                mov rdx, {protection}
+                mov r10, {flags}
+                mov r8, {descriptor}
+                xor r9, r9
+                syscall
+                cmp rax, {error_floor}
+                jb 1f
+                xor rax, rax
+                1:
+                mov {out}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                ldr x8, {syscall_number}
+                mov x0, 0
+                ldr x1, {size}
+                ldr x2, {protection}
+                ldr x3, {flags}
+                ldr x4, {descriptor}
+                mov x5, 0
+                svc 0
+                cmp x0, 0
+                b.ge 1f
+                mov x0, 0
+                1:
+                str x0, {out}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                ld a7, {syscall_number}
+                li a0, 0
+                ld a1, {size}
+                ld a2, {protection}
+                ld a3, {flags}
+                ld a4, {descriptor}
+                li a5, 0
+                ecall
+                bgez a0, 1f
+                li a0, 0
+                1:
+                sd a0, {out}
+            }
+        }
+        ret out;
+    }
+
+    fun linux_allocate_typed[T](size: usize) *T {
+        val syscall_number: usize = SYS_MMAP;
+        val protection: usize = 3;
+        val flags: usize = 0x22;
+        val descriptor: usize = (-1)::isize::usize;
+        val error_floor: usize = (-4095)::isize::usize;
+        var out: *T = nil;
         $if ($mach.build.arch == $mach.arch.x86_64) {
             asm x86_64 {
                 mov rax, {syscall_number}
@@ -178,6 +456,40 @@ $if ($mach.build.os == $mach.os.linux) {
         ret out;
     }
 
+    fun linux_deallocate_typed[T](context: ptr, data: *T, base: *T,
+        size: usize) i64 {
+        val syscall_number: usize = SYS_MUNMAP;
+        var out: i64 = 0;
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 {
+                mov rax, {syscall_number}
+                mov rdi, {base}
+                mov rsi, {size}
+                syscall
+                mov {out}, rax
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 {
+                ldr x8, {syscall_number}
+                ldr x0, {base}
+                ldr x1, {size}
+                svc 0
+                str x0, {out}
+            }
+        }
+        $or ($mach.build.arch == $mach.arch.riscv64) {
+            asm riscv64 {
+                ld a7, {syscall_number}
+                ld a0, {base}
+                ld a1, {size}
+                ecall
+                sd a0, {out}
+            }
+        }
+        ret out;
+    }
+
     fun linux_random_fill(context: ptr, data: *^u8, len: usize) i64 {
         val syscall_number: usize = SYS_GETRANDOM;
         var out: i64 = 0;
@@ -238,6 +550,26 @@ $or ($mach.build.os == $mach.os.windows) {
 }
 
 $if ($mach.build.os == $mach.os.darwin) {
+    #[naked]
+    fun darwin_allocate_typed[T](count: usize, size: usize) *T {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 { jmp _calloc }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 { b _calloc }
+        }
+    }
+
+    #[naked]
+    fun darwin_free_typed[T](data: *T) {
+        $if ($mach.build.arch == $mach.arch.x86_64) {
+            asm x86_64 { jmp _free }
+        }
+        $or ($mach.build.arch == $mach.arch.aarch64) {
+            asm aarch64 { b _free }
+        }
+    }
+
     fun darwin_release(context: ptr, data: *^u8, size: usize) i64 {
         free(data);
         ret 0;
@@ -247,8 +579,26 @@ $if ($mach.build.os == $mach.os.darwin) {
         if (getentropy(data, len) != 0) { ret darwin_system.fail_errno(); }
         ret len::i64;
     }
+
+    fun darwin_release_typed[T](context: ptr, data: *T, base: *T,
+        size: usize) i64 {
+        darwin_free_typed[T](base);
+        ret 0;
+    }
 }
 $or ($mach.build.os == $mach.os.windows) {
+    #[naked]
+    fun windows_allocate_native_typed[T](address: ptr, size: usize,
+        allocation_type: u32, protection: u32) *T {
+        asm x86_64 { jmp VirtualAlloc }
+    }
+
+    #[naked]
+    fun windows_deallocate_native_typed[T](data: *T, size: usize,
+        free_type: u32) i32 {
+        asm x86_64 { jmp VirtualFree }
+    }
+
     fun windows_release(context: ptr, data: *^u8, size: usize) i64 {
         if (windows_deallocate(data, 0, 0x8000) != 0) { ret 0; }
         ret EIO;
@@ -257,6 +607,12 @@ $or ($mach.build.os == $mach.os.windows) {
     fun windows_fill(context: ptr, data: *^u8, len: usize) i64 {
         if (windows_bcrypt_random(0, data, len::u32, 2) != 0) { ret EIO; }
         ret len::i64;
+    }
+
+    fun windows_release_typed[T](context: ptr, data: *T, base: *T,
+        size: usize) i64 {
+        if (windows_deallocate_native_typed[T](base, 0, 0x8000) != 0) { ret 0; }
+        ret EIO;
     }
 }
 $or ($mach.build.os == $mach.os.linux) {
@@ -296,6 +652,46 @@ pub fun deallocate(data: *^u8, size: usize) i64 {
     }
     $or ($mach.build.os == $mach.os.windows) {
         ret release_all(nil, data, size, windows_release);
+    }
+}
+
+# allocate a zero-initialized typed region without changing T's secrecy shape
+# ---
+# count: number of T values
+# ret:   aligned typed owner, or nil for zero count, overflow, or failure
+pub fun allocate_typed[T](count: usize) *T {
+    var total: usize = 0;
+    var alignment: usize = 0;
+    if (!typed_total[T](count, ?total, ?alignment)) { ret nil; }
+
+    var base: *T = nil;
+    $if ($mach.build.os == $mach.os.linux) {
+        base = linux_allocate_typed[T](total);
+    }
+    $or ($mach.build.os == $mach.os.darwin) {
+        base = darwin_allocate_typed[T](1, total);
+    }
+    $or ($mach.build.os == $mach.os.windows) {
+        base = windows_allocate_native_typed[T](nil, total, 0x3000, 4);
+    }
+    if (base == nil) { ret nil; }
+    ret align_typed[T](base, total, alignment, count);
+}
+
+# wipe and release a typed region without changing T's secrecy shape
+# ---
+# data:  allocation returned by allocate_typed[T]
+# count: original element count
+# ret:   zero after release, or a negative error with wiped ownership retained
+pub fun deallocate_typed[T](data: *T, count: usize) i64 {
+    $if ($mach.build.os == $mach.os.linux) {
+        ret release_typed[T](nil, data, count, linux_deallocate_typed[T]);
+    }
+    $or ($mach.build.os == $mach.os.darwin) {
+        ret release_typed[T](nil, data, count, darwin_release_typed[T]);
+    }
+    $or ($mach.build.os == $mach.os.windows) {
+        ret release_typed[T](nil, data, count, windows_release_typed[T]);
     }
 }
 
@@ -484,4 +880,121 @@ test "std.system.os.secret: release wipes before success or failure" {
     if (release_all(?succeeded, ?data[0], 4, probe_release[u8]) != 0 ||
         succeeded.calls != 1 || succeeded.saw_zero == 0) { ret 1; }
     ret 0;
+}
+
+# generic fixtures instantiate only in test builds
+rec TypedSecretLeaf {
+    value: ^u64;
+}
+
+rec TypedSecretRecord {
+    public: u64;
+    nested: TypedSecretLeaf;
+}
+
+#[align(8192)]
+rec OverAlignedSecretRecord {
+    public: u64;
+    secret: ^u64;
+}
+
+rec TypedReleaseProbe {
+    calls:    usize;
+    saw_zero: bool;
+    result:   i64;
+}
+
+fun probe_typed_release[T](context: ptr, data: *TypedSecretRecord,
+    base: *TypedSecretRecord, size: usize) i64 {
+    val probe: *TypedReleaseProbe = context::*TypedReleaseProbe;
+    probe.calls = probe.calls + 1;
+    probe.saw_zero = data[0].public == 0 && data[0].nested.value:^ == 0 &&
+        data[1].public == 0 && data[1].nested.value:^ == 0;
+    ret probe.result;
+}
+
+test "std.system.os.secret: typed allocation preserves public and direct secret shapes" {
+    val public: *u64 = allocate_typed[u64](3);
+    if (public == nil) { ret 1; }
+    var failed: i64 = 0;
+    var i: usize = 0;
+    for (i < 3) {
+        if (public[i] != 0) { failed = 1; }
+        public[i] = i + 1;
+        i = i + 1;
+    }
+    if (deallocate_typed[u64](public, 3) != 0) { ret 1; }
+
+    val direct: *^u64 = allocate_typed[^u64](3);
+    if (direct == nil) { ret 1; }
+    i = 0;
+    for (i < 3) {
+        if (direct[i]:^ != 0) { failed = 1; }
+        direct[i] = 12;
+        i = i + 1;
+    }
+    if (deallocate_typed[^u64](direct, 3) != 0) { ret 1; }
+    ret failed::i32;
+}
+
+test "std.system.os.secret: deeply secret typed allocation is aligned and zeroed" {
+    val data: *TypedSecretRecord = allocate_typed[TypedSecretRecord](2);
+    if (data == nil || !typed_aligned[TypedSecretRecord](data,
+        $align_of(TypedSecretRecord))) { ret 1; }
+    var i: usize = 0;
+    for (i < 2) {
+        if (data[i].public != 0 || data[i].nested.value:^ != 0) { ret 1; }
+        data[i].public = i + 21;
+        data[i].nested.value = 32;
+        i = i + 1;
+    }
+    ret deallocate_typed[TypedSecretRecord](data, 2)::i32;
+}
+
+test "std.system.os.secret: explicit typed alignment is honored" {
+    val data: *OverAlignedSecretRecord =
+        allocate_typed[OverAlignedSecretRecord](2);
+    if (data == nil || !typed_aligned[OverAlignedSecretRecord](data, 8192)) {
+        ret 1;
+    }
+    if (data[0].public != 0 || data[0].secret:^ != 0 ||
+        data[1].public != 0 || data[1].secret:^ != 0) { ret 1; }
+    data[1].public = 41;
+    data[1].secret = 42;
+    ret deallocate_typed[OverAlignedSecretRecord](data, 2)::i32;
+}
+
+test "std.system.os.secret: typed geometry rejects empty and overflowing owners" {
+    if (allocate_typed[u64](0) != nil) { ret 1; }
+    if (deallocate_typed[u64](nil, 0) != 0) { ret 1; }
+    if (deallocate_typed[u64](nil, 1) != EINVAL) { ret 1; }
+    if (allocate_typed[u64](~(0::usize) / $size_of(u64) + 1) != nil) {
+        ret 1;
+    }
+    if (allocate_typed[u8](~(0::usize)) != nil) { ret 1; }
+    ret 0;
+}
+
+test "std.system.os.secret: typed release validates count and retains wiped failures" {
+    val data: *TypedSecretRecord = allocate_typed[TypedSecretRecord](2);
+    if (data == nil) { ret 1; }
+    data[0].public = 51;
+    data[0].nested.value = 52;
+    data[1].public = 53;
+    data[1].nested.value = 54;
+
+    if (deallocate_typed[TypedSecretRecord](data, 1) != EINVAL) { ret 2; }
+    if (data[0].public != 51 || data[0].nested.value:^ != 52 ||
+        data[1].public != 53 || data[1].nested.value:^ != 54) { ret 3; }
+
+    var probe: TypedReleaseProbe = TypedReleaseProbe{
+        calls: 0, saw_zero: false, result: EIO,
+    };
+    if (release_typed[TypedSecretRecord](?probe, data, 2,
+        probe_typed_release[u8]) != EIO) { ret 4; }
+    if (probe.calls != 1) { ret 5; }
+    if (!probe.saw_zero) { ret 6; }
+    if (data[0].public != 0 || data[0].nested.value:^ != 0 ||
+        data[1].public != 0 || data[1].nested.value:^ != 0) { ret 7; }
+    ret deallocate_typed[TypedSecretRecord](data, 2)::i32;
 }

--- a/test/backends/src/main.mach
+++ b/test/backends/src/main.mach
@@ -5,6 +5,16 @@ use std.filesystem;
 use net_async: std.net.async;
 use async_local: std.net.async.local;
 
+rec SecretLeaf {
+    value: ^u64;
+}
+
+#[align(8192)]
+rec SecretRecord {
+    public: u64;
+    secret: SecretLeaf;
+}
+
 #[symbol("main")]
 fun main(argc: i64, argv: **u8) i64 {
     if ($size_of(net_async.Driver) == 0 || $size_of(async_local.Driver) == 0) {
@@ -12,5 +22,10 @@ fun main(argc: i64, argv: **u8) i64 {
     }
     var c: u8 = 'k'::u8;
     os.write(1, ?c, 1);
+    val secrets: *SecretRecord = os.secret_allocate_typed[SecretRecord](2);
+    if (secrets == nil) { ret 1; }
+    secrets[0].public = 1;
+    secrets[0].secret.value = 2;
+    if (os.secret_deallocate_typed[SecretRecord](secrets, 2) != 0) { ret 1; }
     ret 0;
 }

--- a/test/backends/verify.sh
+++ b/test/backends/verify.sh
@@ -51,8 +51,12 @@ for target in "${targets[@]}"; do
 
         secret_ir="out/$target/$profile/ir/std/system/os/secret.ir"
         secret_asm="out/$target/$profile/asm/std/system/os/secret.s"
+        main_ir="out/$target/$profile/ir/backends/main.ir"
+        main_asm="out/$target/$profile/asm/backends/main.s"
         [ -f "$secret_ir" ] || fail "$target $profile: secret OS IR missing"
         [ -f "$secret_asm" ] || fail "$target $profile: secret OS assembly missing"
+        [ -f "$main_ir" ] || fail "$target $profile: typed boundary IR missing"
+        [ -f "$main_asm" ] || fail "$target $profile: typed boundary assembly missing"
         grep -q 'fn @std.system.os.secret.allocate' "$secret_ir" \
             || fail "$target $profile: secret allocation boundary missing"
         grep -q 'fn @std.system.os.secret.deallocate' "$secret_ir" \
@@ -62,7 +66,16 @@ for target in "${targets[@]}"; do
         if grep -Eq 'ptrtoint|inttoptr' "$secret_ir"; then
             fail "$target $profile: secret boundary materialized an integer pointer alias"
         fi
-        if grep -Eq 'std[.]system[.]os[.]secret[.](scripted_fill|all_zero|reset_probe_fill|interrupted_fill|probe_release)' "$secret_ir"; then
+        grep -Fq 'std.system.os.secret_allocate_typed$backends.main.SecretRecord' "$main_ir" \
+            || fail "$target $profile: typed allocation boundary missing"
+        grep -Fq 'std.system.os.secret_deallocate_typed$backends.main.SecretRecord' "$main_ir" \
+            || fail "$target $profile: typed release boundary missing"
+        grep -Fq 'std.system.os.secret.wipe_typed$backends.main.SecretRecord' "$main_ir" \
+            || fail "$target $profile: typed full-layout wipe missing"
+        if grep -Eq 'ptrtoint|inttoptr' "$main_ir"; then
+            fail "$target $profile: typed boundary materialized an integer pointer alias"
+        fi
+        if grep -Eq 'std[.]system[.]os[.]secret[.](scripted_fill|all_zero|reset_probe_fill|interrupted_fill|probe_release|probe_typed_release)' "$secret_ir"; then
             fail "$target $profile: secret test-only inspection entered the production artifact"
         fi
         release_ir="$(sed -n '/fn @std.system.os.secret.release_all/,/^  fn /p' "$secret_ir")"
@@ -76,10 +89,23 @@ for target in "${targets[@]}"; do
         [ -n "$release_ir_line" ] || fail "$target $profile: native release call missing from IR"
         [ "$wipe_ir_line" -lt "$release_ir_line" ] \
             || fail "$target $profile: native release call precedes secret wipe in IR"
+        typed_release_ir="$(sed -n '/fn @std.system.os.secret.release_typed\$backends.main.SecretRecord/,/^  fn /p' "$main_ir")"
+        typed_release_ir_line="$(echo "$typed_release_ir" | grep -n -m1 'call i64 %p3' | cut -d: -f1 || true)"
+        [ -n "$typed_release_ir_line" ] \
+            || fail "$target $profile: typed native release call missing from IR"
+        if [ "$profile" = debug ]; then
+            typed_wipe_ir_line="$(echo "$typed_release_ir" | grep -n -m1 'call void @std.system.os.secret.wipe_typed' | cut -d: -f1 || true)"
+            [ -n "$typed_wipe_ir_line" ] \
+                || fail "$target debug: typed release wipe missing from IR"
+            [ "$typed_wipe_ir_line" -lt "$typed_release_ir_line" ] \
+                || fail "$target debug: native typed release precedes full-layout wipe in IR"
+        fi
         case "$target" in
             linux-*)
                 grep -q 'syscall\|ecall\|svc' "$secret_asm" \
                     || fail "$target $profile: secret boundary omitted native syscalls"
+                grep -q 'syscall\|ecall\|svc' "$main_asm" \
+                    || fail "$target $profile: typed boundary omitted native syscalls"
                 if grep -Eq 'malloc|free|getrandom' "$secret_asm"; then
                     fail "$target $profile: secret boundary gained a libc dependency"
                 fi
@@ -101,6 +127,10 @@ for target in "${targets[@]}"; do
                 if echo "$undefined" | grep -Eq '(^|[[:space:]])(calloc|getentropy|free)$'; then
                     fail "$target $profile: unprefixed Mach-O secret import remains"
                 fi
+                grep -Eq '(jmp|b) _calloc' "$main_asm" \
+                    || fail "$target $profile: typed allocator omitted libSystem calloc"
+                grep -Eq '(jmp|b) _free' "$main_asm" \
+                    || fail "$target $profile: typed release omitted libSystem free"
                 ;;
             windows-*)
                 grep -q 'VirtualAlloc' "$secret_asm" \
@@ -110,6 +140,10 @@ for target in "${targets[@]}"; do
                 if llvm-readobj --coff-imports "$exe" | grep -q 'SystemFunction036'; then
                     fail "$target $profile: legacy RtlGenRandom import remains"
                 fi
+                grep -q 'jmp VirtualAlloc' "$main_asm" \
+                    || fail "$target $profile: typed allocator omitted VirtualAlloc"
+                grep -q 'jmp VirtualFree' "$main_asm" \
+                    || fail "$target $profile: typed release omitted VirtualFree"
                 ;;
         esac
         if [ "$profile" = release ]; then
@@ -130,6 +164,26 @@ for target in "${targets[@]}"; do
             [ -n "$release_line" ] || fail "$target release: native release missing from assembly"
             [ "$wipe_line" -lt "$release_line" ] \
                 || fail "$target release: native release precedes secret wipe in assembly"
+
+            typed_release_body="$(sed -n '/# std.system.os.secret.release_typed\$backends.main.SecretRecord:/,/^# /p' "$main_asm")"
+            typed_wipe_line="$(echo "$typed_release_body" | grep -n -m1 -E 'mov byte \[[^]]+\], 0|strb wzr|sb zero' | cut -d: -f1 || true)"
+            case "$target" in
+                *-x86_64)
+                    typed_release_line="$(echo "$typed_release_body" | grep -n -E 'call r[0-9]+' | tail -1 | cut -d: -f1 || true)"
+                    ;;
+                *-arm64)
+                    typed_release_line="$(echo "$typed_release_body" | grep -n -E 'blr x[0-9]+' | tail -1 | cut -d: -f1 || true)"
+                    ;;
+                linux-riscv64)
+                    typed_release_line="$(echo "$typed_release_body" | grep -n -E 'jalr ra, 0\(' | tail -1 | cut -d: -f1 || true)"
+                    ;;
+            esac
+            [ -n "$typed_wipe_line" ] \
+                || fail "$target release: typed full-layout wipe missing from assembly"
+            [ -n "$typed_release_line" ] \
+                || fail "$target release: typed native release missing from assembly"
+            [ "$typed_wipe_line" -lt "$typed_release_line" ] \
+                || fail "$target release: native typed release precedes full-layout wipe in assembly"
         fi
 
         echo "OK: $target $profile backends compile ($exe)"

--- a/test/secret/src/refusals.mach
+++ b/test/secret/src/refusals.mach
@@ -1,12 +1,25 @@
 use std.system.os;
 use std.types.size.usize;
 
+rec SecretLeaf {
+    value: ^u64;
+}
+
+rec SecretRecord {
+    public: u64;
+    secret: SecretLeaf;
+}
+
 fun erase_pointer() ptr {
     ret os.secret_allocate(1);
 }
 
 fun erase_integer() usize {
     ret os.secret_allocate(1)::usize;
+}
+
+fun erase_typed_pointer() ptr {
+    ret os.secret_allocate_typed[SecretRecord](1);
 }
 
 #[symbol("main")]

--- a/test/secret/verify.sh
+++ b/test/secret/verify.sh
@@ -20,4 +20,6 @@ echo "$log" | grep -q 'expected ptr, found \*\^u8' \
     || { echo "$log" >&2; fail "pointer erasure failed for the wrong reason"; }
 echo "$log" | grep -q 'cannot add or drop the secret qualifier' \
     || { echo "$log" >&2; fail "integer erasure failed for the wrong reason"; }
-echo "OK: pointer and integer erasures preserve the welded-pointer boundary"
+echo "$log" | grep -q 'expected ptr, found \*SecretRecord' \
+    || { echo "$log" >&2; fail "typed pointer erasure failed for the wrong reason"; }
+echo "OK: byte and typed pointer erasures preserve secret storage boundaries"


### PR DESCRIPTION
## Summary

- add `secret_allocate_typed[T]` and `secret_deallocate_typed[T]` while preserving the exact `*T` secrecy shape across every native boundary
- check element and allocation geometry, honor arbitrary type alignment, and return zero-initialized storage
- validate the original count and stored allocation geometry, wipe the full typed layout before release, and retain wiped ownership when release fails
- implement Linux x86_64, aarch64, and riscv64 syscall paths, Darwin x86_64 and aarch64 libSystem thunks, and Windows x86_64 VirtualAlloc and VirtualFree thunks without compiler changes
- add native lifecycle, over-alignment, overflow, compile-refusal, and six-target debug and release IR and assembly gates

## Verification

- `mach test . --target linux-x86_64 -q`: 1036/1036
- `mach test . --target linux-x86_64 -O1 -q`: 1036/1036
- `bash test/secret/verify.sh mach`
- `bash test/backends/verify.sh mach`: all six targets in debug and release
- `mach build . --all-targets -O0 --emit-ir --emit-asm --verify-ir -q`
- `mach build . --all-targets -O1 --emit-ir --emit-asm --verify-ir -q`

Closes #553