### PR TITLE
chore(release): 0.35.1

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.35.0"
+version = "0.35.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/lib/libstd.mach
+++ b/src/lib/libstd.mach
@@ -37,6 +37,8 @@ fwd io_runtime: std.io.runtime;
 fwd io_lifecycle: std.io.lifecycle;
 fwd std.filesystem;
 fwd fs_transaction: std.filesystem.transaction;
+# keep the import-attribution census reachable from dependency test runs
+use os_tests: std.system.os.tests;
 
 fwd std.math;
 fwd std.math.float;

--- a/src/system/os/darwin/libsystem.mach
+++ b/src/system/os/darwin/libsystem.mach
@@ -160,13 +160,14 @@ $or {
     pub ext fun fstatat(dirfd: i32, path: *u8, st: *u8, flags: i32) i32;
 }
 
-#[library("libSystem")]
 # flock: advisory whole-file lock on an open descriptor
 #
 # the lock is held by the open file description and darwin releases it when the
 # last descriptor on that description closes, including at process exit.
+#[library("libSystem")]
 pub ext fun flock(fd: i32, op: i32) i32;
 
+#[library("libSystem")]
 pub ext fun unlinkat(dirfd: i32, path: *u8, flags: i32) i32;
 
 #[library("libSystem")]

--- a/src/system/os/tests.mach
+++ b/src/system/os/tests.mach
@@ -1,0 +1,129 @@
+# import-attribution census for the two-level-namespace targets
+
+use R: std.types.result;
+use O: std.types.option;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use std.text.string.str_free;
+use std.types.string.str_join;
+use std.types.string.str_ends_with;
+use std.types.string.str_region_equals;
+use std.collections.vector.Vector;
+use vector: std.collections.vector;
+use std.allocator.page;
+use A: std.allocator;
+use std.filesystem;
+
+fun line_end(s: str, from: usize, n: usize) usize {
+    var i: usize = from;
+    for (i < n && s[i] != '\n') { i = i + 1; }
+    ret i;
+}
+
+fun first_significant(s: str, from: usize, end: usize) usize {
+    var i: usize = from;
+    for (i < end && (s[i] == ' ' || s[i] == '\t')) { i = i + 1; }
+    ret i;
+}
+
+fun region_has(s: str, start: usize, end: usize, sub: str) bool {
+    val m: usize = str_len(sub);
+    if (m == 0 || end <= start || end - start < m) { ret false; }
+    var i: usize = start;
+    for (i + m <= end) {
+        if (str_region_equals(s, i, m, sub)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# count the ext fun declarations in one source text and how many of them reach
+# the linker without naming a providing library
+#
+# an attribute may sit on the declaration itself or on a line above it, with
+# doc comments and blank lines in between, so the scan carries the attribute
+# forward across those and drops it at the next real line.
+fun census_text(text: str, seen: *usize, bad: *usize) {
+    val n: usize = str_len(text);
+    var pos: usize = 0;
+    var pending: bool = false;
+    for (pos < n) {
+        val end: usize = line_end(text, pos, n);
+        val t:   usize = first_significant(text, pos, end);
+
+        if (t == end) { pos = end + 1; cnt; }
+
+        if (text[t] == '#') {
+            if (region_has(text, t, end, "#[library(")) { pending = true; }
+            pos = end + 1;
+            cnt;
+        }
+
+        if (str_region_equals(text, t, 8, "ext fun ")
+         || str_region_equals(text, t, 12, "pub ext fun ")) {
+            @seen = seen[0] + 1;
+            if (!pending && !region_has(text, t, end, "#[library(")) { @bad = bad[0] + 1; }
+        }
+
+        pending = false;
+        pos = end + 1;
+    }
+}
+
+fun census_dir(a: *A.Allocator, dir: str, seen: *usize, bad: *usize) bool {
+    val dr: R.Result[Vector[str], str] = filesystem.read_dir(a, dir);
+    if (R.is_err[Vector[str], str](dr)) { ret false; }
+    var names: Vector[str] = R.unwrap_ok[Vector[str], str](dr);
+
+    var ok: bool = true;
+    var i: usize = 0;
+    for (i < names.len) {
+        val name: str = names.data[i];
+        if (str_ends_with(name, ".mach")) {
+            val pr: R.Result[str, str] = str_join(a, dir, "/", name);
+            if (R.is_err[str, str](pr)) { ok = false; }
+            or {
+                val path: str = R.unwrap_ok[str, str](pr);
+                val tr: R.Result[str, str] = filesystem.read_string(a, path);
+                if (R.is_err[str, str](tr)) { ok = false; }
+                or {
+                    val text: str = R.unwrap_ok[str, str](tr);
+                    census_text(text, seen, bad);
+                    str_free(a, text);
+                }
+                str_free(a, path);
+            }
+        }
+        str_free(a, name);
+        i = i + 1;
+    }
+
+    vector.dnit[str](?names);
+    ret ok;
+}
+
+# darwin and windows resolve an import through the library that declares it, so
+# an import with no #[library] either fails the link outright on darwin or is
+# attributed to the first dependency on windows rather than the right DLL. the
+# suite runs on one host, so the defect is invisible to every test that only
+# links for that host: this reads the sources instead.
+test "std.system.os: every darwin and windows import names its library" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+
+    var seen: usize = 0;
+    var bad:  usize = 0;
+
+    if (!census_dir(?a, "src/system/os/darwin", ?seen, ?bad))  { ret 2; }
+    if (!census_dir(?a, "src/system/os/windows", ?seen, ?bad)) { ret 3; }
+
+    # a census that reaches no declarations proves nothing about the tree, so
+    # it fails rather than reporting a clean result it never established
+    if (seen == 0) { ret 4; }
+    if (bad != 0)  { ret 5; }
+    ret 0;
+}


### PR DESCRIPTION
Patch release. 0.35.0 broke every Darwin link: `unlinkat` reached the linker with no `#[library]` attribution, and Darwin is a two-level-namespace target, so an unattributed import is a hard error rather than a fallback.

Fixed, and guarded by a source census that now runs as a std test, because the suite links only for its host and could never have seen a Darwin-only link failure.

Census: 155 `ext fun` declarations across the Darwin and Windows OS layers, 0 missing attribution.

Suite 1,079 passed / 0 failed under the 4.26.5 seed. Compiler link leg against this content: 146 pass / 11 fail, matching the expected baseline, with all 28 Darwin cells passing.

Not tagged here; tagging is the owner's.