### PR TITLE
fix(toml): bound how deep a value may nest

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.35.0"
+version = "0.35.1"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/data/toml.mach
+++ b/src/data/toml.mach
@@ -1289,13 +1289,27 @@ fun navigate_segs(a: *Allocator, t: *Table, ks: *KeySegs) Result[*Table, str] {
     ret ok[*Table, str](current);
 }
 
+# how many containers a value may nest inside before the reader refuses
+#
+# arrays and inline tables descend through parse_value, so nesting depth is a
+# count taken straight from the document: without a stated bound the only limit
+# is whatever stack the process happens to have, and a document deep enough to
+# exhaust it kills the reader rather than being rejected by it. sixty-four is
+# far past anything a hand-written document reaches and far short of any stack
+# the reader runs on. DEPTH_MESSAGE names this number and must move with it.
+val MAX_VALUE_DEPTH: usize = 64;
+val DEPTH_MESSAGE: str = "value nesting exceeds the maximum depth of 64";
+
 # parse a TOML value at the current position
 # ---
-# a:   allocator
-# src: source text
-# i:   cursor position
-# ret: parsed Value, or an error
-fun parse_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
+# a:     allocator
+# src:   source text
+# i:     cursor position
+# depth: how many arrays and inline tables enclose this value
+# ret:   parsed Value, or an error
+fun parse_value(a: *Allocator, src: str, i: *usize, depth: usize) Result[Value, str] {
+    if (depth > MAX_VALUE_DEPTH) { ret err[Value, str](DEPTH_MESSAGE); }
+
     skip_ws(src, i);
 
     val b: u8 = src[@i];
@@ -1317,11 +1331,11 @@ fun parse_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
     }
 
     if (b == '[') {
-        ret parse_array_value(a, src, i);
+        ret parse_array_value(a, src, i, depth + 1);
     }
 
     if (b == '{') {
-        ret parse_inline_table(a, src, i);
+        ret parse_inline_table(a, src, i, depth + 1);
     }
 
     if (b == '+' || b == '-' || (b >= '0' && b <= '9') || b == 'i' || b == 'n') {
@@ -1335,9 +1349,10 @@ fun parse_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
 # ---
 # a:   allocator
 # src: source text
-# i:   cursor position (on the '[')
-# ret: parsed array Value, or an error
-fun parse_array_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
+# i:     cursor position (on the '[')
+# depth: how many containers enclose this array, itself included
+# ret:   parsed array Value, or an error
+fun parse_array_value(a: *Allocator, src: str, i: *usize, depth: usize) Result[Value, str] {
     @i = @i + 1;
     var arr: Array = array_make();
 
@@ -1348,7 +1363,7 @@ fun parse_array_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
             brk;
         }
 
-        val vr: Result[Value, str] = parse_value(a, src, i);
+        val vr: Result[Value, str] = parse_value(a, src, i, depth);
         if (is_err[Value, str](vr)) { ret vr; }
 
         val pr: Result[bool, str] = array_push(a, ?arr, unwrap_ok[Value, str](vr));
@@ -1368,9 +1383,10 @@ fun parse_array_value(a: *Allocator, src: str, i: *usize) Result[Value, str] {
 # ---
 # a:   allocator
 # src: source text
-# i:   cursor position (on the '{')
-# ret: parsed table Value, or an error
-fun parse_inline_table(a: *Allocator, src: str, i: *usize) Result[Value, str] {
+# i:     cursor position (on the '{')
+# depth: how many containers enclose this table, itself included
+# ret:   parsed table Value, or an error
+fun parse_inline_table(a: *Allocator, src: str, i: *usize, depth: usize) Result[Value, str] {
     @i = @i + 1;
     var t: Table = table_make();
     var ks: KeySegs = keysegs_make();
@@ -1381,7 +1397,7 @@ fun parse_inline_table(a: *Allocator, src: str, i: *usize) Result[Value, str] {
         ret ok[Value, str](value_table(t));
     }
 
-    val r: Result[bool, str] = parse_inline_entries(a, src, i, ?t, ?ks);
+    val r: Result[bool, str] = parse_inline_entries(a, src, i, ?t, ?ks, depth);
     keysegs_dnit(a, ?ks);
     if (is_err[bool, str](r)) {
         dnit(a, ?t);
@@ -1400,7 +1416,7 @@ fun parse_inline_table(a: *Allocator, src: str, i: *usize) Result[Value, str] {
 # t:   the inline table being built
 # ks:  scratch key-path segments, owned by the caller
 # ret: true when the closing brace was consumed, or the parse error
-fun parse_inline_entries(a: *Allocator, src: str, i: *usize, t: *Table, ks: *KeySegs) Result[bool, str] {
+fun parse_inline_entries(a: *Allocator, src: str, i: *usize, t: *Table, ks: *KeySegs, depth: usize) Result[bool, str] {
     for {
         skip_ws(src, i);
 
@@ -1413,7 +1429,7 @@ fun parse_inline_entries(a: *Allocator, src: str, i: *usize, t: *Table, ks: *Key
         if (src[@i] != '=') { ret err[bool, str]("expected '=' in inline table"); }
         @i = @i + 1;
 
-        val vr: Result[Value, str] = parse_value(a, src, i);
+        val vr: Result[Value, str] = parse_value(a, src, i, depth);
         if (is_err[Value, str](vr)) { ret err[bool, str](unwrap_err[Value, str](vr)); }
 
         val nr: Result[*Table, str] = navigate_segs(a, t, ks);
@@ -1632,7 +1648,7 @@ fun parse_walk(a: *Allocator, src: str, root: *Table, ks: *KeySegs) Result[bool,
         }
         i = i + 1;
 
-        val vr: Result[Value, str] = parse_value(a, src, ?i);
+        val vr: Result[Value, str] = parse_value(a, src, ?i, 0);
         if (is_err[Value, str](vr)) { ret err[bool, str](unwrap_err[Value, str](vr)); }
 
         val nr: Result[*Table, str] = navigate_segs(a, current, ks);
@@ -1828,4 +1844,99 @@ test "toml: an overwritten key and value are released" {
     dnit(?a, ?t);
     if (c.live != 0) { ret 4; }
     ret 0;
+}
+
+# build "k = " followed by `n` open brackets, the shape that used to recurse
+# once per bracket until the stack ran out
+fun t_nest_open(a: *Allocator, n: usize) str {
+    val total: usize = 4 + n;
+    val r: Result[*u8, str] = allocate[u8](a, total + 1);
+    if (is_err[*u8, str](r)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    buf[0] = 'k'; buf[1] = ' '; buf[2] = '='; buf[3] = ' ';
+    var i: usize = 0;
+    for (i < n) { buf[4 + i] = '['; i = i + 1; }
+    buf[total] = 0;
+    ret buf::str;
+}
+
+# close a "k = [[[..." prefix into a whole document, with a scalar at the bottom
+#
+# the scalar matters: an empty innermost array is closed without ever asking for
+# a value, so it costs one descent less. with it, `n` brackets is exactly `n`
+# levels deep, which is what makes the boundary below mean what it says.
+fun t_close(a: *Allocator, open_: str, n: usize) str {
+    val head: usize = str_len(open_);
+    val total: usize = head + 1 + n;
+    val r: Result[*u8, str] = allocate[u8](a, total + 1);
+    if (is_err[*u8, str](r)) { ret nil; }
+    val buf: *u8 = unwrap_ok[*u8, str](r);
+    var i: usize = 0;
+    for (i < head) { buf[i] = open_[i]; i = i + 1; }
+    buf[head] = '1';
+    i = 0;
+    for (i < n) { buf[head + 1 + i] = ']'; i = i + 1; }
+    buf[total] = 0;
+    ret buf::str;
+}
+
+# a value nested past the bound is rejected, not a dead process
+#
+# the reproducer was 8192 unclosed brackets, which exhausted the stack and died
+# on SIGSEGV. the count comes from the document, so it is checked before it is
+# acted on rather than being bounded by whatever stack the reader was given.
+test "toml: value nesting past the maximum is refused" {
+    var c: CountingAlloc;
+    var a: Allocator;
+    if (!counting_make(?c, ?a)) { ret 1; }
+
+    val deep: str = t_nest_open(?a, 8192);
+    if (deep == nil) { ret 2; }
+
+    val r: Result[Table, str] = parse(?a, deep);
+    if (!is_err[Table, str](r)) { ret 3; }
+    if (!str_equals(unwrap_err[Table, str](r), DEPTH_MESSAGE)) { ret 4; }
+
+    deallocate[u8](?a, deep, 4 + 8192 + 1);
+    if (c.live != 0) { ret 5; }
+    ret 0;
+}
+
+# the bound is where it says it is: one under is accepted, one over is refused,
+# so the constant cannot drift from the behaviour without this failing
+test "toml: the nesting bound admits its own maximum and refuses one more" {
+    var c: CountingAlloc;
+    var a: Allocator;
+    if (!counting_make(?c, ?a)) { ret 1; }
+
+    var bad: i32 = 0;
+
+    # MAX_VALUE_DEPTH open brackets, each closed: the deepest accepted document
+    val n_ok: usize = MAX_VALUE_DEPTH;
+    val open_ok: str = t_nest_open(?a, n_ok);
+    if (open_ok == nil) { ret 2; }
+    val doc_ok: str = t_close(?a, open_ok, n_ok);
+    if (doc_ok == nil) { ret 3; }
+    val r_ok: Result[Table, str] = parse(?a, doc_ok);
+    if (is_err[Table, str](r_ok)) { bad = 4; }
+    or { var t: Table = unwrap_ok[Table, str](r_ok); dnit(?a, ?t); }
+    deallocate[u8](?a, open_ok, 4 + n_ok + 1);
+    deallocate[u8](?a, doc_ok, 4 + n_ok + 1 + n_ok + 1);
+
+    # one deeper is refused
+    if (bad == 0) {
+        val n_no: usize = MAX_VALUE_DEPTH + 1;
+        val open_no: str = t_nest_open(?a, n_no);
+        if (open_no == nil) { ret 5; }
+        val doc_no: str = t_close(?a, open_no, n_no);
+        if (doc_no == nil) { ret 6; }
+        val r_no: Result[Table, str] = parse(?a, doc_no);
+        if (!is_err[Table, str](r_no)) { bad = 7; }
+        or (!str_equals(unwrap_err[Table, str](r_no), DEPTH_MESSAGE)) { bad = 8; }
+        deallocate[u8](?a, open_no, 4 + n_no + 1);
+        deallocate[u8](?a, doc_no, 4 + n_no + 1 + n_no + 1);
+    }
+
+    if (bad == 0 && c.live != 0) { bad = 9; }
+    ret bad;
 }


### PR DESCRIPTION
Found by the compiler's fuzzing stream.

`parse_value` descends into `parse_array_value` and `parse_inline_table`, and both come back to `parse_value`, with nothing counting the descent:

```
parse_value        -> parse_array_value  -> parse_value
parse_value        -> parse_inline_table -> parse_inline_entries -> parse_value
```

Nesting depth is a count taken straight from an untrusted document, so the only limit was whatever stack the process happened to have. 8192 unclosed `[` exhausted it and the reader died on SIGSEGV; 4096 answered. The threshold was a property of the caller's stack, not anything the reader stated.

## The fix

The descent carries a depth, checked against a stated maximum before it is acted on. 64 is far past anything a hand-written document reaches (the existing tests nest 2 deep) and far short of any stack the reader runs on. Overshoot is an ordinary parse error naming the depth, the same shape as every other error this reader returns.

## Verification

Replaying both minimized reproducers through a program that calls `toml.parse`:

| | with the bound | bound removed |
|---|---|---|
| `unbounded-array-recursion.toml` | exit 1, parse error | exit 139, signal 11 |
| `unbounded-inline-table-recursion.toml` | exit 1, parse error | exit 139, signal 11 |

That is the mutation proof: the crash returns the moment the check is taken out.

Two std tests. The first replays the 8192-bracket shape and asserts a rejection rather than a dead process. The second pins the boundary behaviourally, accepting exactly `MAX_VALUE_DEPTH` levels and refusing one more, so the constant cannot drift from the behaviour without the test failing.

One subtlety that test surfaced: an empty innermost array is closed without ever asking for a value, so it costs one descent less than it looks. The boundary document puts a scalar at the bottom, which is what makes `n` brackets mean `n` levels.

Suite: 1,081 passed / 0 failed under the 4.26.5 seed, up 2 from 1,079.