### PR TITLE
feat(result): add Void, a success that carries nothing

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.35.1"
+version = "0.35.2"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/types/result.mach
+++ b/src/types/result.mach
@@ -39,6 +39,24 @@ pub fun err[T, E](value: E) Result[T, E] {
     ret res;
 }
 
+# a success that carries nothing
+#
+# most fallible operations succeed without producing a value, and spelling that
+# `Result[bool, E]` makes the caller read a bool that is always true and decide
+# whether it means anything. `Result[Void, E]` says there is nothing to read.
+pub rec Void {}
+
+# create a Result[Void, E] representing success
+#
+# `ok` needs a value to put in the ok arm and Void has none to write, so the
+# one way to build a Void success lives here rather than at every call site.
+# ---
+# ret: a Result[Void, E] with the ok arm present
+pub fun ok_void[E]() Result[Void, E] {
+    var v: Void;
+    ret ok[Void, E](v);
+}
+
 # check if the result is ok (success)
 pub fun is_ok[T, E](res: Result[T, E]) bool {
     ret res.tag;
@@ -157,5 +175,43 @@ test "result: different ok and err types" {
     if (!is_err[u64, i32](r_err)) { ret 1; }
     if (unwrap_ok[u64, i32](r_ok) != 100) { ret 1; }
     if (unwrap_err[u64, i32](r_err) != -1) { ret 1; }
+    ret 0;
+}
+
+# the error arm is an i32 here, not a str: std.types.string imports this module,
+# so reaching for str would make the cycle the module's minimal imports avoid
+test "result: ok_void is ok and carries nothing to read" {
+    val r: Result[Void, i32] = ok_void[i32]();
+    if (!is_ok[Void, i32](r)) { ret 1; }
+    if (is_err[Void, i32](r))  { ret 2; }
+    unwrap_ok[Void, i32](r);
+    ret 0;
+}
+
+test "result: a Void result still carries its error arm" {
+    val r: Result[Void, i32] = err[Void, i32](7);
+    if (is_ok[Void, i32](r))   { ret 1; }
+    if (!is_err[Void, i32](r)) { ret 2; }
+    if (unwrap_err[Void, i32](r) != 7) { ret 3; }
+    ret 0;
+}
+
+# the discriminant survives a round trip through a function boundary, which is
+# where a zero-sized ok arm could plausibly be folded into the wrong tag
+fun t_void_roundtrip(fail: bool) Result[Void, i32] {
+    if (fail) { ret err[Void, i32](3); }
+    ret ok_void[i32]();
+}
+
+test "result: Void round-trips through a call in both arms" {
+    val good: Result[Void, i32] = t_void_roundtrip(false);
+    if (!is_ok[Void, i32](good)) { ret 1; }
+
+    val bad: Result[Void, i32] = t_void_roundtrip(true);
+    if (!is_err[Void, i32](bad)) { ret 2; }
+    if (unwrap_err[Void, i32](bad) != 3) { ret 3; }
+
+    # and a Void ok is distinguishable from an err of the same type
+    if (is_ok[Void, i32](good) == is_ok[Void, i32](bad)) { ret 4; }
     ret 0;
 }


### PR DESCRIPTION
For the compiler's `Result[bool, str]` triage (S-20). The compiler has 4,711 `R.Result[bool, str]` sites and most of those bools are always true, so the triage needs a unit-shaped success type. None existed.

## What ships

`pub rec Void {}` in `std.types.result`, beside `Result`, plus `ok_void[E]()`.

The helper is warranted rather than optional: `ok[T, E](value: T)` is the only way to build an ok arm, and `Void` has no value to hand it. Without the helper every call site would declare an empty local and pass it, which is the same three lines repeated 4,711 times. With it, `ret ok_void[str]();`.

## Notes

- The tests use an `i32` error, not a `str`. `std.types.string` imports this module, so reaching for `str` here creates exactly the cycle the module's four imports exist to avoid. A consumer outside the cycle uses `Result[Void, str]` normally, which I verified with a scratch program that compiles and runs both arms.
- Empty records already have precedent in this tree (`DEmpty`, `Rejecting`, `Accepting`), so nothing new is being asked of the language.
- The name is `Void`. Nothing in either repository used it, and the compiler's `Unit` already means a codegen compilation unit.
- Three tests: construction and `is_ok`, the error arm still working under a `Void` ok, and a round trip through a call boundary in both arms. The third is the one that matters, since a zero-sized ok arm is where a tag could plausibly get folded away.

## Verification

Suite 1,084 passed / 0 failed under the 4.26.5 seed, up 3 from 1,081.

Mutation proof: making `ok_void` return a result tagged err fails two of the three tests, the construction test and the round-trip test.

Nothing else in std is touched.