### PR TITLE
chore(release): 0.36.0

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -1,6 +1,6 @@
 [project]
 id = "std"
-version = "0.35.2"
+version = "0.36.0"
 src = "src"
 out = "out/{target.name}/{profile.name}"
 

--- a/src/types/result.mach
+++ b/src/types/result.mach
@@ -39,6 +39,24 @@ pub fun err[T, E](value: E) Result[T, E] {
     ret res;
 }
 
+# a success that carries nothing
+#
+# most fallible operations succeed without producing a value, and spelling that
+# `Result[bool, E]` makes the caller read a bool that is always true and decide
+# whether it means anything. `Result[Void, E]` says there is nothing to read.
+pub rec Void {}
+
+# create a Result[Void, E] representing success
+#
+# `ok` needs a value to put in the ok arm and Void has none to write, so the
+# one way to build a Void success lives here rather than at every call site.
+# ---
+# ret: a Result[Void, E] with the ok arm present
+pub fun ok_void[E]() Result[Void, E] {
+    var v: Void;
+    ret ok[Void, E](v);
+}
+
 # check if the result is ok (success)
 pub fun is_ok[T, E](res: Result[T, E]) bool {
     ret res.tag;
@@ -157,5 +175,43 @@ test "result: different ok and err types" {
     if (!is_err[u64, i32](r_err)) { ret 1; }
     if (unwrap_ok[u64, i32](r_ok) != 100) { ret 1; }
     if (unwrap_err[u64, i32](r_err) != -1) { ret 1; }
+    ret 0;
+}
+
+# the error arm is an i32 here, not a str: std.types.string imports this module,
+# so reaching for str would make the cycle the module's minimal imports avoid
+test "result: ok_void is ok and carries nothing to read" {
+    val r: Result[Void, i32] = ok_void[i32]();
+    if (!is_ok[Void, i32](r)) { ret 1; }
+    if (is_err[Void, i32](r))  { ret 2; }
+    unwrap_ok[Void, i32](r);
+    ret 0;
+}
+
+test "result: a Void result still carries its error arm" {
+    val r: Result[Void, i32] = err[Void, i32](7);
+    if (is_ok[Void, i32](r))   { ret 1; }
+    if (!is_err[Void, i32](r)) { ret 2; }
+    if (unwrap_err[Void, i32](r) != 7) { ret 3; }
+    ret 0;
+}
+
+# the discriminant survives a round trip through a function boundary, which is
+# where a zero-sized ok arm could plausibly be folded into the wrong tag
+fun t_void_roundtrip(fail: bool) Result[Void, i32] {
+    if (fail) { ret err[Void, i32](3); }
+    ret ok_void[i32]();
+}
+
+test "result: Void round-trips through a call in both arms" {
+    val good: Result[Void, i32] = t_void_roundtrip(false);
+    if (!is_ok[Void, i32](good)) { ret 1; }
+
+    val bad: Result[Void, i32] = t_void_roundtrip(true);
+    if (!is_err[Void, i32](bad)) { ret 2; }
+    if (unwrap_err[Void, i32](bad) != 3) { ret 3; }
+
+    # and a Void ok is distinguishable from an err of the same type
+    if (is_ok[Void, i32](good) == is_ok[Void, i32](bad)) { ret 4; }
     ret 0;
 }


### PR DESCRIPTION
Minor release. Adds `Void`, a success type that carries nothing, and `ok_void[E]()` to build one.

This is what the compiler's `Result[bool, str]` triage needs: 4,711 sites where the bool is almost always true, and `Result[Void, str]` says there is nothing to read instead of handing the caller a bool to interpret.

Additive only. Nothing else in std changed, and no existing signature moved.

Suite 1,084 passed / 0 failed under the 4.26.5 seed.

Not tagged here; tagging is the owner's.